### PR TITLE
fix: logout from PWA

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -29,7 +29,7 @@
           <mat-icon color="primary">edit</mat-icon></a>
         <a mat-button (click)="drafts();" matTooltip="Drafts">
           <mat-icon color="primary">drafts</mat-icon></a>
-        <a mat-button href="/LOGOUT" matTooltip="Log out">
+        <a mat-button (click)="logoutservice.logout()" matTooltip="Log out">
           <mat-icon>power_settings_new</mat-icon></a>
       </div>
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -54,6 +54,7 @@ import { SwPush } from '@angular/service-worker';
 import { exportKeysFromJWK } from './webpush/vapid.tools';
 import { ProgressService } from './http/progress.service';
 import { environment } from '../environments/environment';
+import { LogoutService } from './login/logout.service';
 
 const LOCAL_STORAGE_SETTING_MAILVIEWER_ON_RIGHT_SIDE_IF_MOBILE = 'mailViewerOnRightSideIfMobile';
 const LOCAL_STORAGE_SETTING_MAILVIEWER_ON_RIGHT_SIDE = 'mailViewerOnRightSide';
@@ -141,6 +142,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     private sanitizer: DomSanitizer,
     private renderer: Renderer2,
     private ngZone: NgZone,
+    public logoutservice: LogoutService,
     public websocketsearchservice: WebSocketSearchService,
     private draftDeskService: DraftDeskService,
     public messagelistservice: MessageListService,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -68,6 +68,7 @@ import { environment } from '../environments/environment';
 import { SearchExpressionBuilderModule } from './xapian/search-expression-builder/search-expression-builder.module';
 import { UpdateAlertModule } from './updatealert/updatealert.module';
 import { MultipleSearchFieldsInputModule } from './xapian/multiple-search-fields-input/multiple-search-fields-input.module';
+import { LoginLogoutModule } from './login/loginlogout.module';
 
 window.addEventListener('dragover', (event) => event.preventDefault());
 window.addEventListener('drop', (event) => event.preventDefault());
@@ -130,12 +131,13 @@ const routes: Routes = [
     ResizerModule,
     DomainRegisterModule,
     UpdateAlertModule,
+    LoginLogoutModule,
     SearchExpressionBuilderModule,
     MultipleSearchFieldsInputModule,
     RouterModule.forRoot(routes),
     ServiceWorkerModule.register('/app/ngsw-worker.js', { enabled: environment.production })
   ],
-  declarations: [MainContainerComponent, AppComponent, LoginComponent,
+  declarations: [MainContainerComponent, AppComponent,
     MoveMessageDialogComponent
     ],
   providers: [ProgressService,

--- a/src/app/login/loginlogout.module.ts
+++ b/src/app/login/loginlogout.module.ts
@@ -1,0 +1,46 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2019 Runbox Solutions AS (runbox.com).
+// 
+// This file is part of Runbox 7.
+// 
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+// 
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { NgModule } from '@angular/core';
+import { LogoutService } from './logout.service';
+import { LoginComponent } from './login.component';
+import { MatProgressBarModule, MatInputModule, MatCardModule, MatButtonModule, MatButtonToggleModule } from '@angular/material';
+import { FormsModule } from '@angular/forms';
+import { CommonModule } from '@angular/common';
+
+@NgModule({
+    imports: [
+        CommonModule,
+        FormsModule,
+        MatInputModule,
+        MatCardModule,
+        MatButtonModule,
+        MatButtonToggleModule,
+        MatProgressBarModule
+    ],
+    declarations: [
+        LoginComponent
+    ],
+    providers: [
+        LogoutService
+    ]
+})
+export class LoginLogoutModule {
+
+}

--- a/src/app/login/logout.service.ts
+++ b/src/app/login/logout.service.ts
@@ -1,0 +1,40 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2019 Runbox Solutions AS (runbox.com).
+// 
+// This file is part of Runbox 7.
+// 
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+// 
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { Injectable } from '@angular/core';
+import { Location } from '@angular/common';
+
+@Injectable()
+export class LogoutService {
+    constructor(
+        private location: Location
+    ) {
+
+    }
+    logout() {
+        // logout via an iframe so that PWA does not open it in a new window/frame
+        const logoutiframe: HTMLIFrameElement = document.createElement('iframe');
+        logoutiframe.src = '/LOGOUT';
+        logoutiframe.onload = () => {
+            // Restart app on logout
+            location.href = this.location.prepareExternalUrl('/');
+        };
+        document.documentElement.appendChild(logoutiframe);
+    }
+}

--- a/src/app/menu/headertoolbar.component.html
+++ b/src/app/menu/headertoolbar.component.html
@@ -56,6 +56,6 @@
   </mat-menu>
 
   <a mat-button href="https://blog.runbox.com/" class="mainMenu"><mat-icon>comment</mat-icon>Blog</a>
-  <a mat-button class="mainMenu" href="/LOGOUT"><mat-icon>power_settings_new</mat-icon>Log out</a>
+  <a mat-button class="mainMenu" (click)="logoutservice.logout()"><mat-icon>power_settings_new</mat-icon>Log out</a>
   <img src="assets/runbox7.png" id="logo" alt="Runbox 7" />
 </mat-toolbar>

--- a/src/app/menu/headertoolbar.component.ts
+++ b/src/app/menu/headertoolbar.component.ts
@@ -20,6 +20,7 @@
 import { Component } from '@angular/core';
 import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
 import { Router } from '@angular/router';
+import { LogoutService } from '../login/logout.service';
 
 @Component({
     moduleId: 'angular2/app/menu/',
@@ -30,7 +31,8 @@ import { Router } from '@angular/router';
 export class HeaderToolbarComponent {
     constructor(
         public rmmapi: RunboxWebmailAPI,
-        private router: Router
+        private router: Router,
+        public logoutservice: LogoutService
     ) {
 
     }


### PR DESCRIPTION
When logging out from PWA on iOS a new window is opened with the runbox.com frontpage. This fix goes to the `/LOGOUT` endpoint via an iframe instead so that no new window is opened. When LOGOUT iframe is loaded, the app is restarted so that now it's possible to restart the app on iOS ( by logging out and in again) without having to reinstall the app.

- log out via iframe so that PWA does not open a separate window (iOS)
- restart app on logout