### PR TITLE
feat(mailviewer): Import text/calendar files to Calendar

### DIFF
--- a/src/app/calendar-app/calendar-app.component.spec.ts
+++ b/src/app/calendar-app/calendar-app.component.spec.ts
@@ -18,6 +18,7 @@
 // ---------- END RUNBOX LICENSE ----------
 
 import { ComponentFixture, TestBed, async, fakeAsync, tick } from '@angular/core/testing';
+import { Http } from '@angular/http';
 import { CalendarAppComponent } from './calendar-app.component';
 import { CalendarAppModule } from './calendar-app.module';
 import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
@@ -87,6 +88,8 @@ describe('CalendarAppComponent', () => {
                 { provide: RunboxWebmailAPI, useValue: {
                     getCalendars:      (): Observable<RunboxCalendar[]> => of(mockData['calendars']),
                     getCalendarEvents: (): Observable<RunboxCalendarEvent[]> => of(mockData['events']),
+                } },
+                { provide: Http, useValue: {
                 } },
                 { provide: MatSnackBar, useValue: {
                 } },

--- a/src/app/calendar-app/calendar-app.component.ts
+++ b/src/app/calendar-app/calendar-app.component.ts
@@ -25,6 +25,9 @@ import {
     TemplateRef
 } from '@angular/core';
 
+import { ActivatedRoute } from '@angular/router';
+
+import { Http, ResponseContentType } from '@angular/http';
 import { HttpErrorResponse } from '@angular/common/http';
 
 import {
@@ -89,12 +92,24 @@ export class CalendarAppComponent {
         public  calendarservice: CalendarService,
         private cdr:      ChangeDetectorRef,
         private dialog:   MatDialog,
+        private http:     Http,
+        private route:    ActivatedRoute,
         private snackBar: MatSnackBar,
     ) {
         this.calendarservice.errorLog.subscribe(e => this.showError(e));
         this.calendarservice.calendarSubject.subscribe((calendars) => {
             this.calendars = calendars;
             this.updateEventColors();
+            // see if we're told to import some email-ICS
+            this.route.queryParams.subscribe(params => {
+                const icsUrl = params.import_from;
+                if (!icsUrl)  { return; }
+                this.http.get(icsUrl, { responseType: ResponseContentType.Blob }).subscribe((res) => {
+                    (new Response(res.blob())).text().then(text => {
+                        this.processIcsImport(text);
+                    });
+                });
+            });
         });
         this.calendarservice.eventSubject.subscribe(events => {
             this.events = events;

--- a/src/app/mailviewer/singlemailviewer.component.ts
+++ b/src/app/mailviewer/singlemailviewer.component.ts
@@ -206,6 +206,10 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
       return 'picture_as_pdf';
     } else if (contentType.indexOf('audio') > -1) {
       return 'audiotrack';
+    } else if (contentType.indexOf('text/calendar') > -1) {
+      return 'event';
+    } else if (contentType.indexOf('text/vcard') > -1) {
+      return 'contacts';
     } else if (contentType.indexOf('text') > -1) {
       return 'text_format';
     } else {
@@ -482,6 +486,11 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
   }
 
   public openAttachment(attachment: any) {
+    if (attachment.contentType.indexOf('text/calendar') > -1) {
+      this.router.navigate(['/calendar'], { queryParams: { import_from: attachment.downloadURL }});
+      return;
+    }
+
     // as long as we don't have a separate domain for attachments, we cannot show them in a new tab/window
     const alink = document.createElement('a');
     alink.download = attachment.filename;


### PR DESCRIPTION
This replaces the default attachment action for text/calendar attachments (they still have a download button, the small one).