### PR TITLE
canvastable: increase mousewheel scroll speed

### DIFF
--- a/src/app/canvastable/canvastable.ts
+++ b/src/app/canvastable/canvastable.ts
@@ -280,7 +280,7 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck {
 
     this.canv.onwheel = (event: MouseWheelEvent) => {
       event.preventDefault();
-      this.topindex += event.deltaY / 100;
+      this.topindex += event.deltaY;
       this.enforceScrollLimit();
     };
 


### PR DESCRIPTION
Wheel deltay was divided by 100. Remove divide by 100 so that it scrolls one row per wheel tick.