### PR TITLE
Speed up syncing of message list by separating indexing of headers and body text

### DIFF
--- a/src/app/calendar-app/calendar-app.component.spec.ts
+++ b/src/app/calendar-app/calendar-app.component.spec.ts
@@ -41,7 +41,7 @@ describe('CalendarAppComponent', () => {
             summary: 'Test Event #0',
         }}),
         new RunboxCalendarEvent({ id: 'test-calendar/event1', VEVENT: {
-            dtstart: moment().add(1, 'month').toISOString(),
+            dtstart: moment().add(1, 'month').add(1, 'day').toISOString(),
             summary: 'Event #1, next month',
         }}),
     ];


### PR DESCRIPTION
Separate indexing of message headers and body text contents to speed up
updating of the message list.

Also a small fix to the calendar unit test that failed to run today ( 1st of the month ) @tadzik 

issue #225 