### PR TITLE
Tinymce / compose preview fixes

### DIFF
--- a/src/app/compose/compose.component.ts
+++ b/src/app/compose/compose.component.ts
@@ -296,7 +296,7 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
                 // Need to initialize in a timeout for the editor element to be available
                 tinymce.init({
                     selector: '#' + this.editorRef.nativeElement.id,
-                    plugins: 'print preview fullpage searchreplace autolink directionality ' +
+                    plugins: 'print preview searchreplace autolink directionality ' +
                         'visualblocks visualchars fullscreen image link template codesample ' +
                         'table charmap hr pagebreak ' +
                         'nonbreaking anchor toc insertdatetime advlist lists wordcount imagetools ' +

--- a/src/app/compose/compose.component.ts
+++ b/src/app/compose/compose.component.ts
@@ -76,7 +76,6 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
         private formBuilder: FormBuilder,
         private location: Location
     ) {
-
         this.editorId = 'tinymceinstance_' + (ComposeComponent.tinymceinstancecount++);
     }
 
@@ -97,6 +96,10 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
             } else {
                 this.model.from = from.nameAndAddress;
             }
+        } else {
+            this.rmmapi.getMessageContents(this.model.mid).subscribe(msgObj =>
+                this.model.preview = msgObj.text.text
+            );
         }
 
         this.formGroup = this.formBuilder.group(this.model);
@@ -227,59 +230,54 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
 
     public editDraft() {
         if (this.model.mid > 0) {
-            this.http.get('/rest/v1/email/' + this.model.mid)
-                .pipe(
-                    catchError(err => new Observable(o => o.next({ status: 'error', errors: [err] })))
-                )
-                .subscribe((mailObj: any) => {
-                    if (mailObj.status === 'error') {
-                        this.snackBar.open('Error opening draft for editing ' + mailObj.errors[0], 'OK');
-                    } else {
-                        const result = mailObj.result;
-                        const model = new DraftFormModel();
-                        model.mid = typeof result.mid === 'string' ? parseInt(result.mid, 10) : result.mid;
-                        model.attachments = result.attachments.map((att) => Object.assign({
-                            file_url: att.filename,
-                            file: att.filename
-                        }, att));
+            this.rmmapi.getMessageContents(this.model.mid, true)
+                .subscribe((result: any) => {
+                    const model = new DraftFormModel();
+                    model.mid = typeof result.mid === 'string' ? parseInt(result.mid, 10) : result.mid;
+                    model.attachments = result.attachments.map((att) => Object.assign({
+                        file_url: att.filename,
+                        file: att.filename
+                    }, att));
 
-                        const from: any = result.headers.from;
-                        if (from) {
-                            model.from = from.value && from.value[0] ?
-                                from.value[0].name !== 'undefined' ? from.text : from.value[0].address
-                                : null;
-                        }
-                        if (result.headers.to) {
-                            model.to = result.headers.to.text;
-                        }
-                        if (result.headers.cc) {
-                            model.cc = result.headers.cc.text;
-                        }
-                        if (result.headers.bcc) {
-                            model.bcc = result.headers.bcc.text;
-                        }
-
-                        model.subject = result.headers.subject;
-                        if (result.text) {
-                            if (result.text.html) {
-                                model.msg_body = result.text.html;
-                                model.useHTML = true;
-                            } else {
-                                model.msg_body = result.text.text;
-                            }
-                        }
-
-                        if (!model.msg_body) {
-                            model.msg_body = '';
-                        }
-
-                        this.model = model;
-                        this.editing = true;
-
-                        this.formGroup.patchValue(this.model, { emitEvent: false });
-
-                        this.htmlToggled();
+                    const from: any = result.headers.from;
+                    if (from) {
+                        model.from = from.value && from.value[0] ?
+                            from.value[0].name !== 'undefined' ? from.text : from.value[0].address
+                            : null;
                     }
+                    if (result.headers.to) {
+                        model.to = result.headers.to.text;
+                    }
+                    if (result.headers.cc) {
+                        model.cc = result.headers.cc.text;
+                    }
+                    if (result.headers.bcc) {
+                        model.bcc = result.headers.bcc.text;
+                    }
+
+                    model.subject = result.headers.subject;
+                    if (result.text) {
+                        if (result.text.html) {
+                            model.msg_body = result.text.html;
+                            model.useHTML = true;
+                        } else {
+                            model.msg_body = result.text.text;
+                        }
+                        model.preview = result.text.text;
+                    }
+
+                    if (!model.msg_body) {
+                        model.msg_body = '';
+                    }
+
+                    this.model = model;
+                    this.editing = true;
+
+                    this.formGroup.patchValue(this.model, { emitEvent: false });
+
+                    this.htmlToggled();
+                }, err => {
+                    this.snackBar.open(`Error opening draft for editing ${err}`, 'OK');
                 });
         } else {
             this.editing = true;
@@ -446,9 +444,7 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
         this.model.msg_body = this.formGroup.value.msg_body;
         this.model.useHTML = this.formGroup.value.useHTML;
 
-
         if (this.model.useHTML && this.editor) {
-            this.model.msg_body = this.editor.getContent();
             this.model.preview = this.editor.getContent({ format: 'text' }).substring(0, DraftFormModel.MAX_DRAFT_PREVIEW_LENGTH);
         } else {
             this.model.preview = this.model.msg_body.substring(0, DraftFormModel.MAX_DRAFT_PREVIEW_LENGTH);
@@ -481,9 +477,11 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
             ), send)
                 .subscribe((res) => {
                     this.model.mid = parseInt(res[2], 10);
+                    this.rmmapi.deleteCachedMessageContents(this.model.mid);
                     this.snackBar.open(res[1], null, { duration: 3000 });
 
                     this.draftDeleted.emit(this.model.mid);
+
                     this.exitToTable();
                 }, (err) => {
                     let msg = err.statusText;
@@ -527,6 +525,8 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
                     if (res.mid) {
                         this.model.mid = res.mid;
                     }
+                    this.rmmapi.deleteCachedMessageContents(this.model.mid);
+
                     this.isNew = false;
                     this.saved = new Date();
                     this.saveErrorMessage = null;

--- a/src/app/compose/draftdesk.service.ts
+++ b/src/app/compose/draftdesk.service.ts
@@ -199,7 +199,7 @@ export class DraftDeskService {
 
     private refreshDrafts(): Observable<DraftFormModel[]> {
         return this.refreshFroms().pipe(
-            mergeMap(() => this.rmmapi.listAllMessages(0, 0, 0, 100, false, 'Drafts')),
+            mergeMap(() => this.rmmapi.listAllMessages(0, 0, 0, 100, true, 'Drafts')),
             map((msgs) => {
                 this.draftModels =
                     msgs.map((msgInfo) =>
@@ -207,7 +207,7 @@ export class DraftDeskService {
                             this.froms[0],
                             msgInfo.to.map((addr) => addr.name === null || addr.address.indexOf(addr.name + '@') === 0 ?
                                 addr.address : addr.name + '<' + addr.address + '>').join(','),
-                            msgInfo.subject, msgInfo.plaintext)
+                            msgInfo.subject, null)
                     );
             }),
             map(() => this.draftModels)

--- a/src/app/rmmapi/rbwebmail.spec.ts
+++ b/src/app/rmmapi/rbwebmail.spec.ts
@@ -59,4 +59,8 @@ describe('RBWebMail', () => {
         comp = fixture.componentInstance; // Component test instance
         console.log('Component initialized');
     });
+
+    it('should cache message contents', () => {
+
+    });
 });

--- a/src/app/rmmapi/rbwebmail.spec.ts
+++ b/src/app/rmmapi/rbwebmail.spec.ts
@@ -17,50 +17,74 @@
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
 
-import { Component, OnInit } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { HttpClientModule, HttpClient } from '@angular/common/http';
-import { RunboxWebmailAPI, FolderCountEntry, FromAddress, RunboxMe, Alias } from './rbwebmail';
-import { MatSnackBarModule, MatListModule, MatDialog, MatDialogModule } from '@angular/material';
-
-@Component({
-    // tslint:disable-next-line:component-selector
-    selector: 'testcomponent',
-    template: ``
-})
-export class TestComponent implements OnInit {
-
-    constructor(private http: HttpClient, public rbwmapi: RunboxWebmailAPI) {
-
-    }
-
-    ngOnInit() {
-        // this.rbwmapi.listAllMessages(0).subscribe((res) => console.log(res));
-    }
-}
+import { TestBed } from '@angular/core/testing';
+import { RunboxWebmailAPI } from './rbwebmail';
+import { MatSnackBarModule, MatDialogModule } from '@angular/material';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
 describe('RBWebMail', () => {
-
-    let comp:    TestComponent;
-    let fixture: ComponentFixture<TestComponent>;
-
     beforeEach(() => {
-        const testingmodule = TestBed.configureTestingModule({
-            imports: [HttpClientModule,
-                MatDialogModule,
-                MatSnackBarModule,
-                MatListModule],
-            declarations: [ TestComponent ], // declare the test component
-            providers: [RunboxWebmailAPI]
-        });
-
-        fixture = TestBed.createComponent(TestComponent);
-
-        comp = fixture.componentInstance; // Component test instance
-        console.log('Component initialized');
+            TestBed.configureTestingModule({
+                imports: [
+                    MatSnackBarModule,
+                    MatDialogModule,
+                    HttpClientTestingModule,
+                ],
+                providers: [RunboxWebmailAPI]
+            });
     });
 
-    it('should cache message contents', () => {
+    it('should cache message contents', async () => {
+        const rmmapi = TestBed.get(RunboxWebmailAPI);
 
+        let messageContentsObservable = rmmapi.getMessageContents(123);
+
+        const httpTestingController = TestBed.get(HttpTestingController);
+        let req = httpTestingController.expectOne('/rest/v1/email/123');
+        req.flush({
+            result: {
+                id: 123,
+                subject: 'test'
+            }
+        });
+
+        let messageContents = await messageContentsObservable.toPromise();
+        expect(messageContents.id).toBe(123);
+        expect(messageContents.subject).toBe('test');
+
+        messageContentsObservable = rmmapi.getMessageContents(123);
+        httpTestingController.expectNone('/rest/v1/email/123');
+
+        messageContents = await messageContentsObservable.toPromise();
+        expect(messageContents.id).toBe(123);
+        expect(messageContents.subject).toBe('test');
+
+        messageContentsObservable = rmmapi.getMessageContents(123, true);
+        req = httpTestingController.expectOne('/rest/v1/email/123');
+        req.flush({
+            result: {
+                id: 123,
+                subject: 'test2'
+            }
+        });
+
+        messageContents = await messageContentsObservable.toPromise();
+        expect(messageContents.id).toBe(123);
+        expect(messageContents.subject).toBe('test2');
+
+        rmmapi.deleteCachedMessageContents(123);
+
+        messageContentsObservable = rmmapi.getMessageContents(123);
+        req = httpTestingController.expectOne('/rest/v1/email/123');
+        req.flush({
+            result: {
+                id: 123,
+                subject: 'test3'
+            }
+        });
+
+        messageContents = await messageContentsObservable.toPromise();
+        expect(messageContents.id).toBe(123);
+        expect(messageContents.subject).toBe('test3');
     });
 });

--- a/src/app/rmmapi/rbwebmail.ts
+++ b/src/app/rmmapi/rbwebmail.ts
@@ -199,8 +199,14 @@ export class RunboxWebmailAPI {
             });
     }
 
-    public getMessageContents(messageId: number): Observable<MessageContents> {
+    public deleteCachedMessageContents(messageId: number) {
         if (this.messageContentsCache[messageId]) {
+            delete this.messageContentsCache[messageId];
+        }
+    }
+
+    public getMessageContents(messageId: number, refresh = false): Observable<MessageContents> {
+        if (!refresh && this.messageContentsCache[messageId]) {
             return this.messageContentsCache[messageId];
         } else {
             const messageContentsObservable = new AsyncSubject<MessageContents>();


### PR DESCRIPTION
Found that the `fullpage` plugin of tinymce caused the HTML and text preview to be wrapped with `<!DOCTYPE html><html>` etc. Removed the plugin so that this is fixed.

Also found that editor content was lost in cases where exiting compose before autosave completed. Should be fixed.

Fixed so that compose previews are updated with the correct content after editing draft.

Added test for getting message contents from rmm, and the local cache for this.