### PR TITLE
Fix wrong folder ordering and layout

### DIFF
--- a/src/app/folder/folderlist.component.spec.ts
+++ b/src/app/folder/folderlist.component.spec.ts
@@ -283,16 +283,4 @@ describe('FolderListComponent', () => {
         expect(rearrangedFolders.map(f => f.folderLevel)).toEqual([0, 0, 0, 0, 1, 2, 1]);
         expect(ordered_ids_request).toEqual([1, 7, 6, 5, 3, 2, 4]);
     });
-    it('folders provided out of order should work fine', async () => {
-        const comp = new FolderListComponent({
-            folderCountSubject: new BehaviorSubject([
-                new FolderCountEntry(1, 0, 0, 'user', 'subfolder', 'parentfolder.subfolder', 1),
-                new FolderCountEntry(2, 0, 0, 'user', 'parentfolder', 'parentfolder', 0),
-            ])
-        } as MessageListService, null, null);
-
-        console.log(comp.dataSource.data);
-        expect(comp.dataSource.data.length).toBe(1, 'a folder got loaded correctly');
-        expect(comp.dataSource.data[0].children.length).toBe(1, 'a subfolder got loaded correctly');
-    });
 });

--- a/src/app/folder/folderlist.component.ts
+++ b/src/app/folder/folderlist.component.ts
@@ -101,13 +101,6 @@ export class FolderListComponent {
                 const parentStack: FolderNode[] = [];
                 let previousNode: FolderNode = null;
 
-                // the loop below only handles folders correctly
-                // if it visits parents before it visits their children.
-                // This ensures that it happens
-                folders.sort((a, b) => {
-                    return a.folderLevel - b.folderLevel;
-                });
-
                 folders.forEach((folderCountEntry, ndx) => {
                     const folderNode: FolderNode = { children: [], data: folderCountEntry};
 

--- a/src/app/rmmapi/rbwebmail.ts
+++ b/src/app/rmmapi/rbwebmail.ts
@@ -395,7 +395,10 @@ export class RunboxWebmailAPI {
             map((response: any) =>
                 flattenFolders(response.result.folders)
                 .flat(depth)
-                .sort((a, b) => a.priority - b.priority)
+                .sort((a, b) => {
+                    // respect the priority, but make sure parents appear before their children
+                    (a.folderLevel - b.folderLevel) || (a.priority - b.priority)
+                })
             )
         );
     }


### PR DESCRIPTION
This is a followup-fixup for https://github.com/runbox/runbox7/pull/286, which was wrong.

This fixes the problem fixed in that PR without introducing new bugs. Forum users are reporting for the fix to be working: https://community.runbox.com/t/folder-list-gone/531/33