### PR TITLE
Sync index on foldercount mismatch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,11 @@ cache:
      - ./node_modules
 
 install:
-  - npm install
-  - npm run webdriver-update-ci
+  - npm install  
 
 script:
   - npm run lint
   - npm run policy
   - npm run test -- --watch=false --progress=false --browsers=ChromeHeadlessCI
-  - npm run e2e -- --webdriver-update=false --protractor-config=./protractor-ci.conf.js
+  - npm run e2e -- --protractor-config=./protractor-ci.conf.js
   - npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -1121,9 +1121,9 @@
       "dev": true
     },
     "@types/selenium-webdriver": {
-      "version": "3.0.14",
-      "resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-3.0.14.tgz",
-      "integrity": "sha512-4GbNCDs98uHCT/OMv40qQC/OpoPbYn9XdXeTiFwHBBFO6eJhYEPUu2zDKirXSbHlvDV8oZ9l8EQ+HrEx/YS9DQ==",
+      "version": "3.0.16",
+      "resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-3.0.16.tgz",
+      "integrity": "sha512-lMC2G0ItF2xv4UCiwbJGbnJlIuUixHrioOhNGHSCsYCJ8l4t9hMCUimCytvFv7qy6AfSzRxhRHoGa+UqaqwyeA==",
       "dev": true
     },
     "@types/source-list-map": {
@@ -2196,9 +2196,9 @@
       }
     },
     "browserstack": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/browserstack/-/browserstack-1.5.2.tgz",
-      "integrity": "sha512-+6AFt9HzhKykcPF79W6yjEUJcdvZOV0lIXdkORXMJftGrDl0OKWqRF4GHqpDNkxiceDT/uB7Fb/aDwktvXX7dg==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/browserstack/-/browserstack-1.5.3.tgz",
+      "integrity": "sha512-AO+mECXsW4QcqC9bxwM29O7qWa7bJT94uBFzeb5brylIQwawuEziwq20dPYbins95GlWzOawgyDNdjYAo32EKg==",
       "dev": true,
       "requires": {
         "https-proxy-agent": "^2.2.1"
@@ -6220,56 +6220,15 @@
       }
     },
     "jszip": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.1.5.tgz",
-      "integrity": "sha512-5W8NUaFRFRqTOL7ZDDrx5qWHJyBXy6velVudIzQUSoqAAYqzSh2Z7/m0Rf1QbmQJccegD0r+YZxBjzqoBiEeJQ==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.2.2.tgz",
+      "integrity": "sha512-NmKajvAFQpbg3taXQXr/ccS2wcucR1AZ+NtyWp2Nq7HHVsXhcJFR8p0Baf32C2yVvBylFWVeKf+WI2AnvlPhpA==",
       "dev": true,
       "requires": {
-        "core-js": "~2.3.0",
-        "es6-promise": "~3.0.2",
-        "lie": "~3.1.0",
+        "lie": "~3.3.0",
         "pako": "~1.0.2",
-        "readable-stream": "~2.0.6"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz",
-          "integrity": "sha1-+rg/uwstjchfpjbEudNMdUIMbWU=",
-          "dev": true
-        },
-        "es6-promise": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
-          "integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y=",
-          "dev": true
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~0.10.x",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        }
+        "readable-stream": "~2.3.6",
+        "set-immediate-shim": "~1.0.1"
       }
     },
     "karma": {
@@ -6433,9 +6392,9 @@
       }
     },
     "lie": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
-      "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
       "dev": true,
       "requires": {
         "immediate": "~3.0.5"
@@ -8705,9 +8664,9 @@
           "dev": true
         },
         "webdriver-manager": {
-          "version": "12.1.1",
-          "resolved": "https://registry.npmjs.org/webdriver-manager/-/webdriver-manager-12.1.1.tgz",
-          "integrity": "sha512-L9TEQmZs6JbMMRQI1w60mfps265/NCr0toYJl7p/R2OAk6oXAfwI6jqYP7EWae+d7Ad2S2Aj4+rzxoSjqk3ZuA==",
+          "version": "12.1.6",
+          "resolved": "https://registry.npmjs.org/webdriver-manager/-/webdriver-manager-12.1.6.tgz",
+          "integrity": "sha512-B1mOycNCrbk7xODw7Jgq/mdD3qzPxMaTsnKIQDy2nXlQoyjTrJTTD0vRpEZI9b8RibPEyQvh9zIZ0M1mpOxS3w==",
           "dev": true,
           "requires": {
             "adm-zip": "^0.4.9",
@@ -9504,6 +9463,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
+    "set-immediate-shim": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
       "dev": true
     },
     "set-value": {

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "e2e": "ng e2e",
     "lib": "node ngmakelib-conf.js",
     "libwatch": "node ngmakelib-conf.js --watch",
-    "publishlib": "cd .ngmakelibtmp/dist && npm publish",
-    "webdriver-update-ci": "webdriver-manager update --standalone false --gecko false --versions.chrome 2.37"
+    "publishlib": "cd .ngmakelibtmp/dist && npm publish"
   },
   "dependencies": {
     "@angular/animations": "7.2.15",
@@ -70,7 +69,7 @@
     "karma-jasmine": "~2.0.1",
     "karma-jasmine-html-reporter": "^1.4.0",
     "ngmakelib": "^0.2.6",
-    "protractor": "~5.4.2",
+    "protractor": "^5.4.2",
     "ts-node": "~8.0.1",
     "tsickle": "^0.35.0",
     "tslint": "~5.12.1",

--- a/policy-tests/check-commit-log.js
+++ b/policy-tests/check-commit-log.js
@@ -1,7 +1,7 @@
 const exec = require('child_process').exec;
 
 // starting from 1b9f4c3 all messages are fine... hopefully :)
-exec('git log --oneline --no-merges 1b9f4c3..', (stdin, stdout, stderr) => {
+exec('git log --oneline --no-merges fcb2783..', (stdin, stdout, stderr) => {
     const lines = stdout.split('\n');
     for (const line of lines) {
         if (!line) {

--- a/protractor-ci.conf.js
+++ b/protractor-ci.conf.js
@@ -3,7 +3,7 @@ const config = require('./protractor.conf').config;
 config.capabilities = {
   browserName: 'chrome',
   chromeOptions: {
-    args: ['--headless', '--no-sandbox', '--disable-gpu','--window-size=1920,1080']
+    args: ['--headless','--window-size=1920,1080']
   }
 };
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -817,15 +817,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
           default:
             if (this.searchText.length < 3) {
               // Expand to all folders if search text length is longer than 3 characters
-              const folderQuery = (folderName) => (this.unreadMessagesOnlyCheckbox ? 'unread' : '')
-                + 'folder:"' + folderName.replace(/\//g, '\.') + '" ';
-
-              if (this.selectedFolder === 'Inbox') {
-                // Workaround for IMAP setting folder to "INBOX" when moving messages  there
-                querytext += `(${folderQuery('Inbox')} OR ${folderQuery('INBOX')})`;
-              } else {
-                querytext += folderQuery(this.selectedFolder);
-              }
+              querytext += this.searchService.getFolderQuery(querytext, this.selectedFolder, this.unreadMessagesOnlyCheckbox);
             }
         }
         const previousDisplayFolderColumn = this.displayFolderColumn;

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -133,6 +133,7 @@ const routes: Routes = [
     ContactsAppModule,
     ResizerModule,
     DomainRegisterModule,
+    DkimModule,
     UpdateAlertModule,
     LoginLogoutModule,
     SearchExpressionBuilderModule,

--- a/src/app/canvastable/canvastable.ts
+++ b/src/app/canvastable/canvastable.ts
@@ -90,7 +90,7 @@ export interface CanvasTableColumn {
   originalWidth?: number;
   font?: string;
   backgroundColor?: string;
-  tooltipText?: string;
+  tooltipText?: string | ((rowobj: any) => string);
   draggable?: boolean;
   sortColumn: number;
   excelCellAttributes?: any;
@@ -494,10 +494,13 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck {
         const colIndex = this.getColIndexByClientX(clientX);
         let colStartX = this.columns.reduce((prev, curr, ndx) => ndx < colIndex ? prev + curr.width : prev, 0);
 
-        if (!event.shiftKey && !this.lastMouseDownEvent
-          && this.columns[colIndex]
-          && this.columns[colIndex].draggable) {
+        let tooltipText = this.columns[colIndex] && this.columns[colIndex].tooltipText;
 
+        if (typeof tooltipText === 'function') {
+          tooltipText = tooltipText(this.rows[this.hoverRowIndex]);
+        }
+
+        if (!event.shiftKey && !this.lastMouseDownEvent && tooltipText) {
           if (this.rowWrapMode &&
             colIndex >= this.rowWrapModeWrapColumn) {
             // Subtract first row width if in row wrap mode
@@ -509,7 +512,7 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck {
             (this.hoverRowIndex - this.topindex) * this.rowheight,
             colStartX - this.horizScroll + this.colpaddingleft,
             this.columns[colIndex].width - this.colpaddingright - this.colpaddingleft,
-            this.rowheight, this.columns[colIndex].tooltipText);
+            this.rowheight, tooltipText);
 
           if (this.rowWrapMode) {
             this.floatingTooltip.top +=
@@ -519,7 +522,7 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck {
 
           setTimeout(() => {
             if (this.columnOverlay) {
-              this.columnOverlay.show(1000);
+              this.columnOverlay.show(300);
             }
           }, 0);
         } else {

--- a/src/app/rmmapi/rbwebmail.ts
+++ b/src/app/rmmapi/rbwebmail.ts
@@ -160,7 +160,7 @@ export class MessageFlagChange {
 @Injectable()
 export class RunboxWebmailAPI {
 
-    public static readonly LIST_ALL_MESSAGES_CHUNK_SIZE: number = 1000;
+    public static readonly LIST_ALL_MESSAGES_CHUNK_SIZE: number = 10000;
 
     public messageFlagChangeSubject: Subject<MessageFlagChange> = new Subject();
     public me: AsyncSubject<RunboxMe> = new AsyncSubject();

--- a/src/app/xapian/messageinfo.ts
+++ b/src/app/xapian/messageinfo.ts
@@ -171,9 +171,9 @@ export class IndexingTools {
     public addMessageToIndex(msginfo: MessageInfo,
             foldersNotToIndex?: string[]
         ) {
-        if (msginfo.deletedFlag || (
+        if (
             foldersNotToIndex && foldersNotToIndex.find(foldername =>
-                msginfo.folder === foldername))
+                msginfo.folder === foldername)
          ) {
             this.indexAPI.deleteDocumentByUniqueTerm('Q' + msginfo.id);
             console.log('Deleted msg id search index', msginfo.id);

--- a/src/app/xapian/searchservice.spec.ts
+++ b/src/app/xapian/searchservice.spec.ts
@@ -82,7 +82,7 @@ describe('SearchService', () => {
         req = httpMock.expectOne(mockrequest =>
             mockrequest.urlWithParams.indexOf('/mail/download_xapian_index?' +
             'listallmessages=1&page=0&sinceid=0&sincechangeddate=' + Math.floor(searchService.indexLastUpdateTime / 1000) +
-            '&pagesize=1000&skipcontent=1&avoidcacheuniqueparam=') === 0);
+            '&pagesize=' + RunboxWebmailAPI.LIST_ALL_MESSAGES_CHUNK_SIZE + '&skipcontent=1&avoidcacheuniqueparam=') === 0);
 
         const testMessageId = 3463422;
         const testMessageTime = searchService.indexLastUpdateTime + 1; // message time must be later so that indexLastUpdateTime is updated
@@ -166,9 +166,6 @@ describe('SearchService', () => {
 
         expect(indexLastUpdateTime).toEqual(searchService.indexLastUpdateTime);
 
-        req = httpMock.expectOne('/ajax?action=ajax_getfoldercount');
-        req.flush(folders);
-
         await new Promise(resolve => setTimeout(resolve, 100));
 
         const messageListService = injector.get(MessageListService);
@@ -181,7 +178,7 @@ describe('SearchService', () => {
         req = httpMock.expectOne(mockrequest =>
                 mockrequest.urlWithParams.indexOf('/mail/download_xapian_index?' +
             'listallmessages=1&page=0&sinceid=0&sincechangeddate=' + Math.floor(indexLastUpdateTime / 1000) +
-            '&pagesize=1000&skipcontent=1&avoidcacheuniqueparam=') === 0);
+            '&pagesize=' + RunboxWebmailAPI.LIST_ALL_MESSAGES_CHUNK_SIZE + '&skipcontent=1&avoidcacheuniqueparam=') === 0);
         const testMessageTime = indexLastUpdateTime + 1; // message time must be later so that indexLastUpdateTime is updated
         req.flush(testMessageId + '\t' + testMessageTime + '\t1561389614\tInbox\t1\t0\t0\t' +
             'Cloud Web Services <cloud-marketing-email-replies@cloudsuperhosting.com>\ttest@example.com	Analyse Data at Scale\ty');


### PR DESCRIPTION
This PR adds comparing folder counts received from the server (which is displayed in the left side menu), with the actual count per folder in the local search index. If there are discrepancies, the current folder in view will be retrieved from the server, and added to the index. If the next compare still show discrepancies, a dialog will pop up and suggest downloading a fresh index from the server.

A cause of discrepancies is that the folder count from the server includes messages marked for deletion ( as mentioned in https://github.com/runbox/runbox7/issues/190 ). To prevent this we should decide on either supporting strikethrough of messages marked from deletion in Runbox7, or remove them from the counters as suggested in the issue.


