### PR TITLE
Calendar: add the ability to view/edit event locations and descriptions

### DIFF
--- a/src/app/calendar-app/event-editor-dialog.component.html
+++ b/src/app/calendar-app/event-editor-dialog.component.html
@@ -1,8 +1,21 @@
 <h1 mat-dialog-title>{{ event.title || "New event" }}</h1>
 <div mat-dialog-content>
+    <style>
+        .mat-form-field {
+            width: 100%;
+        }
+    </style>
     <p>
         <mat-form-field>
             <input matInput type="text" placeholder="Title" [(ngModel)]="event.title">
+        </mat-form-field>
+    </p><p>
+        <mat-form-field>
+            <input matInput type="text" placeholder="Location" [(ngModel)]="event.vevent.location">
+        </mat-form-field>
+    </p><p>
+        <mat-form-field>
+            <textarea matInput placeholder="Description" [(ngModel)]="event.vevent.description"></textarea>
         </mat-form-field>
     </p><p>
         <mat-form-field>

--- a/src/app/calendar-app/runbox-calendar-event.ts
+++ b/src/app/calendar-app/runbox-calendar-event.ts
@@ -28,6 +28,11 @@ import {
 
 import * as moment from 'moment';
 
+export class Vevent {
+    location?:    string;
+    description?: string;
+}
+
 export class RunboxCalendarEvent implements CalendarEvent {
     id?:       string;
     start:     Date;
@@ -35,6 +40,8 @@ export class RunboxCalendarEvent implements CalendarEvent {
     title:     string;
     allDay?:   boolean;
     calendar:  string;
+
+    vevent: Vevent = {};
 
     color     = {} as EventColor;
     draggable = true;
@@ -53,11 +60,13 @@ export class RunboxCalendarEvent implements CalendarEvent {
             }
             this.title   = vevent.summary;
             this.allDay  = vevent.dtstart.indexOf('T') === -1;
+            this.vevent  = vevent;
         } else {
             this.start  = event.start;
             this.end    = event.end;
             this.title  = event.title;
             this.allDay = event.allDay;
+            this.vevent = event.vevent;
         }
 
         /*
@@ -107,6 +116,8 @@ export class RunboxCalendarEvent implements CalendarEvent {
                 dtstart: this.dateToJSON(this.start),
                 dtend: this.end ? this.dateToJSON(this.end) : undefined,
                 summary: this.title,
+                location: this.vevent.location,
+                description: this.vevent.description,
                 _all_day: this.allDay
             }
         };


### PR DESCRIPTION
I elected to keep those in a sub-struct of event, given how there's likely going to be quite a few more of those fields, and as the work on recurring events has shown so far, they're often better off detached from the CalendarEvent interface anyway.