### PR TITLE
bugfix: reporting not spam snackbar was not dismissed #86

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -365,14 +365,17 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     if (this.showingSearchResults) {
       messageIds = messageIds.map((docId) => this.searchService.getMessageIdFromDocId(docId));
     }
-    this.messageActionsHandler.rmmapi.trainSpam({is_spam: params.is_spam, messages: messageIds}).subscribe(
-      (data) => {
+    this.messageActionsHandler.rmmapi.trainSpam({is_spam: params.is_spam, messages: messageIds})
+      .subscribe(data => {
         if ( data.status === 'error' ) {
           snackBarRef.dismiss();
           this.snackBar.open('There was an error with Spam functionality. Please select the messages and try again.', 'Dismiss');
         }
         this.searchService.updateIndexWithNewChanges();
         snackBarRef.dismiss();
+      }, (err) => {
+        console.error('Error reporting spam', err);
+        this.snackBar.open('There was an error with Spam functionality.', 'Dismiss');
       },
       () => {
         this.selectedRowIds = {};

--- a/src/app/mailviewer/rmm7messageactions.ts
+++ b/src/app/mailviewer/rmm7messageactions.ts
@@ -95,6 +95,8 @@ export class RMM7MessageActions implements MessageActions {
                     this.snackBar.open('There was an error with Spam functionality. Please try again.', 'Dismiss');
                 }
                 this.searchService.updateIndexWithNewChanges();
+            }, (err) => {
+                console.error('Error reporting spam', err);
             },
             () => {
                 snackBarRef.dismiss();

--- a/src/app/mailviewer/singlemailviewer.component.html
+++ b/src/app/mailviewer/singlemailviewer.component.html
@@ -113,7 +113,7 @@
           </button>    
           <button mat-menu-item *ngIf="folder==='Spam'" (click)="messageActionsHandler.trainSpam({is_spam:0})">
             <mat-icon>report_off</mat-icon>  
-            <span>Not spam</span>>
+            <span>Not spam</span>
           </button>            
         </ng-container>
         <a *ngIf="morebuttonindex<9" mat-menu-item


### PR DESCRIPTION
This fixes that the snackbar popping up after reporting "not spam" is not dismissed.