### PR TITLE
fix(calendar-app): make unit tests less time-dependent

### DIFF
--- a/src/app/calendar-app/calendar-app.component.spec.ts
+++ b/src/app/calendar-app/calendar-app.component.spec.ts
@@ -41,7 +41,7 @@ describe('CalendarAppComponent', () => {
             summary: 'Test Event #0',
         }}),
         new RunboxCalendarEvent({ id: 'test-calendar/event1', VEVENT: {
-            dtstart: moment().add(1, 'month').add(1, 'day').toISOString(),
+            dtstart: moment().add(1, 'month').add(14, 'day').toISOString(),
             summary: 'Event #1, next month',
         }}),
     ];


### PR DESCRIPTION
Tests expected only events from the current month to be shown.
Unfortunately, the calendar also shows all the days from next month
until the nearest sunday.

Moving the event two weeks into the future makes sure that it's never
displayed by accident. Hopefully. See you all again when the tests start
failing next month ;)