### PR TITLE
Canvastable drag select

### DIFF
--- a/e2e/canvastable/canvastable.e2e-spec.ts
+++ b/e2e/canvastable/canvastable.e2e-spec.ts
@@ -1,0 +1,35 @@
+import { browser, by, until, element } from 'protractor';
+import { MockServer } from '../mockserver/mockserver';
+import { CanvasTablePage } from './canvastable.po';
+import { closesyncdialog } from '../dialog/synchronizeprompthandler';
+
+describe('canvastable', () => {
+
+  let server: MockServer;
+
+  beforeEach(async () => {
+    server = new MockServer();
+    server.start();
+  });
+
+  afterEach(() => {
+    browser.manage().logs().get('browser').then(function(browserLogs) {
+        // browserLogs is an array of objects with level and message fields
+        browserLogs.forEach((log) => {
+            console.log(log);
+        });
+     });
+     server.stop();
+  });
+
+  it('should select multiple rows', async () => {
+    browser.waitForAngularEnabled(false);
+    await browser.get('/');
+    await closesyncdialog();
+
+    const page = new CanvasTablePage();
+    await page.selectRows();
+  });
+
+});
+

--- a/e2e/canvastable/canvastable.po.ts
+++ b/e2e/canvastable/canvastable.po.ts
@@ -1,0 +1,34 @@
+import { browser, by, element, until } from 'protractor';
+
+export class CanvasTablePage {
+
+    async selectRows() {
+        const canvasLocator = by.css('canvastable canvas:first-of-type');
+
+        await until.elementLocated(canvasLocator);
+        const canvas = element(canvasLocator);
+
+        await browser.actions()
+            .mouseMove(canvas, {x: 15, y: 10})
+            .perform();
+
+        await new Promise(resolve => setTimeout(resolve, 500));
+        await browser.actions().mouseDown().perform();
+
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        for (let ndx = 0; ndx <= 5; ndx++) {
+            await browser.actions().mouseMove(canvas, {x: 20, y: 36 * ndx + 11}).perform();
+            await new Promise(resolve => setTimeout(resolve, 100));
+        }
+
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        await browser.wait(() => element(by.css('button[mattooltip*="Move"]')).isPresent(), 5000);
+
+        // unselect by moving mouse back up
+        await browser.actions().mouseMove(canvas, {x: 21, y: 12}).perform();
+
+        await browser.wait(async () => !(await element(by.css('button[mattooltip*="Move"]')).isPresent()), 5000);
+    }
+}

--- a/e2e/dialog/synchronizeprompthandler.ts
+++ b/e2e/dialog/synchronizeprompthandler.ts
@@ -1,0 +1,23 @@
+import { browser, until, element, by } from 'protractor';
+
+export async function closesyncdialog() {
+    let shouldclosesyncdialog = true;
+    await browser.wait(until.elementLocated(
+            by.tagName('confirm-dialog')), 5000
+        ).catch(() => {
+            shouldclosesyncdialog = false;
+        })
+        .then(async () => {
+            if (shouldclosesyncdialog) {
+            const buttonLocator = by.css('.mat-dialog-actions button:nth-child(3)');
+            await browser.wait(until.elementLocated(buttonLocator), 10000);
+            await new Promise(resolve => setTimeout(resolve, 1000));
+            await element(buttonLocator).click();
+            console.log(await element(buttonLocator).getWebElement().getText());
+            }
+        });
+
+    browser.wait(async () => !(await element(
+        by.tagName('confirm-dialog')).isPresent()), 10000
+    );
+}


### PR DESCRIPTION
Fixing an annoyance when selecting multiple rows, that the first clicked row was not selected. Also handling that rows in between were not selected if moving mouse fast. Now also possible to undo selection by dragging back up again.

Added end to end test too.

![multiselectrunbox7](https://user-images.githubusercontent.com/9760441/57986670-3b3c9100-7a78-11e9-9f6c-376e8a0c4811.gif)
