### PR TITLE
feat(bundling): check package versions before build + fix(empty-trash/spam): get list from server

### DIFF
--- a/check-prod-bundle-dependencies.js
+++ b/check-prod-bundle-dependencies.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+
+console.log('WARNING: Reverting to committed package-lock.json. If that means your changes are lost you should rebuild it.')
+require('child_process').execSync('git checkout package-lock.json');
+
+const packageLockJSON = JSON.parse(fs.readFileSync('package-lock.json'));
+const packageJSON = JSON.parse(fs.readFileSync('package.json'));
+
+Object.keys(packageJSON.dependencies).concat(Object.keys(packageJSON.devDependencies)).forEach(packagename => {
+    process.stdout.write(`checking integrity of package ${packagename}`);
+    const package = JSON.parse(fs.readFileSync(`node_modules/${packagename}/package.json`));
+    if(packageLockJSON.dependencies[packagename].integrity !== package._integrity) {
+        console.error(`${packagename} integrity does not match with package-lock.json. Please reinstall.`);
+        process.exit(1);
+    }
+    process.stdout.write(` ${package._integrity.substr(0, 20)}... - OK\r\n`);
+});
+
+console.log('All dependency versions ok. Will build production bundle.');

--- a/e2e/compose/compose.e2e-spec.ts
+++ b/e2e/compose/compose.e2e-spec.ts
@@ -54,7 +54,7 @@ describe('Compose', () => {
     await browser.switchTo().frame(element(iframelocator).getWebElement());
 
     console.log('switched to tinymce iframe');
-    await new Promise(resolve => setTimeout(resolve, 500));
+    await new Promise(resolve => setTimeout(resolve, 1000));
     console.log(await element(by.tagName('body')).getText());
     expect(await element(by.tagName('body')).getText()).toContain('Testing session timeout');
     console.log('reply text located');

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "start-use-mockserver": "ng serve --aot --proxy-config backend-proxy-mock.conf.js runbox7",
     "mockserver": "tsc -p e2e/tsconfig.e2e.json && node out-tsc/e2e/mockserver/mockserver.main.js",
     "buildrmm6": "ng build --prod --base-href=/app/ rmm6",
-    "build": "node updatebuildtimestamp.js && ng build --prod --base-href=/app/ && cp ngsw-worker-patched.js dist/ngsw-worker.js && git checkout src/app/buildtimestamp.ts",
+    "build": "node check-prod-bundle-dependencies.js && node updatebuildtimestamp.js && ng build --prod --base-href=/app/ && cp ngsw-worker-patched.js dist/ngsw-worker.js && git checkout src/app/buildtimestamp.ts",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",

--- a/src/app/folder/folderlist.component.ts
+++ b/src/app/folder/folderlist.component.ts
@@ -221,36 +221,40 @@ export class FolderListComponent {
     }
 
     async emptyTrash() {
-        this.folders.pipe(
+        const trashFolderName = await this.folders.pipe(
             map(folders => folders.find(f => f.folderType === 'trash').folderName),
-            tap(trashFolderName => this.selectFolder(trashFolderName)),
-            mergeMap((trashFolderName) =>
-                this.messagelistservice.messagesInViewSubject.pipe(
-                    take(2),
-                    last()
-                )
-            ),
-            mergeMap(messageLists =>
-                this.rmmapi.trashMessages(messageLists.map(msg => msg.id))
-            ),
-            tap(() => this.messagelistservice.refreshFolderCount())
+            take(1)
         ).toPromise();
+
+        if (trashFolderName) {
+            console.log('found trash folder with name', trashFolderName);
+            const messageLists = await this.rmmapi.listAllMessages(0, 0, 0,
+                    RunboxWebmailAPI.LIST_ALL_MESSAGES_CHUNK_SIZE
+                    , true, trashFolderName).toPromise();
+            await this.rmmapi.trashMessages(messageLists.map(msg => msg.id)).toPromise();
+            this.messagelistservice.refreshFolderCount();
+            console.log('Deleted from', trashFolderName);
+        } else {
+            console.error('no trash folder found', trashFolderName);
+        }
     }
 
     async emptySpam() {
-        this.folders.pipe(
+        const spamFolderName = await this.folders.pipe(
             map(folders => folders.find(f => f.folderType === 'spam').folderName),
-            tap(trashFolderName => this.selectFolder(trashFolderName)),
-            mergeMap((trashFolderName) =>
-                this.messagelistservice.messagesInViewSubject.pipe(
-                    take(2),
-                    last()
-                )
-            ),
-            mergeMap(messageLists =>
-                this.rmmapi.trashMessages(messageLists.map(msg => msg.id))
-            ),
-            tap(() => this.messagelistservice.refreshFolderCount())
+            take(1)
         ).toPromise();
+
+        if (spamFolderName) {
+            console.log('found spam folder with name', spamFolderName);
+            const messageLists = await this.rmmapi.listAllMessages(0, 0, 0,
+                    RunboxWebmailAPI.LIST_ALL_MESSAGES_CHUNK_SIZE
+                    , true, spamFolderName).toPromise();
+            await this.rmmapi.trashMessages(messageLists.map(msg => msg.id)).toPromise();
+            this.messagelistservice.refreshFolderCount();
+            console.log('Deleted from', spamFolderName);
+        } else {
+            console.error('no spam folder found', spamFolderName);
+        }
     }
 }


### PR DESCRIPTION
add script to check that installed packages in node_modules matches versions in package-lock.json

the script will complain if the version hashes in node_modules are not the same as in package-lock.json

Also added a fix for empty trash/spam so that instead of used cached folder lists on the client, get the list from the server and run delete operations on the message lists from that.