### PR TITLE
test(calendar): handle beginning of month

### DIFF
--- a/src/app/calendar-app/calendar-app.component.spec.ts
+++ b/src/app/calendar-app/calendar-app.component.spec.ts
@@ -41,7 +41,7 @@ describe('CalendarAppComponent', () => {
             summary: 'Test Event #0',
         }}),
         new RunboxCalendarEvent({ id: 'test-calendar/event1', VEVENT: {
-            dtstart: moment().add(1, 'month').add(1, 'day').toISOString(),
+            dtstart: moment().add(1, 'month').add(15, 'day').toISOString(),
             summary: 'Event #1, next month',
         }}),
     ];


### PR DESCRIPTION
add 15 days to the second calendar test event so that it's not visible
in month view in the beginning of a month
