### PR TITLE
Contact groups improvements

### DIFF
--- a/src/app/contacts-app/contact-details/contact-details.component.html
+++ b/src/app/contacts-app/contact-details/contact-details.component.html
@@ -20,9 +20,35 @@
                     <mat-form-field>
                         <input matInput formControlName="last_name" placeholder="Last Name">
                     </mat-form-field>
-                </td><td>
+                </td>
+                <td *ngIf="newGroupPromptShown">
                     <mat-form-field>
-                        <input matInput formControlName="categories" placeholder="Groups">
+                        <input matInput #newGroupInput placeholder="New group"
+                              [(ngModel)]="newGroupValue" [ngModelOptions]="{standalone: true}">
+                        <!-- <mat-hint align="start"> Press Enter to confirm </mat-hint> -->
+                        <button matSuffix mat-icon-button (click)="newGroupPromptShown = false">
+                            <mat-icon>cancel</mat-icon>
+                        </button>
+                        <button matSuffix mat-icon-button (click)="confirmNewGroup()">
+                            <mat-icon>check</mat-icon>
+                        </button>
+                    </mat-form-field>
+                </td>
+                <td *ngIf="!newGroupPromptShown">
+                    <mat-form-field>
+                        <mat-label> Groups </mat-label>
+                        <mat-select formControlName="categories" placeholder="No groups" multiple>
+                            <mat-select-trigger>
+                                <span *ngIf="contactForm.get('categories').value; else no_groups">
+                                    {{ contactForm.get('categories').value }}
+                                </span>
+                                <ng-template #no_groups>
+                                    No groups
+                                </ng-template>
+                            </mat-select-trigger>
+                            <mat-option *ngFor="let group of groups" [value]="group"> {{ group }} </mat-option>
+                            <mat-option (click)="showNewGroupPrompt()"> Add a new group... </mat-option>
+                        </mat-select>
                     </mat-form-field>
                 </td>
             </tr>

--- a/src/app/contacts-app/contact-details/contact-details.component.ts
+++ b/src/app/contacts-app/contact-details/contact-details.component.ts
@@ -17,7 +17,7 @@
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
 
-import { Component, EventEmitter, Input, Output, OnChanges } from '@angular/core';
+import { Component, ElementRef, EventEmitter, Input, Output, OnChanges, ViewChild } from '@angular/core';
 import { FormArray, FormBuilder, FormControl, FormGroup } from '@angular/forms';
 import { MatDialog } from '@angular/material';
 import { Router, ActivatedRoute } from '@angular/router';
@@ -39,6 +39,12 @@ export class ContactDetailsComponent {
     @Output() contactDeleted = new EventEmitter<Contact>();
 
     contactForm = this.createForm();
+
+    groups = [];
+
+    newGroupPromptShown = false;
+    newGroupValue = "";
+    @ViewChild('newGroupInput') newGroupElement: ElementRef;
 
     constructor(
         public dialog: MatDialog,
@@ -70,6 +76,8 @@ export class ContactDetailsComponent {
             }
             this.loadContact();
         });
+
+        contactsservice.contactGroups.subscribe(groups => this.groups = groups);
     }
 
     loadContact(): void {
@@ -98,7 +106,6 @@ export class ContactDetailsComponent {
         }
 
         this.contactForm.patchValue(this.contact);
-        this.contactForm.get('categories').disable();
     }
 
     createForm(): FormGroup {
@@ -206,5 +213,26 @@ export class ContactDetailsComponent {
             '&return_url=' + return_url,
             '_blank'
         );
+    }
+
+    showNewGroupPrompt(): void {
+        // clear the newly added 'undefined' from categories input
+        let categories = this.contactForm.get('categories').value;
+        categories = categories.filter(c => c);
+        this.contactForm.get('categories').setValue(categories);
+
+        this.newGroupPromptShown = true;
+        setTimeout(() => this.newGroupElement.nativeElement.focus());
+    }
+
+    confirmNewGroup(): void {
+        this.groups.push(this.newGroupValue);
+
+        let categories = this.contactForm.get('categories').value;
+        categories.push(this.newGroupValue);
+        this.contactForm.get('categories').setValue(categories);
+
+        this.newGroupValue = '';
+        this.newGroupPromptShown = false;
     }
 }

--- a/src/app/contacts-app/contacts-app.component.html
+++ b/src/app/contacts-app/contacts-app.component.html
@@ -12,7 +12,30 @@
                 </a>
             </mat-list-item>
 
-            <mat-list-item *ngFor="let contact of contacts">
+            <mat-list-item>
+                <mat-form-field>
+                    <mat-label> Show groups </mat-label>
+                    <mat-select [(value)]="groupFilter" (selectionChange)="filterContacts()">
+                        <mat-option value="RUNBOX:ALL">
+                            All groups
+                        </mat-option>
+                        <mat-option *ngFor="let group of groups" [value]="'USER:' + group">
+                            {{ group }}
+                        </mat-option>
+                        <mat-option value="RUNBOX:NONE">
+                            Uncategorized contacts
+                        </mat-option>
+                    </mat-select>
+                </mat-form-field>
+            </mat-list-item>
+
+            <mat-list-item *ngIf="groupFilter.substr(0, 4) === 'USER'">
+                <a mat-button>
+                  <mat-icon color="primary">email</mat-icon> Email this group
+                </a>
+            </mat-list-item>
+
+            <mat-list-item *ngFor="let contact of shownContacts">
                 <a routerLink="/contacts/{{ contact.id }}" matTooltip="View details">
                     <h4 mat-line>{{ contact.full_name() }}</h4>
                 </a>
@@ -21,6 +44,10 @@
                     routerLink="/compose" [queryParams]="{to: contact.primary_email()}">
                   <mat-icon color="primary">email</mat-icon>
                 </a>
+            </mat-list-item>
+
+            <mat-list-item *ngIf="shownContacts.length != contacts.length">
+                {{ contacts.length - shownContacts.length }} others in other groups
             </mat-list-item>
         </mat-nav-list>
     </mat-sidenav>

--- a/src/app/contacts-app/contacts-app.component.html
+++ b/src/app/contacts-app/contacts-app.component.html
@@ -29,11 +29,13 @@
                 </mat-form-field>
             </mat-list-item>
 
+            <!--
             <mat-list-item *ngIf="groupFilter.substr(0, 4) === 'USER'">
                 <a mat-button>
                   <mat-icon color="primary">email</mat-icon> Email this group
                 </a>
             </mat-list-item>
+            -->
 
             <mat-list-item *ngFor="let contact of shownContacts">
                 <a routerLink="/contacts/{{ contact.id }}" matTooltip="View details">

--- a/src/app/contacts-app/contacts-app.component.ts
+++ b/src/app/contacts-app/contacts-app.component.ts
@@ -34,8 +34,12 @@ import { ContactsService } from './contacts.service';
 })
 export class ContactsAppComponent {
     title = 'Contacts';
-    contacts: Contact[];
+    contacts: Contact[] = [];
+    shownContacts: Contact[] = [];
     selectedContact: Contact;
+
+    groups      = [];
+    groupFilter = "RUNBOX:ALL";
 
     constructor(
         private contactsservice: ContactsService,
@@ -48,6 +52,11 @@ export class ContactsAppComponent {
         this.contactsservice.contactsSubject.subscribe(c => {
             console.log('Contacts.app: got the contacts!');
             this.contacts = c;
+            this.filterContacts();
+        });
+
+        contactsservice.contactGroups.subscribe(groups => {
+            this.groups = groups;
         });
 
         this.contactsservice.informationLog.subscribe(
@@ -57,6 +66,21 @@ export class ContactsAppComponent {
         this.contactsservice.errorLog.subscribe(
             e => this.showError(e)
         );
+    }
+
+    filterContacts(): void {
+        this.shownContacts = this.contacts.filter(c => {
+            if (this.groupFilter === 'RUNBOX:ALL') {
+                return true;
+            }
+            if (this.groupFilter === 'RUNBOX:NONE' && c.categories.length === 0) {
+                return true;
+            }
+
+            const target = this.groupFilter.substr(5); // strip 'USER:'
+
+            return c.categories.find(g => g === target);
+        });
     }
 
     showNotification(message: string, action = 'Dismiss'): void {

--- a/src/app/contacts-app/contacts.service.ts
+++ b/src/app/contacts-app/contacts.service.ts
@@ -29,6 +29,7 @@ export class ContactsService {
 
     settingsSubject = new AsyncSubject<any>();
     contactsSubject = new ReplaySubject<Contact[]>();
+    contactGroups   = new ReplaySubject<string[]>();
     informationLog  = new Subject<string>();
     errorLog        = new Subject<HttpErrorResponse>();
 
@@ -52,6 +53,14 @@ export class ContactsService {
         this.rmmapi.getAllContacts().subscribe(contacts => {
             console.log('Contacts:', contacts);
             this.contactsSubject.next(contacts);
+
+            let groups = {};
+            for (let c of contacts) {
+                for (let cat of c.categories) {
+                    groups[cat] = true;
+                }
+            }
+            this.contactGroups.next(Object.keys(groups));
         }, e => this.apiErrorHandler(e));
     }
 


### PR DESCRIPTION
This adds useful group editing fields (instead of the read-only stubs we currently have) and an ability to filter the contact list by their group.

The "email this group" feature is not yet implemented here, but since the grouping functionality is requested by users I think it's worth it to merge this as it is, and work on compose integration later.