### PR TITLE
canvastable: Adjust scroll speed according to delta mode

### DIFF
--- a/src/app/canvastable/canvastable.ts
+++ b/src/app/canvastable/canvastable.ts
@@ -280,7 +280,21 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck {
 
     this.canv.onwheel = (event: MouseWheelEvent) => {
       event.preventDefault();
-      this.topindex += event.deltaY;
+      switch (event.deltaMode) {
+        case 0:
+          // pixels
+          this.topindex += (event.deltaY / this.rowheight);
+          break;
+        case 1:
+          // lines
+          this.topindex += event.deltaY;
+          break;
+        case 2:
+          // pages
+          this.topindex += (event.deltaY * (this.canv.scrollHeight / this.rowheight));
+          break;
+      }
+
       this.enforceScrollLimit();
     };
 


### PR DESCRIPTION
Take into account pixels, lines or pages mode. With a mousewheel firefox uses lines mode, while chrome uses pixels mode. This PR checks the delta mode and adjusts the scrollspeed there after.