### PR TITLE
canvastable(feat): enable touch zoom

### DIFF
--- a/src/app/canvastable/canvastable.ts
+++ b/src/app/canvastable/canvastable.ts
@@ -179,6 +179,7 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck {
 
   private scrollBarRect: any;
 
+  private isTouchZoom = false;
   private touchdownxy: any;
   private scrollbardrag: Boolean = false;
   private scrollbarArea = false;
@@ -358,6 +359,7 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck {
     let touchMoved = false;
 
     this.canv.addEventListener('touchstart', (event: TouchEvent) => {
+      this.isTouchZoom = false;
 
       this.canv.focus(); // Take away focus from search field
       previousTouchX = event.targetTouches[0].clientX;
@@ -372,6 +374,10 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck {
 
 
     this.canv.addEventListener('touchmove', (event: TouchEvent) => {
+      if (event.targetTouches.length > 1) {
+        this.isTouchZoom = true;
+        return;
+      }
       event.preventDefault();
       touchMoved = true;
 
@@ -401,6 +407,9 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck {
     }, false);
 
     this.canv.addEventListener('touchend', (event: TouchEvent) => {
+      if (this.isTouchZoom) {
+        return;
+      }
       event.preventDefault();
       if (!this.scrollbarArea && !touchMoved) {
         this.selectRow(event.changedTouches[0].clientX, event.changedTouches[0].clientY);

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -45,6 +45,10 @@ $custom-typography: mat-typography-config(
 @include angular-material-typography($custom-typography);
 @include mat-core($custom-typography);
 
+mat-form-field {
+    /* This is for iOS not to zoom in when focusing on text fields */
+    font-size: 16px !important;
+}
 
 /* Generic styles */
 


### PR DESCRIPTION
This enables touch zoom also on the canvastable. Currently it is not possible to revert zoom if accidentally zoomed in on the table, so enabling zoom solves that.

The alternative is to try disable zoom entirely, but in some cases you may want to be able to zoom in on content.

Also added a fix for #152 by setting font-size on `mat-form-field` to 16px. (iOS requires min 16px font size no input fields, otherwise automatic zoom will occur).