### PR TITLE
dev-setup: require valid SSL certificate for backend

### DIFF
--- a/backend-proxy-remote.conf.js
+++ b/backend-proxy-remote.conf.js
@@ -7,7 +7,7 @@ const PROXY_CONFIG = [
     {
         context: ["/websocket"],
         "target": backendhostname.replace(/^http/,'ws'),
-        "secure": false,
+        "secure": true,
         "ws": true,
         "changeOrigin": true
     },
@@ -27,7 +27,7 @@ const PROXY_CONFIG = [
             }
         },
         "target": backendhostname,
-        "secure": false,
+        "secure": true,
         "cookieDomainRewrite": "localhost",
         "changeOrigin": true
         


### PR DESCRIPTION
We originally had the `secure` option set to false for the webpack dev server proxy in order to allow backend servers without a valid SSL certificate (which we had on our devrig). Now with developers using the prod servers as backend for frontend development we should require a valid certificate for the backend, and additional devrig servers should have a valid SSL cert.