### PR TITLE
compose: validation of recipients #39

### DIFF
--- a/src/app/compose/compose.component.ts
+++ b/src/app/compose/compose.component.ts
@@ -462,10 +462,18 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
                     if (send) {
                         this.draftDeleted.emit(this.model.mid);
                     }
-                }, () => this.snackBar.open(
-                    'Offline message posting not supported yet',
-                    'COMING SOON'
-                ));
+                }, (err) => {
+                    let msg = err.statusText;
+                    if (err.field_errors) {
+                        msg = Object.keys(err.field_errors)
+                                .map(fieldname =>
+                                    `field ${fieldname}: ${err.field_errors[fieldname][0]}`);
+                    }
+                    this.snackBar.open(
+                        `Error saving draft: ${msg}`,
+                        'Dismiss'
+                    );
+                });
         } else {
             this.rmmapi.me.pipe(mergeMap((me) => {
                 return this.http.post('/rest/v1/draft', {
@@ -502,12 +510,18 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
                         this.draftDeleted.emit(this.model.mid);
                         this.snackBar.open(res.status_msg, null, { duration: 3000 });
                     }
-                }, (err) =>
+                }, (err) => {
+                    let msg = err.statusText;
+                    if (err.field_errors) {
+                        msg = Object.keys(err.field_errors)
+                                .map(fieldname =>
+                                    `field ${fieldname}: ${err.field_errors[fieldname][0]}`);
+                    }
                     this.snackBar.open(
-                        'Offline message editing not supported yet',
-                        'COMING SOON'
-                    )
-                );
+                        `Error saving draft: ${msg}`,
+                        'Dismiss'
+                    );
+                });
         }
     }
 

--- a/src/app/compose/emailvalidator.spec.ts
+++ b/src/app/compose/emailvalidator.spec.ts
@@ -1,0 +1,32 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2019 Runbox Solutions AS (runbox.com).
+// 
+// This file is part of Runbox 7.
+// 
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+// 
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { isValidEmail } from './emailvalidator';
+
+describe('EmailValidator', () => {
+    it('Validate emails', () => {
+        expect(isValidEmail('example<<test@example.com>')).toBeFalsy();
+        expect(isValidEmail('example<test@example.com>')).toBeTruthy();
+        expect(isValidEmail('<test@testing.com> example<<test@example.com>')).toBeFalsy();
+        expect(isValidEmail('Test example<test@example.>')).toBeFalsy();
+        expect(isValidEmail('Test example<test@example.no>')).toBeTruthy();
+        expect(isValidEmail('test@example.no')).toBeTruthy();
+        expect(isValidEmail('<test@example.no>')).toBeTruthy();
+    });
+});

--- a/src/app/compose/emailvalidator.ts
+++ b/src/app/compose/emailvalidator.ts
@@ -1,0 +1,37 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2019 Runbox Solutions AS (runbox.com).
+// 
+// This file is part of Runbox 7.
+// 
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+// 
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+const EMAIL_REGEXP =
+    // tslint:disable-next-line:max-line-length
+    /^(?=.{1,254}$)(?=.{1,64}@)[-!#$%&'*+/0-9=?A-Z^_`a-z{|}~]+(\.[-!#$%&'*+/0-9=?A-Z^_`a-z{|}~]+)*@[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*$/;
+
+/**
+ * Extract the email part of the input string (either plain email address or inside <>)
+ * @param email 
+ */
+export function isValidEmail(email: string) {
+    email = email.trim();
+    const emailpartindex = email.indexOf('<');
+    if (emailpartindex >= 0 && email.indexOf('>') === email.length - 1 && email.indexOf(',') === -1) {
+        const emailpart = email.substr(emailpartindex + 1, email.length - emailpartindex - 2);
+        return EMAIL_REGEXP.test(emailpart) ? emailpart : false;
+    } else {
+        return EMAIL_REGEXP.test(email);
+    }
+}

--- a/src/app/compose/mailrecipientinput.component.html
+++ b/src/app/compose/mailrecipientinput.component.html
@@ -14,6 +14,7 @@
                 (matChipInputTokenEnd)="addRecipient($event)" 
                 [matAutocomplete]="auto" style="flex-grow: 1" 
                 type="email"
+                email
             />
         <mat-error *ngIf="invalidemail && !searchTextFormControl.valid">
             Please enter a valid email address

--- a/src/app/compose/mailrecipientinput.component.ts
+++ b/src/app/compose/mailrecipientinput.component.ts
@@ -24,6 +24,7 @@ import { BehaviorSubject } from 'rxjs';
 import { MatChipInputEvent, MatAutocomplete } from '@angular/material';
 import { ENTER } from '@angular/cdk/keycodes';
 import { debounceTime } from 'rxjs/operators';
+import { isValidEmail } from './emailvalidator';
 
 const COMMA = 188;
 
@@ -55,10 +56,17 @@ export class MailRecipientInputComponent implements OnInit, AfterViewInit {
 
     constructor(public searchService: SearchService) {
         this.searchService.initSubject.subscribe(() => {
+
+        // Get all recipient terms from search index
         window['termlistresult'] = [];
         searchService.api.termlist('XRECIPIENT:');
-        const recipients: string[] = window['termlistresult'];
 
+        // Filter valid emails and don't suggest more than one instance of an email address
+
+        const recipients: string[] = window['termlistresult']
+            .filter(recipient => isValidEmail(recipient));
+
+        // Listen to search text input and popup suggestions from recipient list
         this.searchTextFormControl.valueChanges
             .pipe(debounceTime(50))
             .subscribe((searchtext: string) => {

--- a/src/app/rmmapi/rmmhttpinterceptor.service.ts
+++ b/src/app/rmmapi/rmmhttpinterceptor.service.ts
@@ -60,8 +60,12 @@ export class RMMHttpInterceptorService implements HttpInterceptor {
                 if (evt instanceof HttpResponse) {
                     const r = evt as HttpResponse<any>;
                     this.decrementHttpRequestCount();
-                    if (r.body.status === 'error' && r.body.errors[0].indexOf('login') > 0) {
+                    if (r.body.status === 'error' &&
+                        r.body.errors &&
+                        r.body.errors[0].indexOf('login') > 0) {
                         this.router.navigate(['/login'], {skipLocationChange: true});
+                        throw(r.body);
+                    } else if (r.body.status === 'error') {
                         throw(r.body);
                     }
                 }


### PR DESCRIPTION
- Filter invalid addresses from search index suggestions
- Fixed missing validation of manually written email addresses in the recipient fields
- Show REST server validation errors and inform draft not saved

![skjermbilde 2019-01-14 kl 12 19 18](https://user-images.githubusercontent.com/9760441/51109798-b0603700-17f6-11e9-8b11-4877729102eb.png)