### PR TITLE
fix(app): re-add deprecated mobileQuery APIs

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -226,12 +226,16 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
       }
     };
 
-    this.mobileQuery.addEventListener('change', this.mobileQueryListener);
+    // the non-deprecated addEventListener doesn't work on Safari, so...
+    // tslint:disable-next-line:deprecation
+    this.mobileQuery.addListener(this.mobileQueryListener);
     this.updateTime();
   }
 
   ngOnDestroy() {
-    this.mobileQuery.removeEventListener('change', this.mobileQueryListener);
+    // the non-deprecated removeEventListener doesn't work on Safari, so...
+    // tslint:disable-next-line:deprecation
+    this.mobileQuery.removeListener(this.mobileQueryListener);
   }
   ngDoCheck(): void {
     this.showSelectOperations = Object.keys(this.selectedRowIds).reduce((prev, current) =>


### PR DESCRIPTION
The new, recommended ones aren't supported on Safari
which breaks the app completely.