### PR TITLE
style(draftdesk): Add a message to an empty draftdesk

### DIFF
--- a/src/app/compose/draftdesk.component.html
+++ b/src/app/compose/draftdesk.component.html
@@ -5,4 +5,7 @@
             <mat-icon>more_horiz</mat-icon>
         </button>        
     </div>
+    <div *ngIf="draftModelsInView.length === 0" class="noMessageSelectedNotification" style="width: 100%">
+      No drafts
+    </div>
 </div>


### PR DESCRIPTION
It now looks less like a rendering error when no drafts are available :)