### PR TITLE
canvastable(fix): multiselect / drag conflict

### DIFF
--- a/e2e/canvastable/canvastable.e2e-spec.ts
+++ b/e2e/canvastable/canvastable.e2e-spec.ts
@@ -31,5 +31,14 @@ describe('canvastable', () => {
     await page.selectRows();
   });
 
+  it('should select one row', async () => {
+    browser.waitForAngularEnabled(false);
+    await browser.get('/');
+    await closesyncdialog();
+
+    const page = new CanvasTablePage();
+    await page.selectOneRow();
+  });
+
 });
 

--- a/e2e/canvastable/canvastable.po.ts
+++ b/e2e/canvastable/canvastable.po.ts
@@ -31,4 +31,29 @@ export class CanvasTablePage {
 
         await browser.wait(async () => !(await element(by.css('button[mattooltip*="Move"]')).isPresent()), 5000);
     }
+
+    async selectOneRow() {
+        const canvasLocator = by.css('canvastable canvas:first-of-type');
+
+        await until.elementLocated(canvasLocator);
+        const canvas = element(canvasLocator);
+
+        await browser.actions()
+            .mouseMove(canvas, {x: 15, y: 40})
+            .perform();
+
+        await new Promise(resolve => setTimeout(resolve, 500));
+        await browser.actions().click().perform();
+
+        await new Promise(resolve => setTimeout(resolve, 500));
+
+        await browser.wait(() => element(by.css('button[mattooltip*="Move"]')).isPresent(), 5000);
+
+        // unselect
+        await browser.actions().mouseMove(canvas, {x: 21, y: 41}).click().perform();
+
+        await new Promise(resolve => setTimeout(resolve, 500));
+
+        await browser.wait(async () => !(await element(by.css('button[mattooltip*="Move"]')).isPresent()), 5000);
+    }
 }

--- a/src/app/canvastable/canvastable.ts
+++ b/src/app/canvastable/canvastable.ts
@@ -652,12 +652,12 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck {
       event.dataTransfer.dropEffect = 'move';
       event.dataTransfer.setDragImage(document.getElementById('thedragimage'), 0, 0);
       event.dataTransfer.setData('text/plain', 'rowIndex:' + selectedRowIndex);
+      this.selectListener.rowSelected(selectedRowIndex, -1, this.rows[selectedRowIndex]);
     } else {
       event.preventDefault();
       this.lastMouseDownEvent = event;
     }
 
-    this.selectListener.rowSelected(selectedRowIndex, -1, this.rows[selectedRowIndex]);
     this.hasChanges = true;
   }
 


### PR DESCRIPTION
* prevent selecting row from dragstart event when drag-selecting in checkbox column
* add e2e test for selecting one row
* **fixes flapping e2e test for selecting multiple rows**