### PR TITLE
fix(Calendar): make event end non-inclusive on the backend

### DIFF
--- a/src/app/calendar-app/event-editor-dialog.component.ts
+++ b/src/app/calendar-app/event-editor-dialog.component.ts
@@ -1,18 +1,18 @@
 // --------- BEGIN RUNBOX LICENSE ---------
 // Copyright (C) 2016-2019 Runbox Solutions AS (runbox.com).
-// 
+//
 // This file is part of Runbox 7.
-// 
+//
 // Runbox 7 is free software: You can redistribute it and/or modify it
 // under the terms of the GNU General Public License as published by the
 // Free Software Foundation, either version 3 of the License, or (at your
 // option) any later version.
-// 
+//
 // Runbox 7 is distributed in the hope that it will be useful, but
 // WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
 // General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
@@ -89,8 +89,19 @@ export class EventEditorDialogComponent {
         } else {
             this.event.calendar = this.calendarFC.value;
         }
-        this.event.dtstart = moment(this.event.start);
-        this.event.dtend = moment(this.event.end);
+        this.event.dtstart = moment(this.event.start).seconds(0).milliseconds(0);
+        this.event.dtend = moment(this.event.end).seconds(0).milliseconds(0);
+
+        // For a user it makes sense that a 2-day-long event starts on 1st and ends on 2nd.
+        // For iCalendar however, that's a 1-day event since end dates are non-inclusive.
+        //
+        // Since the user is the sane one here, let's just make all allDay events one day
+        // longer behind the scenes (that's how nextcloud does it too, for example).
+        if (this.event.allDay) {
+            this.event.dtend.add(1, 'day');
+        }
+
+        this.event.refreshDates();
         this.event.setRecurringFrequency(this.recurring_frequency);
 
         this.dialogRef.close(this.event);

--- a/src/app/calendar-app/runbox-calendar-event.ts
+++ b/src/app/calendar-app/runbox-calendar-event.ts
@@ -108,9 +108,21 @@ export class RunboxCalendarEvent implements CalendarEvent {
         // will have a different start/end, but the same dtstart/dtend.
 
         this.start = this.dtstart.toDate();
+
         if (this.dtend) {
             this.end = this.dtend.toDate();
         }
+
+        // iCalendar uses non-inclusive end dates, while angular-calendar uses
+        // inclusive ones. To counteract this, roll the end times back a little
+        // so that they show properly
+        const shownEnd = moment(this.dtend);
+        if (this.allDay) {
+            shownEnd.subtract(1, 'days');
+        } else {
+            shownEnd.subtract(1, 'seconds');
+        }
+        this.end = shownEnd.toDate();
     }
 
     setRecurringFrequency(frequency: number): void {
@@ -131,7 +143,7 @@ export class RunboxCalendarEvent implements CalendarEvent {
         const sign = timezoneOffsetInHours >= 0 ? '+' : '-';
         const leadingZero = (Math.abs(timezoneOffsetInHours) < 10) ? '0' : '';
 
-        // It's a bit unfortunate that we need to construct a new Date instance 
+        // It's a bit unfortunate that we need to construct a new Date instance
         // (we don't want _date_ Date instance to be modified)
         const correctedDate = new Date(date.getFullYear(), date.getMonth(),
             date.getDate(), date.getHours(), date.getMinutes(), date.getSeconds(),


### PR DESCRIPTION
This fixes GH#154 and makes us behave the same as other caldav clients
(iow: correctly :))