### PR TITLE
feat(mailviewer): experimental PGP decrypt

### DIFF
--- a/src/app/mailviewer/mailparser.ts
+++ b/src/app/mailviewer/mailparser.ts
@@ -1,0 +1,36 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2019 Runbox Solutions AS (runbox.com).
+// 
+// This file is part of Runbox 7.
+// 
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+// 
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { AsyncSubject } from 'rxjs';
+
+let localMailParserSubject = null;
+
+export function loadLocalMailParser(): AsyncSubject<any> {
+  if (localMailParserSubject === null) {
+    localMailParserSubject = new AsyncSubject<any>();
+    const scriptElm: HTMLScriptElement = document.createElement('script');
+    scriptElm.src = '/_js/mailparser.js';
+    scriptElm.onload = () => {
+      localMailParserSubject.next(window['mailparser_parse']);
+      localMailParserSubject.complete();
+    };
+    document.documentElement.appendChild(scriptElm);
+  }
+  return localMailParserSubject;
+}

--- a/src/app/mailviewer/singlemailviewer.component.html
+++ b/src/app/mailviewer/singlemailviewer.component.html
@@ -306,6 +306,10 @@
               </ng-template>              
               <mat-grid-tile-footer style="display: flex; text-align: center">
                   <span>{{att.fileName}}</span>                      
+                  <button mat-icon-button *ngIf="att.fileName==='encrypted.asc'"
+                    matTooltip="Decrypt message"
+                    (click)="decryptAttachment(i);$event.stopPropagation()"
+                  ><mat-icon>lock_open</mat-icon></button>
                   <button mat-icon-button
                     (click)="openAttachment(i,true);$event.stopPropagation()"
                   ><mat-icon>cloud_download</mat-icon></button>


### PR DESCRIPTION
This PR adds experimental support for decrypting messages attached as a file named `encrypted.asc`.

The encrypted attachment is forwarded to pgpapp.no where you can upload 
- add button for decrypting 'encrypted.asc' attachments
- send encrypted message to pgpapp.no and receive decrypted message
- close pgpapp.no once authorized / rejected
- parse decrypted message
- replace subject and body text with parsed decrypted content

Click the unlock button to decrypt the message
![Skjermbilde 2019-06-04 kl  07 48 06](https://user-images.githubusercontent.com/9760441/58854284-20376700-869d-11e9-9923-801d9181721e.png)

Encrypted message is forwarded to pgpapp.no where you can point to your private key (it is not uploaded or stored anywhere at the moment), and also type your passphrase and finally approve the request to decrypt.

![Skjermbilde 2019-06-04 kl  07 50 06](https://user-images.githubusercontent.com/9760441/58854360-655b9900-869d-11e9-89f7-0a1cb704be29.png)
