### PR TITLE
feat(mailviewer): Make email addresses clickable

### DIFF
--- a/src/app/contacts-app/contact-details/contact-details.component.ts
+++ b/src/app/contacts-app/contact-details/contact-details.component.ts
@@ -64,6 +64,21 @@ export class ContactDetailsComponent {
             const contactid = params.id;
             if (contactid === 'new') {
                 this.contact = new Contact({});
+                this.route.queryParams.subscribe(queryParams => {
+                    this.contact.emails = [
+                        { types: ['home'], value: queryParams.email }
+                    ];
+                    const nameParts = queryParams.name.split(' ');
+                    if (nameParts.length === 2) {
+                        // probably "firstName lastName"
+                        this.contact.first_name = nameParts[0];
+                        this.contact.last_name = nameParts[1];
+                    } else {
+                        // no clue
+                        this.contact.nickname = queryParams.name;
+                    }
+                    this.loadContact();
+                });
             } else {
                 this.contact = contacts.find(c => c.id === contactid);
 

--- a/src/app/mailviewer/contactcard.component.ts
+++ b/src/app/mailviewer/contactcard.component.ts
@@ -1,0 +1,66 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2018 Runbox Solutions AS (runbox.com).
+// 
+// This file is part of Runbox 7.
+// 
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+// 
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { Component, Input, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+
+import { Contact } from '../contacts-app/contact';
+import { ContactsService } from '../contacts-app/contacts.service';
+
+@Component({
+    // tslint:disable-next-line:component-selector
+    selector: 'rmm7-contact-card',
+    template: `
+        <a [ngStyle]="style" (click)="clicked()"
+           [matTooltip]="contactsEntry ? 'Show contact' : 'Add to contacts'">
+            {{contact.name}} &lt;{{contact.address}}&gt;
+        </a>
+    `,
+})
+export class ContactCardComponent implements OnInit {
+    @Input() contact: any;
+    contactsEntry: Contact;
+    style = { 'border-bottom': '1px dashed' };
+
+    constructor(
+        private router: Router,
+        private contactsservice: ContactsService,
+    ) {
+    }
+
+    ngOnInit() {
+        this.contactsservice.lookupContact(this.contact.address).then(c => {
+            if (c) {
+                this.contactsEntry = c;
+                this.style['border-bottom'] = '1px solid';
+            }
+        });
+    }
+
+    clicked() {
+        if (this.contactsEntry) {
+            this.router.navigate(['/contacts/' + this.contactsEntry.id]);
+        } else {
+            this.router.navigate(
+                ['/contacts/new'],
+                { queryParams: { name: this.contact.name, email: this.contact.address } }
+            );
+        }
+    }
+}

--- a/src/app/mailviewer/contactcard.component.ts
+++ b/src/app/mailviewer/contactcard.component.ts
@@ -30,6 +30,8 @@ import { ContactsService } from '../contacts-app/contacts.service';
         <a [ngStyle]="style" (click)="clicked()"
            [matTooltip]="contactsEntry ? 'Show contact' : 'Add to contacts'">
             {{contact.name}} &lt;{{contact.address}}&gt;
+            <mat-icon *ngIf="contactsEntry">  person     </mat-icon>
+            <mat-icon *ngIf="!contactsEntry"> person_add </mat-icon>
         </a>
     `,
 })

--- a/src/app/mailviewer/mailviewer.module.ts
+++ b/src/app/mailviewer/mailviewer.module.ts
@@ -24,10 +24,11 @@ import { MatToolbarModule, MatButtonModule,
     MatTooltipModule, MatDialogModule, MatMenuModule,
     MatRadioModule, MatCheckboxModule, MatCardModule, MatGridListModule,
     MatDividerModule, MatExpansionModule } from '@angular/material';
+import { FormsModule } from '@angular/forms';
 import { HttpModule } from '@angular/http';
 import { SingleMailViewerComponent, ShowHTMLDialogComponent } from './singlemailviewer.component';
 import { ResizerModule } from '../directives/resizer.module';
-import { FormsModule } from '@angular/forms';
+import { ContactCardComponent } from './contactcard.component';
 export { SingleMailViewerComponent } from './singlemailviewer.component';
 
 @NgModule({
@@ -53,6 +54,7 @@ export { SingleMailViewerComponent } from './singlemailviewer.component';
         SingleMailViewerComponent
     ],
     declarations: [
+        ContactCardComponent,
         SingleMailViewerComponent,
         ShowHTMLDialogComponent
     ],

--- a/src/app/mailviewer/singlemailviewer.component.html
+++ b/src/app/mailviewer/singlemailviewer.component.html
@@ -179,24 +179,28 @@
       </div>
       <ng-container *ngIf="!showAllHeaders">
         <div class="messageHeaderRow">
-          <div class="messageHeaderFrom">From:</div>
-          <div class="messageHeaderFrom">{{mailObj.from[0].name}} &lt;{{mailObj.from[0].address}}&gt;</div>        
+          <div class="messageHeaderFrom">
+            From: <rmm7-contact-card [contact]="mailObj.from[0]"></rmm7-contact-card>
+          </div>
         </div>
         <div class="messageHeaderRow">                                                                                                                                       
           <div class="messageHeaderDate">Time:</div>
           <div class="messageHeaderDate">{{mailObj.date | date:'yyyy-MM-dd HH:mm ZZZZ'}}</div>
         </div>
         <div *ngIf="mailObj.to" class="messageHeaderRow">
-          <div class="messageHeaderTo">To:</div>
-          <div class="messageHeaderTo"><span *ngFor="let to of mailObj.to">{{to.name}} &lt;{{to.address}}&gt;</span></div>
+          <div class="messageHeaderTo">
+            To: <rmm7-contact-card *ngFor="let to of mailObj.to" [contact]="to"></rmm7-contact-card>
+          </div>
         </div>
         <div *ngIf="mailObj.cc" class="messageHeaderRow">
-          <div class="messageHeaderCC">CC:</div>
-          <div class="messageHeaderCC"><span *ngFor="let to of mailObj.cc">{{to.name}} &lt;{{to.address}}&gt;</span></div>
+          <div class="messageHeaderCC">
+            CC: <rmm7-contact-card *ngFor="let to of mailObj.cc" [contact]="to"></rmm7-contact-card>
+          </div>
         </div>
         <div *ngIf="mailObj.bcc"class="messageHeaderRow">
-          <div class="messageHeaderBCC">BCC:</div>
-          <div class="messageHeaderBCC"><span *ngFor="let to of mailObj.bcc">{{to.name}} &lt;{{to.address}}&gt;</span></div>
+          <div class="messageHeaderBCC">
+            BCC: <rmm7-contact-card *ngFor="let to of mailObj.bcc" [contact]="to"></rmm7-contact-card>
+          </div>
         </div>
       </ng-container>      
       <table *ngIf="showAllHeaders">

--- a/src/app/mailviewer/singlemailviewer.component.spec.ts
+++ b/src/app/mailviewer/singlemailviewer.component.spec.ts
@@ -30,8 +30,10 @@ import { FormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
 import { Http } from '@angular/http';
 import { RunboxWebmailAPI, MessageContents } from '../rmmapi/rbwebmail';
+import { ContactsService } from '../contacts-app/contacts.service';
 import { ProgressService } from '../http/progress.service';
 import { RouterTestingModule } from '@angular/router/testing';
+import { ContactCardComponent } from './contactcard.component';
 import { MessageActions } from './messageactions';
 import { Observable, of } from 'rxjs';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -62,7 +64,7 @@ describe('SingleMailViewerComponent', () => {
         MatExpansionModule,
         RouterTestingModule
       ],
-      declarations: [SingleMailViewerComponent],
+      declarations: [ContactCardComponent, SingleMailViewerComponent],
       providers: [
         { provide: MessageListService, useValue: { spamFolderName: 'Spam' }},
         { provide: Http, useValue: {} },
@@ -96,6 +98,11 @@ describe('SingleMailViewerComponent', () => {
               ]
             });
           }
+        } },
+        { provide: ContactsService, useValue: {
+            lookupContact(email: string) {
+              return new Promise((resolve, reject) => resolve(null));
+            }
         } },
         { provide: ProgressService, useValue: {} }
       ]


### PR DESCRIPTION
Froms, Tos, CCs etc are now clickable, enabling the user to show the
contacts they're related to (if they exist) or add new ones.

Fixes GH-45.

Looks like this – dotted line for new contacts, solid for existing ones.
![2019-06-19-132743_517x125_scrot](https://user-images.githubusercontent.com/86378/59761834-16655480-9296-11e9-8716-20a551e42ee5.png)
