### PR TITLE
Calendar overview

### DIFF
--- a/src/app/calendar-app/calendar-app.component.html
+++ b/src/app/calendar-app/calendar-app.component.html
@@ -28,22 +28,29 @@
 <ng-template #viewModeButtons>
     <button mat-raised-button
         class="calendarToolbarButton"
-        (click)="view = CalendarView.Month"
-        [color]="view === CalendarView.Month ? 'primary' : ''"
+        (click)="setView(RunboxCalendarView.Overview)"
+        [color]="view === RunboxCalendarView.Overview ? 'primary' : ''"
+    >
+        Overview
+    </button>
+    <button mat-raised-button
+        class="calendarToolbarButton"
+        (click)="setView(RunboxCalendarView.Month)"
+        [color]="view === RunboxCalendarView.Month ? 'primary' : ''"
     >
         Month
     </button>
     <button mat-raised-button
         class="calendarToolbarButton"
-        (click)="view = CalendarView.Week"
-        [color]="view === CalendarView.Week ? 'primary' : ''"
+        (click)="setView(RunboxCalendarView.Week)"
+        [color]="view === RunboxCalendarView.Week ? 'primary' : ''"
     >
         Week
     </button>
     <button mat-raised-button
         class="calendarToolbarButton"
-        (click)="view = CalendarView.Day"
-        [color]="view === CalendarView.Day ? 'primary' : ''"
+        (click)="setView(RunboxCalendarView.Day)"
+        [color]="view === RunboxCalendarView.Day ? 'primary' : ''"
     >
         Day
     </button>
@@ -51,9 +58,10 @@
 
 <ng-template #previousPeriodButton>
     <button mat-raised-button mwlCalendarPreviousView
+        *ngIf="view !== RunboxCalendarView.Overview"
         id="previousPeriodButton"
         class="calendarToolbarButton"
-        [view]="view"
+        [view]="mwlView"
         [(viewDate)]="viewDate"
         (viewDateChange)="activeDayIsOpen = false"
     >
@@ -68,10 +76,11 @@
 
 <ng-template #nextPeriodButton>
     <button mat-raised-button
+        *ngIf="view !== RunboxCalendarView.Overview"
         id="nextPeriodButton"
         class="calendarToolbarButton"
         mwlCalendarNextView
-        [view]="view"
+        [view]="mwlView"
         [(viewDate)]="viewDate"
         (viewDateChange)="activeDayIsOpen = false"
     >
@@ -85,8 +94,8 @@
 </ng-template>
 
 <ng-template #calendarTitle>
-    <span class="calendarTitle" *ngIf="view">
-        {{ viewDate | calendarDate:(view + 'ViewTitle'):'en' }}
+    <span class="calendarTitle">
+        {{ mwlView ? (viewDate | calendarDate:(mwlView + 'ViewTitle'):'en') : 'Overview' }}
     </span>
 </ng-template>
 
@@ -101,10 +110,13 @@
     >
         <mat-nav-list dense>
             <app-sidenav-menu (closeMenu)="sideMenu.close()"></app-sidenav-menu>
-            <mat-list-item *ngIf="mobileQuery.matches">
-                View:
+
+            <mat-divider></mat-divider>
+
+            <div class="sidenavSubMenu" *ngIf="mobileQuery.matches">
                 <ng-container *ngTemplateOutlet="viewModeButtons"></ng-container>
-            </mat-list-item>
+            </div>
+
             <mat-list-item>
                 <button id="addEventButton" mat-button (click)="addEvent()">
                     <mat-icon>add</mat-icon> Add event
@@ -181,10 +193,10 @@
             <div *ngIf="!mobileQuery.matches; else mobileHeader">
                 <ng-container *ngTemplateOutlet="previousPeriodButton">
                 </ng-container>
-                <button mat-raised-button
+                <button mat-raised-button mwlCalendarToday
+                    *ngIf="view !== RunboxCalendarView.Overview"
                     id="todayButton"
                     class="calendarToolbarButton"
-                    mwlCalendarToday
                     [(viewDate)]="viewDate"
                 >
                     Today
@@ -213,8 +225,15 @@
         </mat-toolbar>
 
         <div [ngSwitch]="view">
+          <app-calendar-overview
+            *ngSwitchCase="RunboxCalendarView.Overview"
+            [events]="shown_events"
+            [refresh]="refresh"
+            (editEvent)="openEvent($event)"
+          >
+          </app-calendar-overview>
           <mwl-calendar-month-view
-            *ngSwitchCase="CalendarView.Month"
+            *ngSwitchCase="RunboxCalendarView.Month"
             [cellTemplate]="mobileQuery.matches ? undefined : dayViewTemplate"
             [viewDate]="viewDate"
             [events]="shown_events"
@@ -228,7 +247,7 @@
           >
           </mwl-calendar-month-view>
           <mwl-calendar-week-view
-            *ngSwitchCase="CalendarView.Week"
+            *ngSwitchCase="RunboxCalendarView.Week"
             [viewDate]="viewDate"
             [events]="shown_events"
             [refresh]="refresh"
@@ -239,7 +258,7 @@
           >
           </mwl-calendar-week-view>
           <mwl-calendar-day-view
-            *ngSwitchCase="CalendarView.Day"
+            *ngSwitchCase="RunboxCalendarView.Day"
             [viewDate]="viewDate"
             [events]="shown_events"
             [refresh]="refresh"

--- a/src/app/calendar-app/calendar-app.module.ts
+++ b/src/app/calendar-app/calendar-app.module.ts
@@ -30,6 +30,7 @@ import { adapterFactory } from 'angular-calendar/date-adapters/date-fns';
 import { CalendarService } from './calendar.service';
 import { CalendarAppComponent } from './calendar-app.component';
 import { CalendarEditorDialogComponent } from './calendar-editor-dialog.component';
+import { CalendarOverviewComponent } from './calendar-overview.component';
 import { CalendarSettingsDialogComponent } from './calendar-settings-dialog.component';
 import { ColorSelectorDialogComponent } from './color-selector-dialog.component';
 import { DeleteConfirmationDialogComponent } from './delete-confirmation-dialog.component';
@@ -39,6 +40,7 @@ import { OwlDateTimeModule, OwlNativeDateTimeModule } from 'ng-pick-datetime';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MatDialogModule } from '@angular/material/dialog';
@@ -55,6 +57,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 @NgModule({
   declarations: [
     CalendarAppComponent,
+    CalendarOverviewComponent,
     CalendarEditorDialogComponent,
     CalendarSettingsDialogComponent,
     ColorSelectorDialogComponent,
@@ -68,8 +71,9 @@ import { MatTooltipModule } from '@angular/material/tooltip';
     FormsModule,
     MenuModule,
     MatButtonModule,
-    MatDatepickerModule,
+    MatCardModule,
     MatCheckboxModule,
+    MatDatepickerModule,
     MatDialogModule,
     MatFormFieldModule,
     MatIconModule,

--- a/src/app/calendar-app/calendar-overview.component.html
+++ b/src/app/calendar-app/calendar-overview.component.html
@@ -1,0 +1,51 @@
+<div style="padding-left: 25px; padding-right: 25px;">
+    <h2> Upcoming events </h2>
+
+    <mat-card class="upcomingEventCard"
+        *ngFor="let e of visible_events.slice(0, event_limit)"
+    >
+        <mat-card-header>
+            <mat-card-title>
+                {{ e.title }}
+                <span *ngIf="e.ongoing" style="font-weight: bold;">
+                    ONGOING
+                </span>
+            </mat-card-title>
+            <mat-card-subtitle>
+                <span *ngIf="!e.ongoing; else started"> Starts </span>
+                <ng-template #started> Started </ng-template>
+                {{ e.dtstart.calendar() }}
+            </mat-card-subtitle>
+            <mat-card-subtitle *ngIf="e.dtend">
+                Ends {{ e.dtend.calendar() }}
+            </mat-card-subtitle>
+            <mat-card-subtitle *ngIf="e.recurringFrequency">
+                {{ e.recurringFrequency }} event
+            </mat-card-subtitle>
+            <mat-card-subtitle *ngIf="e.location">
+                Location: {{ e.location }}
+            </mat-card-subtitle>
+        </mat-card-header>
+        <mat-card-content>
+            <p>
+                {{ e.description }}
+            </p>
+        </mat-card-content>
+        <mat-card-actions>
+            <button mat-button (click)="editEvent.emit(e.event)"> Edit </button>
+        </mat-card-actions>
+    </mat-card>
+
+    <div *ngIf="visible_events.length - event_limit; let remaining">
+        <mat-card *ngIf="remaining > 0" class="upcomingEventCard">
+            <mat-card-header>
+                <mat-card-subtitle>
+                    ... and {{ remaining }} more event{{ (remaining > 1) ? 's' : '' }}
+                </mat-card-subtitle>
+            </mat-card-header>
+            <mat-card-actions>
+                <button mat-button (click)="showMore()"> Show more </button>
+            </mat-card-actions>
+        </mat-card>
+    </div>
+</div>

--- a/src/app/calendar-app/calendar-overview.component.ts
+++ b/src/app/calendar-app/calendar-overview.component.ts
@@ -1,0 +1,96 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2019 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { Component, EventEmitter, Input, OnChanges, OnInit, Output } from '@angular/core';
+import { Subject } from 'rxjs';
+import { RunboxCalendarEvent } from './runbox-calendar-event';
+import * as moment from 'moment';
+
+class EventOverview {
+    ongoing: boolean;
+
+    constructor(public event: RunboxCalendarEvent) { }
+
+    get title(): string {
+        return this.event.title;
+    }
+
+    get dtstart(): moment.Moment {
+        return this.event.dtstart;
+    }
+
+    get dtend(): moment.Moment {
+        return this.event.dtend;
+    }
+
+    get recurringFrequency(): string {
+        // titlecase
+        const freq = this.event.recurringFrequency;
+        return freq.charAt(0).toUpperCase() + freq.slice(1).toLowerCase();
+    }
+
+    get location(): string {
+        return this.event.location;
+    }
+
+    get description(): string {
+        return this.event.description;
+    }
+}
+
+@Component({
+    selector: 'app-calendar-overview',
+    templateUrl: './calendar-overview.component.html',
+})
+export class CalendarOverviewComponent implements OnChanges, OnInit {
+    @Input() events: RunboxCalendarEvent[];
+    @Input() refresh: Subject<any>;
+
+    @Output() editEvent: EventEmitter<RunboxCalendarEvent> = new EventEmitter();
+
+    visible_events: EventOverview[] = [];
+    event_limit = 5;
+
+    ngOnChanges() {
+        this.showUpcoming();
+    }
+
+    ngOnInit() {
+        this.refresh.subscribe(_ => this.ngOnChanges());
+    }
+
+    showMore() {
+        this.event_limit += 5;
+    }
+
+    showUpcoming() {
+        const now = moment();
+        this.visible_events = this.events.filter(e => {
+            return e.dtstart.isAfter(now) || (e.dtend && e.dtend.isAfter(now));
+        }).map(e => {
+            const ev = new EventOverview(e);
+            if (e.dtstart.isBefore(now)) {
+                ev.ongoing = true;
+            }
+            return ev;
+        }).sort((a, b) => {
+            return a.dtstart.isBefore(b.dtstart) ? -1 : 1;
+        });
+    }
+}

--- a/src/app/calendar-app/runbox-calendar-view.ts
+++ b/src/app/calendar-app/runbox-calendar-view.ts
@@ -17,18 +17,9 @@
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
 
-import { RunboxCalendarView } from './runbox-calendar-view';
-
-export class CalendarSettings {
-    weekStartsOnSunday = false;
-    lastUsedView: RunboxCalendarView = RunboxCalendarView.Month;
-
-    constructor(props: any) {
-        if ('weekStartsOnSunday' in props) {
-            this.weekStartsOnSunday = props['weekStartsOnSunday'];
-        }
-        if ('lastUsedView' in props) {
-            this.lastUsedView = props['lastUsedView'];
-        }
-    }
+export enum RunboxCalendarView {
+    Overview,
+    Month,
+    Week,
+    Day,
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -927,6 +927,10 @@ app-calendar-event-editor-dialog p {
     width: 50px;
 }
 
+.upcomingEventCard {
+    margin: 10px;
+}
+
 /* Payment */
 
 .productCardSpecial .mat-card, .productCardSpecial mat-card {


### PR DESCRIPTION
This implements a basic (for now) calendar overview screen. I based it on tadzik/jcal to make sure it's using all the latest and greatest and to reduce the possibility of conflicts.

Currently looks somewhat like this:
![2019-10-30-144214_1016x790_scrot](https://user-images.githubusercontent.com/86378/67863063-7e208b80-fb23-11e9-8d71-bd8edf4d52d9.png)

Suggestions welcome :)
