### PR TITLE
Canvastable scroll lagging and column resize fixes

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -19,9 +19,8 @@
 
 import { AfterViewInit, Component, DoCheck, NgZone, OnInit, ViewChild, Renderer2, ChangeDetectorRef, OnDestroy } from '@angular/core';
 import {
-  CanvasTableSelectListener, AnimationFrameThrottler, CanvasTableComponent,
-  CanvasTableContainerComponent,
-  CanvasTableColumn
+  CanvasTableSelectListener, CanvasTableComponent,
+  CanvasTableContainerComponent
 } from './canvastable/canvastable';
 import { SingleMailViewerComponent } from './mailviewer/singlemailviewer.component';
 import { SearchService } from './xapian/searchservice';

--- a/src/app/canvastable/canvastable.ts
+++ b/src/app/canvastable/canvastable.ts
@@ -339,7 +339,6 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck {
     this.canv.addEventListener('touchstart', (event: TouchEvent) => {
       this.isTouchZoom = false;
 
-      this.canv.focus(); // Take away focus from search field
       previousTouchX = event.targetTouches[0].clientX;
       previousTouchY = event.targetTouches[0].clientY;
       checkScrollbarDrag(event.targetTouches[0].clientX, event.targetTouches[0].clientY);


### PR DESCRIPTION
when touching the table a focus event is currently triggered to take focus away from the search input field when scrolling the table. On iOS devices this causes lagging scroll, and the fix is as simple as just removing the call to `this.canv.focus()`.

Now this contains no replacement for taking away the focus from the input field when scrolling, so if you still want this you'll have to find another alternative for that.

Also fixed that if you drag the resizer next to the subject column causes the mailviewer to open, and removed the animationframethrottler which only seems to be used by the resizer. If a throttle mechanism is needed (seems not to be), probably better to find another alternative mechanism than requesting animation frames