### PR TITLE
mailviewer(fix): reply when empty subject (issue #146)

### DIFF
--- a/src/app/xapian/messageinfo.spec.ts
+++ b/src/app/xapian/messageinfo.spec.ts
@@ -26,6 +26,8 @@ describe('MessageInfo', () => {
         expect(MessageInfo.getSubjectWithoutAbbreviation('FWD: Testing the subject')).toBe('Testing the subject');
         expect(MessageInfo.getSubjectWithoutAbbreviation('Re: Fwd: Testing the subject')).toBe('Testing the subject');
         expect(MessageInfo.getSubjectWithoutAbbreviation('SV: Fwd: Test FWD: svar')).toBe('Test FWD: svar');
+        expect(MessageInfo.getSubjectWithoutAbbreviation('')).toBe('');
+        expect(MessageInfo.getSubjectWithoutAbbreviation(null)).toBe('');
     });
 
     it('testAddMessageToIndexWithDeleteFolders', () => {

--- a/src/app/xapian/messageinfo.ts
+++ b/src/app/xapian/messageinfo.ts
@@ -113,7 +113,7 @@ export class MessageInfo {
             'VS:',
             'VB:'
         ];
-        const subjectparts = subject.split(' ');
+        const subjectparts = subject ? subject.split(' ') : [];
         let subjectTextStart = 0;
         while (emailsubjectabbreviations.find(abbr => abbr === subjectparts[subjectTextStart])) {
             subjectTextStart ++;


### PR DESCRIPTION
- handle empty subject when clicking reply
- add unit test expectation for empty/null subject

fixes #146