### PR TITLE
Compose initial input focus

### DIFF
--- a/e2e/compose/compose.e2e-spec.ts
+++ b/e2e/compose/compose.e2e-spec.ts
@@ -25,14 +25,15 @@ describe('Compose', () => {
   });
 
   it('should display draft card', async () => {
-    page.navigateTo();
+    await page.navigateTo();
     await page.waitForRedirect();
     browser.waitForAngularEnabled(false);
     expect(page.getDraftActionBarText()).toEqual('New message');
+    expect(await page.checkToRecipientInputFocus()).toBeTruthy();
   });
 
   it('should complain on invalid email address', async () => {
-    page.navigateTo();
+    await page.navigateTo();
     await page.waitForRedirect();
     browser.waitForAngularEnabled(false);
     await page.setRecipientInputField('invalidaddress');

--- a/e2e/compose/compose.po.ts
+++ b/e2e/compose/compose.po.ts
@@ -2,7 +2,9 @@ import { browser, by, element, until, Key } from 'protractor';
 
 export class ComposePage {
   navigateTo() {
-    return browser.get('/compose?new=true');
+    return browser.get('/')
+        .then(() => browser.executeScript(() => localStorage.setItem('localSearchPromptDisplayed221', 'true'))
+        .then(() => browser.get('/compose?new=true')));
   }
 
   waitForRedirect() {
@@ -17,6 +19,19 @@ export class ComposePage {
     const elm = element(by.css('mailrecipient-input input'));
     await elm.sendKeys(value);
     await elm.sendKeys(Key.TAB);
+  }
+
+  async checkToRecipientInputFocus() {
+    const elm = element(by.css('mailrecipient-input input[placeholder="To"]'));
+    const elmPlaceHolder = await elm.getAttribute('placeholder');
+    console.log('Mail recipient input placeholder', elmPlaceHolder);
+    browser.wait(async () => {
+      return (await browser.driver.switchTo().activeElement().getAttribute('placeholder')) === 'To';
+    });
+    const activeElement = await browser.driver.switchTo().activeElement();
+    const activeElementPlaceHolder = await activeElement.getAttribute('placeholder');
+    console.log('Active element placeholder', activeElementPlaceHolder);
+    return elmPlaceHolder === 'To' && elmPlaceHolder === activeElementPlaceHolder;
   }
 
   waitForMailRecipientErrorInputToBePresent() {

--- a/e2e/folders/emptytrash.po.ts
+++ b/e2e/folders/emptytrash.po.ts
@@ -1,4 +1,4 @@
-import { browser, by, element, until, Key } from 'protractor';
+import { browser, by, element, until } from 'protractor';
 
 export class EmptyTrashPage {
   navigateTo() {
@@ -25,10 +25,13 @@ export class EmptyTrashPage {
     const trashFolderActionsButton = element(by.cssContainingText('mat-tree-node', 'Trash'))
                 .element(by.css('button.mat-icon-button[mattooltip="Folder actions"]'));
 
-    trashFolderActionsButton.click();
-    await browser.wait(until.elementLocated(by.css('div.mat-menu-content button')), 10000);
+    browser.wait(() => trashFolderActionsButton.isPresent(), 5000);
+    await trashFolderActionsButton.click();
     const emptyTrashButton = element(by.cssContainingText('div.mat-menu-content button', 'Empty trash'));
-    emptyTrashButton.click();
+    browser.wait(() => emptyTrashButton.isPresent(), 5000);
+    // Opening a sub menu seems to leave an overlay for some moment so we need to wait a bit more
+    await (new Promise(r => setTimeout(r, 500))); // Not a good solution, but should be enough to wait for the overlay to disappear
+    await emptyTrashButton.click();
   }
 
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "ng": "ng",
     "appdev": "ng serve --disable-host-check --base-href=/appdev/",
     "rmm6dev": "ng serve --disable-host-check --base-href=/appdev/ rmm6",
-    "start": "ng serve --aot --proxy-config backend-proxy-remote.conf.js runbox7",
+    "start": "ng serve --proxy-config backend-proxy-remote.conf.js runbox7",
     "start-use-mockserver": "ng serve --aot --proxy-config backend-proxy-mock.conf.js runbox7",
     "mockserver": "tsc -p e2e/tsconfig.e2e.json && node out-tsc/e2e/mockserver/mockserver.main.js",
     "buildrmm6": "ng build --prod --base-href=/app/ rmm6",

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -53,6 +53,7 @@ import { xapianLoadedSubject } from './xapian/xapianwebloader';
 import { SwPush } from '@angular/service-worker';
 import { exportKeysFromJWK } from './webpush/vapid.tools';
 import { ProgressService } from './http/progress.service';
+import { environment } from '../environments/environment';
 
 const LOCAL_STORAGE_SETTING_MAILVIEWER_ON_RIGHT_SIDE_IF_MOBILE = 'mailViewerOnRightSideIfMobile';
 const LOCAL_STORAGE_SETTING_MAILVIEWER_ON_RIGHT_SIDE = 'mailViewerOnRightSide';
@@ -330,6 +331,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
   }
 
   subscribeToNotifications() {
+    if (environment.production) {
       this.http.get('/rest/v1/webpush/vapidkeys').pipe(
         map(res => res.json()),
         map(jwk => exportKeysFromJWK(jwk).public),
@@ -341,6 +343,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
         )),
         mergeMap(sub => this.http.post('/rest/v1/webpush/subscribe', sub))
       ).subscribe();
+    }
   }
 
   public drafts() {

--- a/src/app/compose/compose.component.ts
+++ b/src/app/compose/compose.component.ts
@@ -328,10 +328,11 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
                 );
             }
 
-            setTimeout(() => {
-                this.moveTextAreaCaretPositionToStart();
-                this.messageTextArea.nativeElement.focus();
-            }, 0);
+            if (this.formGroup.controls['msg_body'].value) {
+                setTimeout(() => {
+                    this.moveTextAreaCaretPositionToStart();
+                }, 0);
+            }
         }
     }
 
@@ -543,7 +544,7 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
             range.moveStart('character', 0);
             range.select();
         }
-        window.scrollTo(0, txtElement.scrollTop - 20);
+        txtElement.scrollTo(0, 0);
     }
 }
 

--- a/src/app/updatealert/updatealert.service.ts
+++ b/src/app/updatealert/updatealert.service.ts
@@ -21,6 +21,7 @@ import { Injectable, NgZone } from '@angular/core';
 import { SwUpdate } from '@angular/service-worker';
 import { MatDialog } from '@angular/material';
 import { UpdateAlertComponent } from './updatealert.component';
+import { environment } from '../../environments/environment';
 
 @Injectable()
 export class UpdateAlertService {
@@ -29,12 +30,14 @@ export class UpdateAlertService {
         private ngZone: NgZone,
         dialog: MatDialog
     ) {
-        console.log('UpdateAlertService started');
-        swupdate.available.subscribe(() => {
-            dialog.open(UpdateAlertComponent);
-        });
+        if (environment.production) {
+            console.log('UpdateAlertService started');
+            swupdate.available.subscribe(() => {
+                dialog.open(UpdateAlertComponent);
+            });
 
-        this.checkForUpdates();
+            this.checkForUpdates();
+        }
     }
 
     checkForUpdates() {


### PR DESCRIPTION
- In compose: Fix and E2E-test for `To` input field to be in focus when creating a new empty draft, but if there's text in the body focus on that field. E2E test verifies this.
- In development drop using the `--aot` option for `npm start` as it is faster for rebuilding cycles.
- Disable service worker interaction (notifications, update checks) in dev environment as it creates error messages in the console we don't need to see.
- end-to-end tests (e2e): Fix for flapping "empty trash" test which seems to be caused by an "overlay" when opening the popup menu for the trash folder.
