### PR TITLE
feat(rmmapi): use folderlist from REST

### DIFF
--- a/e2e/mockserver/mockserver.ts
+++ b/e2e/mockserver/mockserver.ts
@@ -97,8 +97,8 @@ export class MockServer {
                 case '/ajax/aliases':
                     response.end(JSON.stringify({ 'status': 'success', 'aliases': [] }));
                     break;
-                case '/ajax?action=ajax_getfoldercount':
-                    response.end(JSON.stringify(this.foldercount()));
+                case '/rest/v1/email_folder/list':
+                    response.end(JSON.stringify(this.emailFoldersListResponse()));
                     break;
                 case '/mail/download_xapian_index':
                     response.end('');
@@ -199,13 +199,78 @@ export class MockServer {
         };
     }
 
-    foldercount() {
-        return [
-            [3692896, 0, 413, 'drafts', 'Drafts', 'Drafts', 0], [3692892, 2, 29, 'inbox', 'Inbox', 'Inbox', 0],
-            [3692893, 0, 136, 'sent', 'Sent', 'Sent', 0],
-            [3692894, 0, 0, 'spam', 'Spam', 'Spam', 0],
-            [3692895, 0, 218, 'trash', 'Trash', 'Trash', 0]
-        ];
+    emailFoldersListResponse() {
+        return {
+            'status': 'success',
+            'result': {
+                'folders': [
+                    {
+                        'old': 296,
+                        'name': 'Drafts',
+                        'priority': '0',
+                        'id': '5',
+                        'parent': null,
+                        'new': 0,
+                        'total': 296,
+                        'folder': 'Drafts',
+                        'msg_new': 0,
+                        'msg_total': 296,
+                        'size': '11389678',
+                        'msg_size': '11389678',
+                        'subfolders': [],
+                        'type': 'drafts'
+                    },
+                    {
+                        'old': 296,
+                        'name': 'Inbox',
+                        'priority': '0',
+                        'id': '1',
+                        'parent': null,
+                        'new': 0,
+                        'total': 296,
+                        'folder': 'Inbox',
+                        'msg_new': 0,
+                        'msg_total': 296,
+                        'size': '11389678',
+                        'msg_size': '11389678',
+                        'subfolders': [],
+                        'type': 'inbox'
+                    },
+                    {
+                        'old': 296,
+                        'name': 'Spam',
+                        'priority': '0',
+                        'id': '2',
+                        'parent': null,
+                        'new': 0,
+                        'total': 296,
+                        'folder': 'Spam',
+                        'msg_new': 0,
+                        'msg_total': 296,
+                        'size': '11389678',
+                        'msg_size': '11389678',
+                        'subfolders': [],
+                        'type': 'spam'
+                    },
+                    {
+                        'old': 296,
+                        'name': 'Trash',
+                        'priority': '0',
+                        'id': '2',
+                        'parent': null,
+                        'new': 0,
+                        'total': 296,
+                        'folder': 'Trash',
+                        'msg_new': 0,
+                        'msg_total': 296,
+                        'size': '11389678',
+                        'msg_size': '11389678',
+                        'subfolders': [],
+                        'type': 'trash'
+                    },
+                ]
+            }
+        };
     }
 
     auth_challenge_2fa() {

--- a/src/app/folder/folderlist.component.spec.ts
+++ b/src/app/folder/folderlist.component.spec.ts
@@ -102,6 +102,7 @@ describe('FolderListComponent', () => {
         expect(refreshFolderCountCalled).toBeTruthy();
     }));
     it('folderReorderingDrop', async () => {
+        let ordered_ids_request: number[];
         const comp = new FolderListComponent({
             folderCountSubject: new BehaviorSubject([
                 new FolderCountEntry(1,
@@ -120,7 +121,8 @@ describe('FolderListComponent', () => {
                     50, 40, 'user', 'folder3', 'folder3', 0)
             ])
         } as MessageListService, {
-            moveFolder: (folderId: number, newParentFolderId: number): Observable<boolean> => {
+            moveFolder: (folderId: number, newParentFolderId: number, ordered_ids?: number[]): Observable<boolean> => {
+                ordered_ids_request = ordered_ids;
                 return of(true);
             }
         } as RunboxWebmailAPI, null);
@@ -141,6 +143,7 @@ describe('FolderListComponent', () => {
         comp.folderReorderingDrop(6, 5, DropPosition.BELOW);
         rearrangedFolders = await comp.messagelistservice.folderCountSubject.pipe(take(1)).toPromise();
         console.log(rearrangedFolders.map(f => f.folderId));
+        expect(ordered_ids_request).toEqual([1, 2, 3, 4, 5, 6, 7]);
         expect(rearrangedFolders.map(f => f.folderId)).toEqual([1, 2, 3, 4, 5, 6, 7]);
         expect(rearrangedFolders.map(f => f.folderLevel)).toEqual([0, 0, 1, 2, 2, 2, 0]);
 
@@ -148,6 +151,7 @@ describe('FolderListComponent', () => {
         comp.folderReorderingDrop(5, 7, DropPosition.BELOW);
         rearrangedFolders = await comp.messagelistservice.folderCountSubject.pipe(take(1)).toPromise();
         console.log(rearrangedFolders.map(f => f.folderId));
+        expect(ordered_ids_request).toEqual([1, 2, 3, 4, 6, 7, 5]);
         expect(rearrangedFolders.map(f => f.folderId)).toEqual([1, 2, 3, 4, 6, 7, 5]);
         expect(rearrangedFolders[6].folderPath).toBe('subsubfolder2');
         expect(rearrangedFolders.map(f => f.folderLevel)).toEqual([0, 0, 1, 2, 2, 0, 0]);
@@ -276,5 +280,6 @@ describe('FolderListComponent', () => {
 
         expect(rearrangedFolders.map(f => f.folderId)).toEqual([1, 7, 6, 5, 3, 2, 4]);
         expect(rearrangedFolders.map(f => f.folderLevel)).toEqual([0, 0, 0, 0, 1, 2, 1]);
+        expect(ordered_ids_request).toEqual([1, 7, 6, 5, 3, 2, 4]);
     });
 });

--- a/src/app/folder/folderlist.component.ts
+++ b/src/app/folder/folderlist.component.ts
@@ -390,7 +390,7 @@ export class FolderListComponent {
         this.messagelistservice.folderCountSubject.next(folders);
 
         const newParentFolderId = destinationParent ? folders.find(fld => fld.folderPath === destinationParent).folderId : 0;
-        await this.rmmapi.moveFolder(sourceFolderId, newParentFolderId).toPromise();
+        await this.rmmapi.moveFolder(sourceFolderId, newParentFolderId, folders.map(folder => folder.folderId)).toPromise();
     }
 
     async emptyTrash() {

--- a/src/app/rmmapi/rbwebmail.spec.ts
+++ b/src/app/rmmapi/rbwebmail.spec.ts
@@ -24,14 +24,14 @@ import { HttpClientTestingModule, HttpTestingController } from '@angular/common/
 
 describe('RBWebMail', () => {
     beforeEach(() => {
-            TestBed.configureTestingModule({
-                imports: [
-                    MatSnackBarModule,
-                    MatDialogModule,
-                    HttpClientTestingModule,
-                ],
-                providers: [RunboxWebmailAPI]
-            });
+        TestBed.configureTestingModule({
+            imports: [
+                MatSnackBarModule,
+                MatDialogModule,
+                HttpClientTestingModule,
+            ],
+            providers: [RunboxWebmailAPI]
+        });
     });
 
     it('should cache message contents', async () => {
@@ -86,5 +86,532 @@ describe('RBWebMail', () => {
         messageContents = await messageContentsObservable.toPromise();
         expect(messageContents.id).toBe(123);
         expect(messageContents.subject).toBe('test3');
+    });
+
+    it('should flatten folder tree structure and sort by priority', async () => {
+        const listEmailFoldersResponse = {
+            'status': 'success',
+            'result': {
+                'folders': [
+                    {
+                        'total': 4,
+                        'msg_new': 0,
+                        'folder': 'Funstuff',
+                        'parent': null,
+                        'new': 0,
+                        'priority': '7',
+                        'old': 4,
+                        'name': 'Funstuff',
+                        'id': '3693195',
+                        'subfolders': [],
+                        'type': 'user',
+                        'size': '159190',
+                        'msg_size': '159190',
+                        'msg_total': 4
+                    },
+                    {
+                        'folder': 'HTML',
+                        'msg_new': 0,
+                        'total': 9,
+                        'id': '3693182',
+                        'old': 9,
+                        'priority': '1',
+                        'name': 'HTML',
+                        'new': 0,
+                        'parent': null,
+                        'type': 'user',
+                        'subfolders': [
+                            {
+                                'msg_new': 0,
+                                'folder': 'HTML.lalala',
+                                'total': 26,
+                                'id': '3693645',
+                                'name': 'lalala',
+                                'old': 26,
+                                'priority': '2',
+                                'new': 0,
+                                'parent': 3693182,
+                                'type': 'user',
+                                'subfolders': [
+                                    {
+                                        'total': 48,
+                                        'folder': 'HTML.lalala.Tester',
+                                        'msg_new': 0,
+                                        'new': 0,
+                                        'parent': 3693645,
+                                        'priority': '5',
+                                        'old': 48,
+                                        'name': 'Tester',
+                                        'id': '3693667',
+                                        'subfolders': [
+                                            {
+                                                'type': 'user',
+                                                'subfolders': [],
+                                                'msg_total': 4,
+                                                'msg_size': '1806016',
+                                                'size': '1806016',
+                                                'folder': 'HTML.lalala.Tester.Test2',
+                                                'msg_new': 0,
+                                                'total': 4,
+                                                'id': '3693670',
+                                                'old': 4,
+                                                'name': 'Test2',
+                                                'priority': '6',
+                                                'parent': 3693667,
+                                                'new': 0
+                                            }
+                                        ],
+                                        'type': 'user',
+                                        'size': '3460523',
+                                        'msg_size': '3460523',
+                                        'msg_total': 48
+                                    },
+                                    {
+                                        'msg_total': 12,
+                                        'size': '85843',
+                                        'msg_size': '85843',
+                                        'subfolders': [
+                                            {
+                                                'size': '21731',
+                                                'msg_size': '21731',
+                                                'msg_total': 10,
+                                                'subfolders': [],
+                                                'type': 'user',
+                                                'parent': 3693776,
+                                                'new': 1,
+                                                'name': 'subtest',
+                                                'old': 9,
+                                                'priority': '4',
+                                                'id': '3693777',
+                                                'total': 10,
+                                                'msg_new': 1,
+                                                'folder': 'HTML.lalala.hohohohahaha.subtest'
+                                            }
+                                        ],
+                                        'type': 'user',
+                                        'old': 12,
+                                        'name': 'hohohohahaha',
+                                        'priority': '3',
+                                        'id': '3693776',
+                                        'parent': 3693645,
+                                        'new': 0,
+                                        'total': 12,
+                                        'folder': 'HTML.lalala.hohohohahaha',
+                                        'msg_new': 0
+                                    }
+                                ],
+                                'msg_total': 26,
+                                'msg_size': '796443',
+                                'size': '796443'
+                            }
+                        ],
+                        'msg_total': 9,
+                        'msg_size': '11188',
+                        'size': '11188'
+                    }
+                ]
+            }
+        };
+
+        const rmmapi = TestBed.get(RunboxWebmailAPI);
+        const folderCountPromise = rmmapi.getFolderCount().toPromise();
+        const httpTestingController = TestBed.get(HttpTestingController);
+        const req = httpTestingController.expectOne('/rest/v1/email_folder/list');
+        req.flush(listEmailFoldersResponse);
+
+        const folders = await folderCountPromise;
+        expect(folders.length).toBe(7);
+        expect(folders.findIndex(folder => folder.folderPath === 'HTML')).toBe(0);
+        expect(folders[1].folderPath).toBe('HTML/lalala');
+        expect(folders[1].folderLevel).toBe(1);
+        expect(folders[4].folderPath).toBe('HTML/lalala/Tester');
+        expect(folders[4].folderLevel).toBe(2);
+        expect(folders[3].folderPath).toBe('HTML/lalala/hohohohahaha/subtest');
+        expect(folders[3].folderLevel).toBe(3);
+    });
+
+    it('should flatten folder tree structure', async () => {
+        const listEmailFoldersResponse = {
+            'status': 'success',
+            'result': {
+                'folders': [
+                    {
+                        'old': 296,
+                        'name': 'Drafts',
+                        'priority': '0',
+                        'id': '3692896',
+                        'parent': null,
+                        'new': 0,
+                        'total': 296,
+                        'folder': 'Drafts',
+                        'msg_new': 0,
+                        'msg_total': 296,
+                        'size': '11389678',
+                        'msg_size': '11389678',
+                        'subfolders': [],
+                        'type': 'drafts'
+                    },
+                    {
+                        'type': 'inbox',
+                        'subfolders': [],
+                        'msg_total': 21,
+                        'msg_size': '7024718',
+                        'size': '7024718',
+                        'folder': 'Inbox',
+                        'msg_new': 0,
+                        'total': 21,
+                        'id': '3692892',
+                        'priority': '0',
+                        'old': 21,
+                        'name': 'Inbox',
+                        'new': 0,
+                        'parent': null
+                    },
+                    {
+                        'msg_total': 133,
+                        'msg_size': '30479054',
+                        'size': '30479054',
+                        'type': 'sent',
+                        'subfolders': [
+                            {
+                                'new': 0,
+                                'parent': 3692893,
+                                'id': '3693770',
+                                'old': 3,
+                                'name': 'Subsent',
+                                'priority': '0',
+                                'msg_new': 0,
+                                'folder': 'Sent.Subsent',
+                                'total': 3,
+                                'msg_size': '2256226',
+                                'size': '2256226',
+                                'msg_total': 3,
+                                'type': 'user',
+                                'subfolders': []
+                            }
+                        ],
+                        'id': '3692893',
+                        'old': 133,
+                        'priority': '0',
+                        'name': 'Sent',
+                        'new': 0,
+                        'parent': null,
+                        'folder': 'Sent',
+                        'msg_new': 0,
+                        'total': 133
+                    },
+                    {
+                        'msg_new': 0,
+                        'folder': 'Spam',
+                        'total': 1,
+                        'id': '3692894',
+                        'name': 'Spam',
+                        'old': 1,
+                        'priority': '0',
+                        'parent': null,
+                        'new': 0,
+                        'type': 'spam',
+                        'subfolders': [],
+                        'msg_total': 1,
+                        'msg_size': '1157',
+                        'size': '1157'
+                    },
+                    {
+                        'id': '3692895',
+                        'name': 'Trash',
+                        'old': 6,
+                        'priority': '0',
+                        'new': 0,
+                        'parent': null,
+                        'msg_new': 0,
+                        'folder': 'Trash',
+                        'total': 6,
+                        'msg_total': 6,
+                        'msg_size': '135016',
+                        'size': '135016',
+                        'type': 'trash',
+                        'subfolders': []
+                    },
+                    {
+                        'subfolders': [],
+                        'type': 'user',
+                        'msg_total': 0,
+                        'size': '0',
+                        'msg_size': '0',
+                        'total': 0,
+                        'msg_new': 0,
+                        'folder': 'DragAndDropMeSomewhere',
+                        'name': 'DragAndDropMeSomewhere',
+                        'old': 0,
+                        'priority': '0',
+                        'id': '3693671',
+                        'parent': 0,
+                        'new': 0
+                    },
+                    {
+                        'msg_size': '1248553',
+                        'size': '1248553',
+                        'msg_total': 15,
+                        'type': 'user',
+                        'subfolders': [
+                            {
+                                'subfolders': [],
+                                'type': 'user',
+                                'msg_total': 8,
+                                'size': '138665',
+                                'msg_size': '138665',
+                                'total': 8,
+                                'folder': 'Encoding Test.EmailPrivacyTester',
+                                'msg_new': 1,
+                                'old': 7,
+                                'name': 'EmailPrivacyTester',
+                                'priority': '0',
+                                'id': '3693665',
+                                'new': 1,
+                                'parent': 3693643
+                            }
+                        ],
+                        'new': 0,
+                        'parent': null,
+                        'id': '3693643',
+                        'old': 15,
+                        'name': 'Encoding Test',
+                        'priority': '0',
+                        'msg_new': 0,
+                        'folder': 'Encoding Test',
+                        'total': 15
+                    },
+                    {
+                        'total': 4,
+                        'msg_new': 0,
+                        'folder': 'Funstuff',
+                        'parent': null,
+                        'new': 0,
+                        'priority': '0',
+                        'old': 4,
+                        'name': 'Funstuff',
+                        'id': '3693195',
+                        'subfolders': [],
+                        'type': 'user',
+                        'size': '159190',
+                        'msg_size': '159190',
+                        'msg_total': 4
+                    },
+                    {
+                        'folder': 'HTML',
+                        'msg_new': 0,
+                        'total': 9,
+                        'id': '3693182',
+                        'old': 9,
+                        'priority': '0',
+                        'name': 'HTML',
+                        'new': 0,
+                        'parent': null,
+                        'type': 'user',
+                        'subfolders': [
+                            {
+                                'msg_new': 0,
+                                'folder': 'HTML.lalala',
+                                'total': 26,
+                                'id': '3693645',
+                                'name': 'lalala',
+                                'old': 26,
+                                'priority': '0',
+                                'new': 0,
+                                'parent': 3693182,
+                                'type': 'user',
+                                'subfolders': [
+                                    {
+                                        'total': 48,
+                                        'folder': 'HTML.lalala.Tester',
+                                        'msg_new': 0,
+                                        'new': 0,
+                                        'parent': 3693645,
+                                        'priority': '0',
+                                        'old': 48,
+                                        'name': 'Tester',
+                                        'id': '3693667',
+                                        'subfolders': [
+                                            {
+                                                'type': 'user',
+                                                'subfolders': [],
+                                                'msg_total': 4,
+                                                'msg_size': '1806016',
+                                                'size': '1806016',
+                                                'folder': 'HTML.lalala.Tester.Test2',
+                                                'msg_new': 0,
+                                                'total': 4,
+                                                'id': '3693670',
+                                                'old': 4,
+                                                'name': 'Test2',
+                                                'priority': '0',
+                                                'parent': 3693667,
+                                                'new': 0
+                                            }
+                                        ],
+                                        'type': 'user',
+                                        'size': '3460523',
+                                        'msg_size': '3460523',
+                                        'msg_total': 48
+                                    },
+                                    {
+                                        'msg_total': 12,
+                                        'size': '85843',
+                                        'msg_size': '85843',
+                                        'subfolders': [
+                                            {
+                                                'size': '21731',
+                                                'msg_size': '21731',
+                                                'msg_total': 10,
+                                                'subfolders': [],
+                                                'type': 'user',
+                                                'parent': 3693776,
+                                                'new': 1,
+                                                'name': 'subtest',
+                                                'old': 9,
+                                                'priority': '0',
+                                                'id': '3693777',
+                                                'total': 10,
+                                                'msg_new': 1,
+                                                'folder': 'HTML.lalala.hohohohahaha.subtest'
+                                            }
+                                        ],
+                                        'type': 'user',
+                                        'old': 12,
+                                        'name': 'hohohohahaha',
+                                        'priority': '0',
+                                        'id': '3693776',
+                                        'parent': 3693645,
+                                        'new': 0,
+                                        'total': 12,
+                                        'folder': 'HTML.lalala.hohohohahaha',
+                                        'msg_new': 0
+                                    }
+                                ],
+                                'msg_total': 26,
+                                'msg_size': '796443',
+                                'size': '796443'
+                            }
+                        ],
+                        'msg_total': 9,
+                        'msg_size': '11188',
+                        'size': '11188'
+                    },
+                    {
+                        'type': 'user',
+                        'subfolders': [],
+                        'msg_total': 14,
+                        'msg_size': '45945',
+                        'size': '45945',
+                        'msg_new': 0,
+                        'folder': 'Mailsploit',
+                        'total': 14,
+                        'id': '3693666',
+                        'old': 14,
+                        'priority': '0',
+                        'name': 'Mailsploit',
+                        'new': 0,
+                        'parent': null
+                    },
+                    {
+                        'id': '3693669',
+                        'old': 7,
+                        'name': 'Test',
+                        'priority': '0',
+                        'parent': 0,
+                        'new': 0,
+                        'msg_new': 0,
+                        'folder': 'Test',
+                        'total': 7,
+                        'msg_total': 7,
+                        'msg_size': '18279',
+                        'size': '18279',
+                        'type': 'user',
+                        'subfolders': []
+                    },
+                    {
+                        'msg_total': 7,
+                        'msg_size': '17001',
+                        'size': '17001',
+                        'type': 'user',
+                        'subfolders': [],
+                        'id': '3693648',
+                        'priority': '0',
+                        'old': 7,
+                        'name': 'popfolder',
+                        'new': 0,
+                        'parent': null,
+                        'msg_new': 0,
+                        'folder': 'popfolder',
+                        'total': 7
+                    },
+                    {
+                        'msg_size': '5748',
+                        'size': '5748',
+                        'msg_total': 4,
+                        'type': 'user',
+                        'subfolders': [],
+                        'new': 1,
+                        'parent': null,
+                        'id': '3693649',
+                        'priority': '0',
+                        'old': 3,
+                        'name': 'popfolder2',
+                        'folder': 'popfolder2',
+                        'msg_new': 1,
+                        'total': 4
+                    },
+                    {
+                        'total': 4,
+                        'folder': 'testaaa',
+                        'msg_new': 0,
+                        'new': 0,
+                        'parent': null,
+                        'old': 4,
+                        'name': 'testaaa',
+                        'priority': '0',
+                        'id': '3693632',
+                        'subfolders': [],
+                        'type': 'user',
+                        'size': '140433',
+                        'msg_size': '140433',
+                        'msg_total': 4
+                    },
+                    {
+                        'msg_size': '8457',
+                        'size': '8457',
+                        'msg_total': 6,
+                        'type': 'user',
+                        'subfolders': [],
+                        'new': 0,
+                        'parent': null,
+                        'id': '3693623',
+                        'name': 'testagain',
+                        'old': 6,
+                        'priority': '0',
+                        'msg_new': 0,
+                        'folder': 'testagain',
+                        'total': 6
+                    }
+                ]
+            }
+        };
+
+        const rmmapi = TestBed.get(RunboxWebmailAPI);
+        const folderCountPromise = rmmapi.getFolderCount().toPromise();
+        const httpTestingController = TestBed.get(HttpTestingController);
+        const req = httpTestingController.expectOne('/rest/v1/email_folder/list');
+        req.flush(listEmailFoldersResponse);
+
+        const folders = await folderCountPromise;
+        expect(folders[0].folderId).toBe(3692896);
+        expect(folders.length).toBe(22);
+        expect(folders.findIndex(folder => folder.folderPath === 'HTML')).toBe(10);
+        expect(folders[11].folderPath).toBe('HTML/lalala');
+        expect(folders[11].folderLevel).toBe(1);
+        expect(folders[12].folderPath).toBe('HTML/lalala/Tester');
+        expect(folders[12].folderLevel).toBe(2);
+        expect(folders[15].folderPath).toBe('HTML/lalala/hohohohahaha/subtest');
+        expect(folders[15].folderLevel).toBe(3);
     });
 });

--- a/src/app/rmmapi/rbwebmail.ts
+++ b/src/app/rmmapi/rbwebmail.ts
@@ -48,6 +48,7 @@ export class MessageFields {
 
 export class FolderCountEntry {
     isExpandable?: boolean;
+    priority?: number; // for sorting order
 
     constructor(
         public folderId: number,
@@ -337,11 +338,17 @@ export class RunboxWebmailAPI {
         return req.pipe(map((res: any) => res.status === 'success'));
     }
 
-    moveFolder(folderId: number, newParentFolderId: number): Observable<boolean> {
-        const req = this.http.put('/rest/v1/email_folder/move', {
-            'to_folder': newParentFolderId,
-            'folder_id': folderId
-        });
+    moveFolder(folderId: number, newParentFolderId: number, ordered_ids?: number[]): Observable<boolean> {
+        const requestBody: any = {
+                'to_folder': newParentFolderId,
+                'folder_id': folderId
+            };
+
+        if (ordered_ids) {
+            requestBody.ordered_ids = ordered_ids;
+        }
+
+        const req = this.http.put('/rest/v1/email_folder/move', requestBody);
         this.subscribeShowBackendErrors(req);
         return req.pipe(map((res: any) => res.status === 'success'));
     }
@@ -353,18 +360,39 @@ export class RunboxWebmailAPI {
     }
 
     getFolderCount(): Observable<Array<FolderCountEntry>> {
-        return this.http.get('/ajax?action=ajax_getfoldercount').pipe(
-            map((arr: any[]) =>
-                arr.filter((arr2: any[]) => arr2.length > 0)
-                    .map((entry) => new FolderCountEntry(
-                        entry[0],
-                        entry[1],
-                        entry[2],
-                        entry[3],
-                        entry[4],
-                        entry[5],
-                        entry[6]))
-            ));
+        let folderLevel = 0;
+        let depth = 0;
+        const flattenFolders = folders => {
+            folderLevel++;
+            const flattenedFolders = folders.map(folder => {
+                const folderCountEntry = new FolderCountEntry(
+                    parseInt(folder.id, 10),
+                    folder.msg_new,
+                    folder.total,
+                    folder.type,
+                    folder.name,
+                    folder.folder,
+                    folderLevel - 1
+                );
+                folderCountEntry.priority = folder.priority;
+
+                return folder.subfolders.length > 0 ?
+                    [folderCountEntry].concat(flattenFolders(folder.subfolders)) : folderCountEntry;
+
+            });
+            if (folderLevel > depth) {
+                depth = folderLevel;
+            }
+            folderLevel--;
+            return flattenedFolders;
+        };
+        return this.http.get('/rest/v1/email_folder/list').pipe(
+            map((response: any) =>
+                flattenFolders(response.result.folders)
+                .flat(depth)
+                .sort((a, b) => a.priority - b.priority)
+            )
+        );
     }
 
     public moveToFolder(messageIds: number[], folderId: number): Observable<any> {

--- a/src/app/xapian/searchservice.spec.ts
+++ b/src/app/xapian/searchservice.spec.ts
@@ -20,7 +20,7 @@
 import { SearchService, XAPIAN_GLASS_WR } from './searchservice';
 import { TestBed } from '@angular/core/testing';
 import { Injector } from '@angular/core';
-import { RunboxWebmailAPI, RunboxMe, FolderCountEntry } from '../rmmapi/rbwebmail';
+import { RunboxWebmailAPI, RunboxMe } from '../rmmapi/rbwebmail';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { MatSnackBarModule, MatDialogModule } from '@angular/material';
 
@@ -36,11 +36,61 @@ describe('SearchService', () => {
     let injector: Injector;
     let httpMock: HttpTestingController;
 
-    const folders = [
-        [1, 1, 2, 'inbox', 'Inbox', 'Inbox', 0 ],
-        [2, 0, 0, 'spam', 'Spam', 'Spam', 0],
-        [3, 0, 0, 'trash', 'Trash', 'Trash', 0 ]
-    ];
+    const listEmailFoldersResponse = {
+        'status': 'success',
+        'result': {
+            'folders': [
+                {
+                    'old': 296,
+                    'name': 'Inbox',
+                    'priority': '0',
+                    'id': '1',
+                    'parent': null,
+                    'new': 0,
+                    'total': 296,
+                    'folder': 'Inbox',
+                    'msg_new': 0,
+                    'msg_total': 296,
+                    'size': '11389678',
+                    'msg_size': '11389678',
+                    'subfolders': [],
+                    'type': 'inbox'
+                },
+                {
+                    'old': 296,
+                    'name': 'Spam',
+                    'priority': '0',
+                    'id': '2',
+                    'parent': null,
+                    'new': 0,
+                    'total': 296,
+                    'folder': 'Spam',
+                    'msg_new': 0,
+                    'msg_total': 296,
+                    'size': '11389678',
+                    'msg_size': '11389678',
+                    'subfolders': [],
+                    'type': 'spam'
+                },
+                {
+                    'old': 296,
+                    'name': 'Trash',
+                    'priority': '0',
+                    'id': '2',
+                    'parent': null,
+                    'new': 0,
+                    'total': 296,
+                    'folder': 'Trash',
+                    'msg_new': 0,
+                    'msg_total': 296,
+                    'size': '11389678',
+                    'msg_size': '11389678',
+                    'subfolders': [],
+                    'type': 'trash'
+                },
+            ]
+        }
+    };
 
     beforeEach((() => {
         TestBed.configureTestingModule({
@@ -66,8 +116,8 @@ describe('SearchService', () => {
                 uid: 555
             } as RunboxMe
         });
-        req = httpMock.expectOne('/ajax?action=ajax_getfoldercount');
-        req.flush(folders);
+        req = httpMock.expectOne('/rest/v1/email_folder/list');
+        req.flush(listEmailFoldersResponse);
 
         expect(await searchService.initSubject.toPromise()).toBeFalsy();
         expect(searchService.localSearchActivated).toBeFalsy();
@@ -157,8 +207,9 @@ describe('SearchService', () => {
             } as RunboxMe
         });
 
-        req = httpMock.expectOne('/ajax?action=ajax_getfoldercount');
-        req.flush(folders);
+        req = httpMock.expectOne('/rest/v1/email_folder/list');
+        req.flush(listEmailFoldersResponse);
+
 
         expect(await searchService.initSubject.toPromise()).toBeTruthy();
         expect(searchService.localSearchActivated).toBeTruthy();

--- a/src/app/xapian/searchservice.ts
+++ b/src/app/xapian/searchservice.ts
@@ -730,7 +730,7 @@ export class SearchService {
             if (this.folderCountDiscrepanciesCheckedCount[currentFolder.folderPath] >= 1) {
               this.folderCountDiscrepanciesCheckedCount[currentFolder.folderPath]++;
 
-              if (this.folderCountDiscrepanciesCheckedCount[currentFolder.folderPath] === 3) {
+              /*if (this.folderCountDiscrepanciesCheckedCount[currentFolder.folderPath] === 3) {
                 this.dialog.open(InfoDialog, {data: new InfoParams(
                   `Message count mismatch in folder ${currentFolder.folderName}`,
                   `<p>Your local search index is not in sync for folder ${currentFolder.folderName}.
@@ -742,7 +742,7 @@ export class SearchService {
                   reload and click "Start synchronizing" to download a fresh index.</p>
                   `)
                 });
-              }
+              }*/
             } else {
               // Only check folder discrepancies once per folder
               this.folderCountDiscrepanciesCheckedCount[currentFolder.folderPath] = 1;


### PR DESCRIPTION
- remove references to rmm6 folderlist (/ajax?getfoldercount)
- add fetching folderlist from /rest/v1/email_folder/list
- add functionality for flattening the nested folderlist structure
 - so that it returns same folderlist array as previously
- use priority field to sort folderlist in the frontend
- add tests for new REST endpoint and priority field
- disable folder count discrepancy check popup dialog

fixes #265