### PR TITLE
Contacts: improve the way contact names are displayed

### DIFF
--- a/src/app/contacts-app/contact-details/contact-details.component.html
+++ b/src/app/contacts-app/contact-details/contact-details.component.html
@@ -3,7 +3,7 @@
 </div>
 
 <div class="contact-details" *ngIf="contact">
-    <h2> {{ contact.full_name() || "New contact" }}'s details </h2>
+    <h2> {{ contact.display_name() || "New contact" }}'s details </h2>
     <form [formGroup]="contactForm">
         <h3> Basic information </h3>
         <table>

--- a/src/app/contacts-app/contact.ts
+++ b/src/app/contacts-app/contact.ts
@@ -98,10 +98,11 @@ export class Contact {
 
     display_name(): string {
         if (this.nickname) {
-            return this.nickname;
-        } else if (this.full_name()) {
-            return this.full_name();
+            const fn = this.full_name();
+            const postfix = fn ?  (' (' + fn + ')') : '';
+            return this.nickname + postfix;
         }
+        return this.full_name();
     }
 
     full_name(): string {

--- a/src/app/contacts-app/contacts-app.component.html
+++ b/src/app/contacts-app/contacts-app.component.html
@@ -14,9 +14,9 @@
 
             <mat-list-item *ngFor="let contact of contacts">
                 <a routerLink="/contacts/{{ contact.id }}" matTooltip="View details">
-                    <h4 mat-line>{{ contact.full_name() }}</h4>
+                    <h4 mat-line>{{ contact.display_name() }}</h4>
                 </a>
-                <a mat-icon-button matTooltip="Email {{ contact.full_name() }}" 
+                <a mat-icon-button matTooltip="Email {{ contact.display_name() }}"
                     *ngIf="contact.primary_email()"
                     routerLink="/compose" [queryParams]="{to: contact.primary_email()}">
                   <mat-icon color="primary">email</mat-icon>


### PR DESCRIPTION
Previously we mostly used full names everywhere, which caused problems
when a contact only had a nickname, without a real name. This attempts
to show all possible information, ensuring that nothing is left out.

This addresses a user request: https://community.runbox.com/t/announcement-runbox-7-contacts-contact-sync/794/5