### PR TITLE
fix: 2FA challenge not showing because of error thrown by http interceptor

### DIFF
--- a/e2e/login/login.e2e-spec.ts
+++ b/e2e/login/login.e2e-spec.ts
@@ -42,4 +42,17 @@ describe('login', () => {
     browser.waitForAngularEnabled(false);
     expect(await page.getSidenavGreetingText()).toContain('test@runbox.com');
   });
+
+  it('should log in with 2fa', async () => {
+    server.challenge2fa = true;
+    page.navigateTo();
+    await page.waitForRedirect();
+    browser.waitForAngularEnabled(false);
+    await page.fillLoginInputsAndClickLoginButton();
+    await page.perform2FA();
+    await page.expectProgressBarWhileWaitingForLogin();
+    await page.waitForLoggedIn();
+
+    expect(await page.getSidenavGreetingText()).toContain('test@runbox.com');
+  });
 });

--- a/e2e/login/login.po.ts
+++ b/e2e/login/login.po.ts
@@ -36,4 +36,16 @@ export class AppPage {
   getSidenavGreetingText() {
     return element(by.id('sidenavGreeting')).getText();
   }
+
+  async perform2FA() {
+    const totpbuttonlocator = by.cssContainingText('mat-button-toggle', 'TOTP');
+    await browser.wait(() => element(totpbuttonlocator).isPresent(), 10000);
+    await element(totpbuttonlocator).click();
+    const totpfieldlocator = by.css('input[placeholder="Timed one-time password"]');
+    await browser.wait(until.elementsLocated(totpfieldlocator));
+    await element(totpfieldlocator).sendKeys('123456');
+    const loginbuttonlocator = by.cssContainingText('button', 'Log in');
+    await browser.wait(() => element(loginbuttonlocator).isPresent(), 10000);
+    await element(loginbuttonlocator).click();
+  }
 }

--- a/src/app/rmmapi/rmmhttpinterceptor.service.ts
+++ b/src/app/rmmapi/rmmhttpinterceptor.service.ts
@@ -53,13 +53,19 @@ export class RMMHttpInterceptorService implements HttpInterceptor {
             map((evt: HttpEvent<any>) => {
                 if (evt instanceof HttpResponse) {
                     const r = evt as HttpResponse<any>;
-                    if (r.body && r.body.status === 'error' &&
-                        r.body.errors &&
-                        r.body.errors[0].indexOf('login') > 0) {
-                        this.authguardservice.redirectToLogin();
-                        throw(r.body);
-                    } else if (r.body.status === 'error') {
-                        throw(r.body);
+                    if (r.body && r.body.status === 'error') {
+                        if (
+                            r.body.errors &&
+                            r.body.errors[0].indexOf('login') > 0) {
+                            this.authguardservice.redirectToLogin();
+                            throw(r.body);
+                        } else if (
+                            req.url === '/ajax_mfa_authenticate' &&
+                            r.body.is_2fa_enabled === '1') {
+                                console.log('proceed with 2fa login');
+                        } else {
+                           throw(r.body);
+                        }
                     }
                 }
                 return evt;


### PR DESCRIPTION
Users experienced 2FA challenge not showing after started using http interceptor also for login network traffic (to get progress bar showing while logging in). This ensures that the 2fa challenge does not throw an error.

Also added e2e test for 2fa challenge