### PR TITLE
feat(folderlist): drag and drop reordering

### DIFF
--- a/src/app/canvastable/canvastable.spec.ts
+++ b/src/app/canvastable/canvastable.spec.ts
@@ -1,0 +1,78 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2018 Runbox Solutions AS (runbox.com).
+// 
+// This file is part of Runbox 7.
+// 
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+// 
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { TestBed } from '@angular/core/testing';
+import { CanvasTableModule, CanvasTableSelectListener, CanvasTableContainerComponent } from './canvastable';
+import { AsyncSubject } from 'rxjs';
+
+describe('canvastable', () => {
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [
+                CanvasTableModule
+            ]
+        });
+    });
+
+    it('should activate draggable column overlay on mouseover', async () => {
+        const fixture = TestBed.createComponent(CanvasTableContainerComponent);
+        fixture.componentInstance.canvastableselectlistener = {
+            rowSelected: (rowIndex: number, colIndex: number, rowContent: any, multiSelect?: boolean): void => {
+
+            },
+            isSelectedRow: (rowObj: any): boolean => {
+                return false;
+            },
+            isBoldRow: (rowObj: any): boolean => {
+                return false;
+            }
+        };
+        fixture.componentInstance.canvastable.columns = [
+            {
+                name: 'Column1',
+                sortColumn: null,
+                getValue: (row) => row.col1,
+                width: 200
+            },
+            {
+                name: 'Column2',
+                sortColumn: null,
+                getValue: (row) => row.col2,
+                width: 200,
+                draggable: true
+            },
+        ];
+        fixture.componentInstance.canvastable.rows = [
+            { col1: 'subject1', col2: 'fld' },
+            { col1: 'test', col2: 'hello' }
+        ];
+        fixture.componentInstance.canvastable.rowWrapMode = false;
+        fixture.detectChanges();
+
+        fixture.componentInstance.canvastable.canvRef.nativeElement.dispatchEvent(new MouseEvent('mousemove', {
+            clientX: 270,
+            clientY: 50
+        }));
+
+        await new Promise(resolve => setTimeout(resolve, 500));
+        fixture.detectChanges();
+        expect(fixture.componentInstance.canvastable.floatingTooltip).toBeTruthy();
+        expect(fixture.componentInstance.canvastable.columnOverlay).toBeTruthy();
+    });
+});

--- a/src/app/canvastable/canvastable.ts
+++ b/src/app/canvastable/canvastable.ts
@@ -494,13 +494,16 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck {
         const colIndex = this.getColIndexByClientX(clientX);
         let colStartX = this.columns.reduce((prev, curr, ndx) => ndx < colIndex ? prev + curr.width : prev, 0);
 
-        let tooltipText = this.columns[colIndex] && this.columns[colIndex].tooltipText;
+        let tooltipText: string | ((rowobj: any) => string) =
+              this.columns[colIndex] && this.columns[colIndex].tooltipText;
 
-        if (typeof tooltipText === 'function') {
+        if (typeof tooltipText === 'function' && this.rows[this.hoverRowIndex]) {
           tooltipText = tooltipText(this.rows[this.hoverRowIndex]);
         }
 
-        if (!event.shiftKey && !this.lastMouseDownEvent && tooltipText) {
+        if (!event.shiftKey && !this.lastMouseDownEvent &&
+            (tooltipText || (this.columns[colIndex] && this.columns[colIndex].draggable))
+          ) {
           if (this.rowWrapMode &&
             colIndex >= this.rowWrapModeWrapColumn) {
             // Subtract first row width if in row wrap mode
@@ -512,7 +515,7 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck {
             (this.hoverRowIndex - this.topindex) * this.rowheight,
             colStartX - this.horizScroll + this.colpaddingleft,
             this.columns[colIndex].width - this.colpaddingright - this.colpaddingleft,
-            this.rowheight, tooltipText);
+            this.rowheight, tooltipText as string);
 
           if (this.rowWrapMode) {
             this.floatingTooltip.top +=

--- a/src/app/folder/folder.module.ts
+++ b/src/app/folder/folder.module.ts
@@ -19,6 +19,7 @@
 
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { DragDropModule } from '@angular/cdk/drag-drop';
 
 import { FolderListComponent } from './folderlist.component';
 export { FolderListComponent } from './folderlist.component';
@@ -42,6 +43,7 @@ import { DialogModule } from '../dialog/dialog.module';
         MatListModule,
         MatTreeModule,
         DialogModule,
+        DragDropModule,
         MatTooltipModule,
         MatBadgeModule
     ],

--- a/src/app/folder/folderlist.component.css
+++ b/src/app/folder/folderlist.component.css
@@ -13,7 +13,16 @@
 }
 
 .dropToFolderAllowed {
-    background-color: rgba(0, 0, 0, 0.04);
+    transition: background 0.2s ease;
+    background: rgba(0, 255, 0, 0.4);
+}
+.dropAboveFolderAllowed {
+    transition: background 0.2s ease;
+    background: linear-gradient(0deg, rgba(0, 255, 0, 0.0) 0%, rgba(0, 255, 0, 0.1) 90%, rgba(0, 100, 0, 1.0) 100%);
+}
+.dropBelowFolderAllowed {
+    transition: background 0.2s ease;
+    background: linear-gradient(180deg, rgba(0, 255, 0, 0.0) 0%, rgba(0, 255, 0, 0.1) 90%, rgba(0, 100, 0, 1.0) 100%);
 }
 
 .folderCount {

--- a/src/app/folder/folderlist.component.html
+++ b/src/app/folder/folderlist.component.html
@@ -5,15 +5,19 @@
   </button>
 </div>
 <mat-tree [dataSource]="dataSource" [treeControl]="treeControl">
-    <mat-tree-node *matTreeNodeDef="let node" matTreeNodePadding
-      matTreeNodePaddingIndent="20" style="display: flex"
+    <mat-tree-node *matTreeNodeDef="let node" [matTreeNodePadding]="node.folderLevel"
+      matTreeNodePaddingIndent="20"
+      style="display: flex"
+      class="mailFolder"
       [ngClass]="{
         'selectedFolder' : selectedFolder == node.folderPath,
-        'dropToFolderAllowed' : dropFolderId === node.folderId
+        'dropToFolderAllowed' : dropFolderId===node.folderId && dropAboveOrBelowOrInside === dropPosition.INSIDE,
+        'dropAboveFolderAllowed' : dropFolderId===node.folderId && dropAboveOrBelowOrInside === dropPosition.ABOVE,
+        'dropBelowFolderAllowed' : dropFolderId===node.folderId && dropAboveOrBelowOrInside === dropPosition.BELOW
         }"
-        (drop)="dropToFolder(node.folderId)"         
-        (dragover)="allowDropToFolder($event,node.folderId);treeControl.expand(node)" 
-        (dragleave)="dropFolderId=null" class="mailFolder"
+        (drop)="dropToFolder($event,node.folderId)"         
+        (dragover)="allowDropToFolder($event,node)" 
+        (dragend)="dragCancel()" 
         (click)="selectFolder(node.folderPath)"
       >
         <button mat-icon-button matTreeNodeToggle
@@ -30,10 +34,14 @@
         <mat-icon *ngIf="node.folderType=='templates'" mat-list-icon class="folderIconStandard">description</mat-icon>
         <mat-icon *ngIf="node.folderType=='trash'" mat-list-icon class="folderIconStandard">delete</mat-icon>
         <mat-icon *ngIf="node.folderType=='user'" mat-list-icon class="folderIconUser">folder</mat-icon>
-	<span style="margin-left: 5px;">{{node.folderName}}</span>
+        <div style="margin-left: 5px;" 
+              draggable="true"
+              (dragstart)="dragFolderStart($event, node.folderId)">
+              {{node.folderName}}
+        </div>
         <span *ngIf="node.newMessages" matBadge="{{node.newMessages}}" matBadgeOverlap="true" class="newMessagesCount" matBadgeSize="medium">&nbsp;</span>
-	<span style="flex-grow: 1"></span>
-        <span class="foldersidebarcount">{{node.totalMessages}}</span>   
+	      <span style="flex-grow: 1"></span>
+        <span class="foldersidebarcount">{{node.totalMessages}}</span>
         
         <ng-container [ngSwitch]="node.folderType">
           <ng-container *ngSwitchCase="'user'">

--- a/src/app/folder/folderlist.component.spec.ts
+++ b/src/app/folder/folderlist.component.spec.ts
@@ -17,10 +17,10 @@
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
 
-import { FolderListComponent } from './folderlist.component';
+import { FolderListComponent, DropPosition } from './folderlist.component';
 import { MessageListService } from '../rmmapi/messagelist.service';
 import { RunboxWebmailAPI, FolderCountEntry } from '../rmmapi/rbwebmail';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, of, Observable } from 'rxjs';
 import { async, tick, TestBed, getTestBed } from '@angular/core/testing';
 import { MessageInfo } from '../xapian/messageinfo';
 import { last, take } from 'rxjs/operators';
@@ -101,4 +101,180 @@ describe('FolderListComponent', () => {
         });
         expect(refreshFolderCountCalled).toBeTruthy();
     }));
+    it('folderReorderingDrop', async () => {
+        const comp = new FolderListComponent({
+            folderCountSubject: new BehaviorSubject([
+                new FolderCountEntry(1,
+                    50, 40, 'inbox', 'folder1', 'folder2', 0),
+                new FolderCountEntry(2,
+                        50, 40, 'user', 'folder2', 'folder2', 0),
+                new FolderCountEntry(3,
+                    50, 40, 'user', 'subfolder', 'folder2.subfolder', 1),
+                new FolderCountEntry(4,
+                    50, 40, 'user', 'subsubfolder', 'folder2.subfolder.subsubfolder', 2),
+                new FolderCountEntry(5,
+                    50, 40, 'user', 'subsubfolder2', 'folder2.subfolder.subsubfolder2', 2),
+                new FolderCountEntry(6,
+                        50, 40, 'user', 'subsubfolder3', 'folder2.subfolder.subsubfolder3', 2),
+                new FolderCountEntry(7,
+                    50, 40, 'user', 'folder3', 'folder3', 0)
+            ])
+        } as MessageListService, {
+            moveFolder: (folderId: number, newParentFolderId: number): Observable<boolean> => {
+                return of(true);
+            }
+        } as RunboxWebmailAPI, null);
+
+        console.log('move folder with id 6 above 5');
+        await comp.folderReorderingDrop(6, 5, DropPosition.ABOVE);
+        let rearrangedFolders = await comp.messagelistservice.folderCountSubject.pipe(take(1)).toPromise();
+        expect(rearrangedFolders.map(f => f.folderId)).toEqual([1, 2, 3, 4, 6, 5, 7]);
+        expect(rearrangedFolders.map(f => f.folderLevel)).toEqual([0, 0, 1, 2, 2, 2, 0]);
+
+        console.log('move folder with id 6 above 5 - should not cause any changes');
+        await comp.folderReorderingDrop(6, 5, DropPosition.ABOVE);
+        rearrangedFolders = await comp.messagelistservice.folderCountSubject.pipe(take(1)).toPromise();
+        expect(rearrangedFolders.map(f => f.folderId)).toEqual([1, 2, 3, 4, 6, 5, 7]);
+        expect(rearrangedFolders.map(f => f.folderLevel)).toEqual([0, 0, 1, 2, 2, 2, 0]);
+
+        console.log('move folder with id 6 below 5');
+        comp.folderReorderingDrop(6, 5, DropPosition.BELOW);
+        rearrangedFolders = await comp.messagelistservice.folderCountSubject.pipe(take(1)).toPromise();
+        console.log(rearrangedFolders.map(f => f.folderId));
+        expect(rearrangedFolders.map(f => f.folderId)).toEqual([1, 2, 3, 4, 5, 6, 7]);
+        expect(rearrangedFolders.map(f => f.folderLevel)).toEqual([0, 0, 1, 2, 2, 2, 0]);
+
+        console.log('move folder with id 5 below 7');
+        comp.folderReorderingDrop(5, 7, DropPosition.BELOW);
+        rearrangedFolders = await comp.messagelistservice.folderCountSubject.pipe(take(1)).toPromise();
+        console.log(rearrangedFolders.map(f => f.folderId));
+        expect(rearrangedFolders.map(f => f.folderId)).toEqual([1, 2, 3, 4, 6, 7, 5]);
+        expect(rearrangedFolders[6].folderPath).toBe('subsubfolder2');
+        expect(rearrangedFolders.map(f => f.folderLevel)).toEqual([0, 0, 1, 2, 2, 0, 0]);
+
+        console.log('move folder with id 5 inside 7');
+        comp.folderReorderingDrop(5, 7, DropPosition.INSIDE);
+        rearrangedFolders = await comp.messagelistservice.folderCountSubject.pipe(take(1)).toPromise();
+        console.log(rearrangedFolders.map(f => f.folderId));
+        expect(rearrangedFolders.map(f => f.folderId)).toEqual([1, 2, 3, 4, 6, 7, 5]);
+        expect(rearrangedFolders[6].folderPath).toBe('folder3/subsubfolder2');
+        expect(rearrangedFolders.map(f => f.folderLevel)).toEqual([0, 0, 1, 2, 2, 0, 1]);
+
+        console.log('move folder with id 7 above 1');
+        comp.folderReorderingDrop(7, 1, DropPosition.ABOVE);
+        rearrangedFolders = await comp.messagelistservice.folderCountSubject.pipe(take(1)).toPromise();
+        console.log(rearrangedFolders.map(f => f.folderId));
+        expect(rearrangedFolders.map(f => f.folderId)).toEqual([7, 5, 1, 2, 3, 4, 6]);
+        expect(rearrangedFolders[0].folderPath).toBe('folder3');
+        expect(rearrangedFolders[1].folderPath).toBe('folder3/subsubfolder2');
+        expect(rearrangedFolders.map(f => f.folderLevel)).toEqual([0, 1, 0, 0, 1, 2, 2]);
+
+        console.log('move folder with id 7 below 1');
+        comp.folderReorderingDrop(7, 1, DropPosition.BELOW);
+        rearrangedFolders = await comp.messagelistservice.folderCountSubject.pipe(take(1)).toPromise();
+        console.log(rearrangedFolders.map(f => f.folderId));
+        expect(rearrangedFolders.map(f => f.folderId)).toEqual([1, 7, 5, 2, 3, 4, 6]);
+        expect(rearrangedFolders[1].folderPath).toBe('folder3');
+        expect(rearrangedFolders[2].folderPath).toBe('folder3/subsubfolder2');
+        expect(rearrangedFolders.map(f => f.folderLevel)).toEqual([0, 0, 1, 0, 1, 2, 2]);
+
+        console.log('move folder with id 4 above 7');
+        comp.folderReorderingDrop(4, 7, DropPosition.ABOVE);
+        rearrangedFolders = await comp.messagelistservice.folderCountSubject.pipe(take(1)).toPromise();
+        console.log(rearrangedFolders.map(f => f.folderId));
+        expect(rearrangedFolders.map(f => f.folderId)).toEqual([1, 4, 7, 5, 2, 3, 6]);
+        expect(rearrangedFolders[1].folderPath).toBe('subsubfolder');
+        expect(rearrangedFolders[2].folderPath).toBe('folder3');
+        expect(rearrangedFolders[3].folderPath).toBe('folder3/subsubfolder2');
+        expect(rearrangedFolders.map(f => f.folderLevel)).toEqual([0, 0, 0, 1, 0, 1, 2]);
+
+        console.log('move folder with id 5 below 7');
+        comp.folderReorderingDrop(5, 7, DropPosition.BELOW);
+        rearrangedFolders = await comp.messagelistservice.folderCountSubject.pipe(take(1)).toPromise();
+        console.log(rearrangedFolders.map(f => f.folderId));
+        expect(rearrangedFolders[2].folderPath).toBe('folder3');
+        expect(rearrangedFolders[3].folderPath).toBe('subsubfolder2');
+        expect(rearrangedFolders.map(f => f.folderId)).toEqual([1, 4, 7, 5, 2, 3, 6]);
+        expect(rearrangedFolders.map(f => f.folderLevel)).toEqual([0, 0, 0, 0, 0, 1, 2]);
+
+        console.log('move folder with id 6 below 3');
+        comp.folderReorderingDrop(6, 3, DropPosition.BELOW);
+        rearrangedFolders = await comp.messagelistservice.folderCountSubject.pipe(take(1)).toPromise();
+        console.log(rearrangedFolders.map(f => f.folderId));
+
+        expect(rearrangedFolders.map(f => f.folderId)).toEqual([1, 4, 7, 5, 2, 3, 6]);
+        expect(rearrangedFolders.map(f => f.folderLevel)).toEqual([0, 0, 0, 0, 0, 1, 1]);
+
+        console.log('move folder with id 6 inside 7');
+        comp.folderReorderingDrop(6, 7, DropPosition.INSIDE);
+        rearrangedFolders = await comp.messagelistservice.folderCountSubject.pipe(take(1)).toPromise();
+        console.log(rearrangedFolders.map(f => f.folderId));
+
+        expect(rearrangedFolders.map(f => f.folderId)).toEqual([1, 4, 7, 6, 5, 2, 3]);
+        expect(rearrangedFolders.map(f => f.folderLevel)).toEqual([0, 0, 0, 1, 0, 0, 1]);
+
+        console.log('move folder with id 3 above 7');
+        comp.folderReorderingDrop(3, 7, DropPosition.ABOVE);
+        rearrangedFolders = await comp.messagelistservice.folderCountSubject.pipe(take(1)).toPromise();
+        console.log(rearrangedFolders.map(f => f.folderId));
+
+        expect(rearrangedFolders.map(f => f.folderId)).toEqual([1, 4, 3, 7, 6, 5, 2]);
+        expect(rearrangedFolders.map(f => f.folderLevel)).toEqual([0, 0, 0, 0, 1, 0, 0]);
+
+        console.log('move folder with id 6 above 4');
+        comp.folderReorderingDrop(6, 4, DropPosition.ABOVE);
+        rearrangedFolders = await comp.messagelistservice.folderCountSubject.pipe(take(1)).toPromise();
+        console.log(rearrangedFolders.map(f => f.folderId));
+
+        expect(rearrangedFolders.map(f => f.folderId)).toEqual([1, 6, 4, 3, 7, 5, 2]);
+        expect(rearrangedFolders.map(f => f.folderLevel)).toEqual([0, 0, 0, 0, 0, 0, 0]);
+
+        console.log('move folder with id 6 inside 4');
+        comp.folderReorderingDrop(6, 4, DropPosition.INSIDE);
+        rearrangedFolders = await comp.messagelistservice.folderCountSubject.pipe(take(1)).toPromise();
+        console.log(rearrangedFolders.map(f => f.folderId));
+
+        expect(rearrangedFolders.map(f => f.folderId)).toEqual([1, 4, 6, 3, 7, 5, 2]);
+        expect(rearrangedFolders.map(f => f.folderLevel)).toEqual([0, 0, 1, 0, 0, 0, 0]);
+
+        console.log('move folder with id 3 inside 5');
+        comp.folderReorderingDrop(3, 5, DropPosition.INSIDE);
+        rearrangedFolders = await comp.messagelistservice.folderCountSubject.pipe(take(1)).toPromise();
+        console.log(rearrangedFolders.map(f => f.folderId));
+
+        expect(rearrangedFolders.map(f => f.folderId)).toEqual([1, 4, 6, 7, 5, 3, 2]);
+        expect(rearrangedFolders.map(f => f.folderLevel)).toEqual([0, 0, 1, 0, 0, 1, 0]);
+
+        console.log('move folder with id 4 above 5');
+        comp.folderReorderingDrop(4, 5, DropPosition.ABOVE);
+        rearrangedFolders = await comp.messagelistservice.folderCountSubject.pipe(take(1)).toPromise();
+        console.log(rearrangedFolders.map(f => f.folderId));
+
+        expect(rearrangedFolders.map(f => f.folderId)).toEqual([1, 7, 4, 6, 5, 3, 2]);
+        expect(rearrangedFolders.map(f => f.folderLevel)).toEqual([0, 0, 0, 1, 0, 1, 0]);
+
+        console.log('move folder with id 6 below 7');
+        comp.folderReorderingDrop(6, 7, DropPosition.BELOW);
+        rearrangedFolders = await comp.messagelistservice.folderCountSubject.pipe(take(1)).toPromise();
+        console.log(rearrangedFolders.map(f => f.folderId));
+
+        expect(rearrangedFolders.map(f => f.folderId)).toEqual([1, 7, 6, 4, 5, 3, 2]);
+        expect(rearrangedFolders.map(f => f.folderLevel)).toEqual([0, 0, 0, 0, 0, 1, 0]);
+
+        console.log('move folder with id 2 inside 3');
+        comp.folderReorderingDrop(2, 3, DropPosition.INSIDE);
+        rearrangedFolders = await comp.messagelistservice.folderCountSubject.pipe(take(1)).toPromise();
+        console.log(rearrangedFolders.map(f => f.folderId));
+
+        expect(rearrangedFolders.map(f => f.folderId)).toEqual([1, 7, 6, 4, 5, 3, 2]);
+        expect(rearrangedFolders.map(f => f.folderLevel)).toEqual([0, 0, 0, 0, 0, 1, 2]);
+
+        console.log('move folder with id 4 below 3');
+        comp.folderReorderingDrop(4, 3, DropPosition.BELOW);
+        rearrangedFolders = await comp.messagelistservice.folderCountSubject.pipe(take(1)).toPromise();
+        console.log(rearrangedFolders.map(f => f.folderId));
+
+        expect(rearrangedFolders.map(f => f.folderId)).toEqual([1, 7, 6, 5, 3, 2, 4]);
+        expect(rearrangedFolders.map(f => f.folderLevel)).toEqual([0, 0, 0, 0, 1, 2, 1]);
+    });
 });

--- a/src/app/rmmapi/rbwebmail.ts
+++ b/src/app/rmmapi/rbwebmail.ts
@@ -337,6 +337,15 @@ export class RunboxWebmailAPI {
         return req.pipe(map((res: any) => res.status === 'success'));
     }
 
+    moveFolder(folderId: number, newParentFolderId: number): Observable<boolean> {
+        const req = this.http.put('/rest/v1/email_folder/move', {
+            'to_folder': newParentFolderId,
+            'folder_id': folderId
+        });
+        this.subscribeShowBackendErrors(req);
+        return req.pipe(map((res: any) => res.status === 'success'));
+    }
+
     deleteFolder(folderid: number): Observable<boolean> {
         const req = this.http.delete(`/rest/v1/email_folder/delete/${folderid}`);
         this.subscribeShowBackendErrors(req);


### PR DESCRIPTION
**NOTE:** While the UI updates here supports reordering of the folders, the backend does not. Changing the order of folders will be immediately reflected in the user interface, but will be reset when a new folderlist is read from the server. We need backend support for setting the order of folders.

- add drag and drop reordering of folders
- fix canvas table broken drag messages to folder (was broken in 7dc8150e)
- indicate drop above / below / inside when dragging over
- move above / below / into folder ( **IMPORTANT: Backend currently only supports moving into folders, not above/below)**
- add unit test for various cases of rearranging folders
- add unit test for canvastable draggable overlay being activated on hover
- changed to using dragend event instead of dragleave
- load xapian only on demand

fixes #34