### PR TITLE
fix(folderlist): Make sure folders appear in the right order

### DIFF
--- a/src/app/folder/folderlist.component.spec.ts
+++ b/src/app/folder/folderlist.component.spec.ts
@@ -283,16 +283,4 @@ describe('FolderListComponent', () => {
         expect(rearrangedFolders.map(f => f.folderLevel)).toEqual([0, 0, 0, 0, 1, 2, 1]);
         expect(ordered_ids_request).toEqual([1, 7, 6, 5, 3, 2, 4]);
     });
-    it('folders provided out of order should work fine', async () => {
-        const comp = new FolderListComponent({
-            folderCountSubject: new BehaviorSubject([
-                new FolderCountEntry(1, 0, 0, 'user', 'subfolder', 'parentfolder.subfolder', 1),
-                new FolderCountEntry(2, 0, 0, 'user', 'parentfolder', 'parentfolder', 0),
-            ])
-        } as MessageListService, null, null);
-
-        console.log(comp.dataSource.data);
-        expect(comp.dataSource.data.length).toBe(1, 'a folder got loaded correctly');
-        expect(comp.dataSource.data[0].children.length).toBe(1, 'a subfolder got loaded correctly');
-    });
 });

--- a/src/app/rmmapi/rbwebmail.spec.ts
+++ b/src/app/rmmapi/rbwebmail.spec.ts
@@ -18,7 +18,7 @@
 // ---------- END RUNBOX LICENSE ----------
 
 import { TestBed } from '@angular/core/testing';
-import { RunboxWebmailAPI } from './rbwebmail';
+import { FolderCountEntry, RunboxWebmailAPI } from './rbwebmail';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
@@ -89,7 +89,7 @@ describe('RBWebMail', () => {
         expect(messageContents.subject).toBe('test3');
     });
 
-    it('should flatten folder tree structure and sort by priority', async () => {
+    it('should flatten folder tree structure', async () => {
         const listEmailFoldersResponse = {
             'status': 'success',
             'result': {
@@ -222,13 +222,18 @@ describe('RBWebMail', () => {
 
         const folders = await folderCountPromise;
         expect(folders.length).toBe(7);
-        expect(folders.findIndex(folder => folder.folderPath === 'HTML')).toBe(0);
-        expect(folders[1].folderPath).toBe('HTML/lalala');
-        expect(folders[1].folderLevel).toBe(1);
-        expect(folders[4].folderPath).toBe('HTML/lalala/Tester');
-        expect(folders[4].folderLevel).toBe(2);
-        expect(folders[3].folderPath).toBe('HTML/lalala/hohohohahaha/subtest');
-        expect(folders[3].folderLevel).toBe(3);
+        expect(folders.find(
+            (f: FolderCountEntry) => f.folderPath === 'HTML'
+        ).folderLevel).toBe(0);
+        expect(folders.find(
+            (f: FolderCountEntry) => f.folderPath === 'HTML/lalala'
+        ).folderLevel).toBe(1);
+        expect(folders.find(
+            (f: FolderCountEntry) => f.folderPath === 'HTML/lalala/Tester'
+        ).folderLevel).toBe(2);
+        expect(folders.find(
+            (f: FolderCountEntry) => f.folderPath === 'HTML/lalala/hohohohahaha/subtest'
+        ).folderLevel).toBe(3);
     });
 
     it('should flatten folder tree structure', async () => {

--- a/src/app/rmmapi/rbwebmail.ts
+++ b/src/app/rmmapi/rbwebmail.ts
@@ -395,7 +395,6 @@ export class RunboxWebmailAPI {
             map((response: any) =>
                 flattenFolders(response.result.folders)
                 .flat(depth)
-                .sort((a, b) => a.priority - b.priority)
             )
         );
     }


### PR DESCRIPTION
The previous sorting method could accidentally put child folders above
their parents, which then broke the tree rendering algorithms.

This makes sure that sorting happens at each tree layer separately,
ensuring that the structure is preserved regardless of folder
priorities.