### PR TITLE
local index: skip alert about no server side index

### DIFF
--- a/src/app/xapian/searchservice.ts
+++ b/src/app/xapian/searchservice.ts
@@ -389,19 +389,12 @@ export class SearchService {
         mergeMap(() => this.checkIfDownloadableIndexExists()),
         mergeMap((res) => new Observable( (observer) => {
         if (!res) {
-          this.dialog.open(InfoDialog, {data: new InfoParams('No search index available',
-            `Couldn't find an index for your account on the server.
-              Will create an index locally for your last 10 000 messages.
-              `)})
-              .afterClosed()
-              .subscribe(() => {
-                this.api.initXapianIndex(XAPIAN_GLASS_WR);
-                this.localSearchActivated = true;
-                this.pollCache = {};
-                this.indexLastUpdateTime = 0;
-                this.updateIndexWithNewChanges();
-                observer.next(true);
-              });
+          this.api.initXapianIndex(XAPIAN_GLASS_WR);
+          this.localSearchActivated = true;
+          this.pollCache = {};
+          this.indexLastUpdateTime = 0;
+          this.updateIndexWithNewChanges();
+          observer.next(true);
           return;
         }
 


### PR DESCRIPTION
For new users no search index is yet generated on the servers. However the user may still generate an index in locally in the browser, and will be prompted about that when viewing the app for the first time. After accepting a local index, the app will look for an index on the server to start from - which is good if it's an account with many messages. For new accounts there will only be one or two messages and no search index exist on the server, and a new prompt shows about this. This pull request will remove that second prompt, and just create the local index immediately (since the user already accepted this in the first prompt).