### PR TITLE
fix(folder): make sure folders are handled correctly regadless of order

### DIFF
--- a/src/app/folder/folderlist.component.spec.ts
+++ b/src/app/folder/folderlist.component.spec.ts
@@ -282,4 +282,16 @@ describe('FolderListComponent', () => {
         expect(rearrangedFolders.map(f => f.folderLevel)).toEqual([0, 0, 0, 0, 1, 2, 1]);
         expect(ordered_ids_request).toEqual([1, 7, 6, 5, 3, 2, 4]);
     });
+    it('folders provided out of order should work fine', async () => {
+        const comp = new FolderListComponent({
+            folderCountSubject: new BehaviorSubject([
+                new FolderCountEntry(1, 0, 0, 'user', 'subfolder', 'parentfolder.subfolder', 1),
+                new FolderCountEntry(2, 0, 0, 'user', 'parentfolder', 'parentfolder', 0),
+            ])
+        } as MessageListService, null, null);
+
+        console.log(comp.dataSource.data);
+        expect(comp.dataSource.data.length).toBe(1, 'a folder got loaded correctly');
+        expect(comp.dataSource.data[0].children.length).toBe(1, 'a subfolder got loaded correctly');
+    });
 });

--- a/src/app/folder/folderlist.component.ts
+++ b/src/app/folder/folderlist.component.ts
@@ -100,6 +100,13 @@ export class FolderListComponent {
                 const parentStack: FolderNode[] = [];
                 let previousNode: FolderNode = null;
 
+                // the loop below only handles folders correctly
+                // if it visits parents before it visits their children.
+                // This ensures that it happens
+                folders.sort((a, b) => {
+                    return a.folderLevel - b.folderLevel;
+                });
+
                 folders.forEach((folderCountEntry, ndx) => {
                     const folderNode: FolderNode = { children: [], data: folderCountEntry};
 


### PR DESCRIPTION
With the new priority sorting (done by getFolderCount() in RunboxWebmailAPI)
there is a risk that subfolders appear before parent folders in the
resulting list. The flattening algorithm in FolderListComponent doesn't
handle that correctly, breaks and displays nothing. This fixes it and
adds a testcase.

It feels like now that the folders are pre sorted the BFS loop (or what
looks like one :)) below could be somewhat simplified too – but that's
a task for another time.