### PR TITLE
Remember mailviewer orientation (#84)

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -55,6 +55,7 @@ import { exportKeysFromJWK } from './webpush/vapid.tools';
 import { ProgressService } from './http/progress.service';
 
 const LOCAL_STORAGE_SETTING_MAILVIEWER_ON_RIGHT_SIDE_IF_MOBILE = 'mailViewerOnRightSideIfMobile';
+const LOCAL_STORAGE_SETTING_MAILVIEWER_ON_RIGHT_SIDE = 'mailViewerOnRightSide';
 
 @Component({
   moduleId: 'angular2/app/',
@@ -205,7 +206,8 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
       changeDetectorRef.detectChanges();
       if (!this.mobileQuery.matches && !this.sidemenu.opened) {
         this.sidemenu.open();
-        this.mailViewerOnRightSide = true;
+        const storedMailViewerOrientationSetting = localStorage.getItem(LOCAL_STORAGE_SETTING_MAILVIEWER_ON_RIGHT_SIDE);
+        this.mailViewerOnRightSide = !storedMailViewerOrientationSetting || storedMailViewerOrientationSetting === 'true';
         this.allowMailViewerOrientationChange = true;
         this.mailViewerRightSideWidth = '40%';
       } else if (this.mobileQuery.matches && this.sidemenu.opened) {
@@ -876,6 +878,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
       localStorage.setItem(LOCAL_STORAGE_SETTING_MAILVIEWER_ON_RIGHT_SIDE_IF_MOBILE,
           `${this.mailViewerOnRightSide}`);
     }
+    localStorage.setItem(LOCAL_STORAGE_SETTING_MAILVIEWER_ON_RIGHT_SIDE, this.mailViewerOnRightSide ? 'true' : 'false');
     // Reopen message on orientation change
     setTimeout(() => this.singlemailviewer.messageId = currentMessageId, 0);
   }

--- a/src/app/directives/horizresizer.directive.ts
+++ b/src/app/directives/horizresizer.directive.ts
@@ -111,14 +111,8 @@ export class HorizResizerDirective implements OnInit {
 
 
     getParentOffsetTop(): number {
-        let elm = this.el.nativeElement.offsetParent;
-        let offsetTop = elm.offsetTop;
-
-        while (elm.offsetParent && elm.offsetParent.offsetTop) {
-            elm = elm.offsetParent;
-            offsetTop += elm.offsetTop;
-        }
-        return offsetTop;
+        const toolbarelement = document.querySelector('rmm-headertoolbar mat-toolbar');
+        return toolbarelement ? toolbarelement.clientHeight : 0;
     }
 
     resizePercentage(percentage: number): void {

--- a/src/app/mailviewer/singlemailviewer.component.ts
+++ b/src/app/mailviewer/singlemailviewer.component.ts
@@ -18,25 +18,6 @@
 // ---------- END RUNBOX LICENSE ----------
 
 import { filter, map } from 'rxjs/operators';
-// --------- BEGIN RUNBOX LICENSE ---------
-// Copyright (C) 2016-2018 Runbox Solutions AS (runbox.com).
-// 
-// This file is part of Runbox 7 App.
-// 
-// Runbox 7 App is free software: You can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-// 
-// Runbox 7 App is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU General Public License for more details.
-// 
-// You should have received a copy of the GNU General Public License
-// along with Runbox 7 App. If not, see <https://www.gnu.org/licenses/>.
-// ---------- END RUNBOX LICENSE ----------
-
 import {
   SecurityContext, Component, Input, OnInit, Output, EventEmitter, NgZone, ViewChild,
   ElementRef,


### PR DESCRIPTION
Also fix for mailviewer vertical position/height being 64 pixels below the table causing an empty space when the header toolbar is visible.