### PR TITLE
fix(messagetable): no preloading while scrolling

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -294,7 +294,8 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
 
     // Download visible messages in the background
     this.canvastable.repaintDoneSubject.pipe(
-        throttleTime(500),
+        filter(() => !this.canvastable.isScrollInProgress()),
+        throttleTime(1000),
         map(() => this.canvastable.getVisibleRowIndexes()),
         mergeMap((rowIndexes) =>
           from(


### PR DESCRIPTION
preloading messages while scrolling delays the messages we want to see when done scrolling, so only preload messages when scrolling is finished.

This will also reduce the amount of requests to the server, as we skip preloading messages while scrolling over a long list.