### PR TITLE
fix: avoid cache in Safari / iOS

### DIFF
--- a/src/app/rmmapi/rbwebmail.ts
+++ b/src/app/rmmapi/rbwebmail.ts
@@ -250,12 +250,14 @@ export class RunboxWebmailAPI {
         skipContent: boolean = false,
         folder?: string)
         : Observable<MessageInfo[]> {
+        // TODO: Need a JSON based REST api endpoint for this
         const url = '/mail/download_xapian_index?listallmessages=1' +
                     '&page=' + page +
                     '&sinceid=' + sinceid +
                     '&sincechangeddate=' + Math.floor(sincechangeddate / 1000) +
                     '&pagesize=' + pagesize + (skipContent ? '&skipcontent=1' : '') +
-                    (folder ? '&folder=' + folder.replace(/\//g, '.') : '');
+                    (folder ? '&folder=' + folder.replace(/\//g, '.') : '') +
+                    '&avoidcacheuniqueparam=' + new Date().getTime();
 
         return this.http.get(url, { responseType: 'text' }).pipe(
             map((txt: string) => txt.length > 0 ? txt.split('\n') : []),

--- a/src/app/xapian/searchservice.spec.ts
+++ b/src/app/xapian/searchservice.spec.ts
@@ -153,9 +153,10 @@ describe('SearchService', () => {
 
         const testMessageId = 3463499;
         await new Promise(resolve => setTimeout(resolve, 100));
-        req = httpMock.expectOne('/mail/download_xapian_index?' +
+        req = httpMock.expectOne(mockrequest =>
+                mockrequest.urlWithParams.indexOf('/mail/download_xapian_index?' +
             'listallmessages=1&page=0&sinceid=0&sincechangeddate=' + Math.floor(indexLastUpdateTime / 1000) +
-            '&pagesize=1000&skipcontent=1');
+            '&pagesize=1000&skipcontent=1&avoidcacheuniqueparam=') === 0);
         const testMessageTime = indexLastUpdateTime + 1; // message time must be later so that indexLastUpdateTime is updated
         req.flush(testMessageId + '\t' + testMessageTime + '\t1561389614\tInbox\t1\t0\t0\t' +
             'Cloud Web Services <cloud-marketing-email-replies@cloudsuperhosting.com>\ttest@example.com	Analyse Data at Scale\ty');


### PR DESCRIPTION
If being logged out e.g. by session timeout or another tab, Safari caches the following forbidden responses, even if logging back in again.

- add unique query parameter with timestamp when polling server for changes to avoid cache
- add todo note about replacing with REST api as REST api responses does not seem to be cached like this one (maybe because the old RMM api returns a login html page when logged out and not a prober JSON error response).