### PR TITLE
folderlist(fix): handle draft subfolders

### DIFF
--- a/src/app/folder/folderlist.component.ts
+++ b/src/app/folder/folderlist.component.ts
@@ -81,7 +81,7 @@ export class FolderListComponent {
 
         const foldertreedataobservable = this.folders
             .pipe(
-                map(folders => folders.filter(f => f.folderPath !== 'Drafts')),
+                map(folders => folders.filter(f => f.folderPath.indexOf('Drafts') !== 0)),
                 map((folders) => {
                 const treedata: FolderNode[] = [];
 


### PR DESCRIPTION
folder list crashed if there were draft subfolders.

This fix will not show any draft subfolders, but prevent the folderlist from crashing ( and showing no folders at all) if there are draft subfolders.