### PR TITLE
Compose/draftdesk fixes

### DIFF
--- a/src/app/compose/compose.component.html
+++ b/src/app/compose/compose.component.html
@@ -47,7 +47,8 @@
         
         <button *ngIf="editing" [disabled]="saved" mat-icon-button matTooltip="Save draft" (click)="submit()">
             <mat-icon *ngIf="saved">cloud_done</mat-icon>
-            <mat-icon *ngIf="!saved">save</mat-icon>
+            <mat-icon *ngIf="!saved && !saveErrorMessage">save</mat-icon>
+            <mat-icon *ngIf="!saved && saveErrorMessage" color="warn" [matTooltip]="saveErrorMessage">save</mat-icon>
         </button>
         <button *ngIf="editing && !isNew" mat-icon-button matTooltip="Move draft to trash" (click)="trashDraft()">
             <mat-icon>delete</mat-icon>
@@ -123,14 +124,13 @@
                     [id]="editorId" #editor 
                     [hidden]="!formGroup.value.useHTML">
           </textarea>
-          <mat-form-field style="width: 100%" *ngIf="!formGroup.value.useHTML" floatPlaceholder="auto" id="messageTextAreaField">
+          <mat-form-field class="messageTextArea" *ngIf="!formGroup.value.useHTML" floatPlaceholder="auto">
             <textarea 
                #messageTextArea
                placeholder="Message text" 
                matInput                                      
                formControlName="msg_body"
                rows="20"
-	       id="messageTextArea"
                >
             </textarea>
           </mat-form-field>   

--- a/src/app/compose/compose.component.html
+++ b/src/app/compose/compose.component.html
@@ -50,7 +50,7 @@
             <mat-icon *ngIf="!saved && !saveErrorMessage">save</mat-icon>
             <mat-icon *ngIf="!saved && saveErrorMessage" color="warn" [matTooltip]="saveErrorMessage">save</mat-icon>
         </button>
-        <button *ngIf="editing && !isNew" mat-icon-button matTooltip="Move draft to trash" (click)="trashDraft()">
+        <button *ngIf="!isNew" mat-icon-button matTooltip="Move draft to trash" (click)="trashDraft()">
             <mat-icon>delete</mat-icon>
         </button>
         <button *ngIf="editing" mat-icon-button matTooltip="Close draft" (click)="close()">

--- a/src/app/compose/compose.component.scss
+++ b/src/app/compose/compose.component.scss
@@ -1,0 +1,3 @@
+.messageTextArea {
+    border: 1px solid #949494;
+}

--- a/src/app/compose/compose.component.ts
+++ b/src/app/compose/compose.component.ts
@@ -42,7 +42,8 @@ declare var MailParser;
     moduleId: 'angular2/app/compose/',
     // tslint:disable-next-line:component-selector
     selector: 'compose',
-    templateUrl: 'compose.component.html'
+    templateUrl: 'compose.component.html',
+    styleUrls: ['compose.component.scss']
 })
 export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
     static tinymceinstancecount = 1;
@@ -61,6 +62,8 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
     public isNew = false;
     public uploadprogress: number = null;
     public saved: Date = null;
+
+    saveErrorMessage: string;
 
     @Input() shouldExitToTable = false;
 
@@ -506,6 +509,8 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
                     }
                     this.isNew = false;
                     this.saved = new Date();
+                    this.saveErrorMessage = null;
+
                     if (send) {
                         this.draftDeleted.emit(this.model.mid);
                         this.snackBar.open(res.status_msg, null, { duration: 3000 });
@@ -517,10 +522,7 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
                                 .map(fieldname =>
                                     `field ${fieldname}: ${err.field_errors[fieldname][0]}`);
                     }
-                    this.snackBar.open(
-                        `Error saving draft: ${msg}`,
-                        'Dismiss'
-                    );
+                    this.saveErrorMessage = `Error saving draft: ${msg}`;
                 });
         }
     }

--- a/src/app/compose/compose.component.ts
+++ b/src/app/compose/compose.component.ts
@@ -459,9 +459,9 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
                 .subscribe((res) => {
                     this.model.mid = parseInt(res[2], 10);
                     this.snackBar.open(res[1], null, { duration: 3000 });
-                    if (send) {
-                        this.draftDeleted.emit(this.model.mid);
-                    }
+
+                    this.draftDeleted.emit(this.model.mid);
+                    this.exitToTable();
                 }, (err) => {
                     let msg = err.statusText;
                     if (err.field_errors) {
@@ -470,7 +470,7 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
                                     `field ${fieldname}: ${err.field_errors[fieldname][0]}`);
                     }
                     this.snackBar.open(
-                        `Error saving draft: ${msg}`,
+                        `Error sending: ${msg}`,
                         'Dismiss'
                     );
                 });

--- a/src/app/compose/draftdesk.component.html
+++ b/src/app/compose/draftdesk.component.html
@@ -1,4 +1,4 @@
-<div style="width: 99%; height: 100%; display: flex; flex-wrap: wrap; padding: 0 10px 10px 0;">
+<div style="position: absolute; top: 64px; bottom: 0px; left: 0px; right: 0px; display: flex; flex-wrap: wrap; padding: 0 10px 10px 0;">
     <compose [model]="draftModel" (draftDeleted)="draftDeleted($event)" #draft [style.width]="draft.editing ? '100%' : 'auto'" *ngFor="let draftModel of draftModelsInView"></compose>
     <div *ngIf="hasMoreDrafts" style="width: 180px; height: 180px; text-align: center; padding-top: 80px">            
         <button mat-icon-button mat-tooltip="Show more" (click)="showMore()" style="transform: scale(4,4);">

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -676,17 +676,6 @@ compose .draftPreview {
     min-width: 50px !important;
 }
 
-#messageTextAreaField {
-    margin-top: 20px;
-    width: 97% !important;
-}
-
-#messageTextArea {
-    border: 1px solid #949494;
-    padding: 10px;
-}
-
-
 /* Styles to decrease vertical spacing on Compose */
 
 compose .mat-card-actions {


### PR DESCRIPTION
- Fix for  #42 and #57 .
- Skipped annoying "Error saving draft" snackbar, and instead color the save button with warning color (and a tooltip showing the error).
- Show toolbar with side menu toggle button also in draftdesk view.