### PR TITLE
mailviewer: Include HTML mail content in print

### DIFF
--- a/src/app/mailviewer/singlemailviewer.component.html
+++ b/src/app/mailviewer/singlemailviewer.component.html
@@ -1,6 +1,9 @@
 <div *ngIf="messageId" [ngClass]="{'adjustableHeight': adjustableHeight}"
   appHorizResizable [resizableDisabled]="!adjustableHeight" (resized)="heightChanged($event)">
-  <iframe #printFrame style="width: 0px; height: 0px; border: none; position: absolute"></iframe>
+  <iframe #printFrame
+    sandbox="allow-same-origin allow-modals"
+    style="width: 0px; height: 0px; border: none; position: absolute" 
+  ></iframe>
   <mat-toolbar style="display: flex; overflow-x: auto;">
     <!-- Message preview toolbar -->
     <div style="flex-grow: 1; overflow: hidden" #toolbarButtonContainer>      

--- a/src/app/mailviewer/singlemailviewer.component.ts
+++ b/src/app/mailviewer/singlemailviewer.component.ts
@@ -426,9 +426,17 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
   }
 
   print() {
-    const printablecontent = this.messageContents.nativeElement.innerHTML;
+    let printablecontent = this.messageContents.nativeElement.innerHTML;
+    if (this.htmliframe) {
+      printablecontent = printablecontent.replace(/\<iframe.*\<\/iframe\>/g,
+        this.htmliframe.nativeElement.contentWindow.document.documentElement.innerHTML
+      );
+    }
     this.printFrame.nativeElement.onload = () => this.printFrame.nativeElement.contentWindow.print();
-    this.printFrame.nativeElement.src = URL.createObjectURL(new Blob([printablecontent], { type: 'text/html' }));
+    this.printFrame.nativeElement.src = URL.createObjectURL(new Blob([printablecontent],
+        { type: 'text/html' }
+      )
+    );
   }
 
   public openAttachment(attachmentIndex: number, download?: boolean) {


### PR DESCRIPTION
For HTML mails print output showed only headers (issue #25). Fixed so that HTML content is included in print.