### PR TITLE
Make calendar (more) mobile friendly

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -31,7 +31,7 @@ module.exports = function (config) {
     customLaunchers: {
       ChromeHeadlessCI: {
         base: 'ChromeHeadless',
-        flags: ['--no-sandbox', '--disable-gpu']
+        flags: ['--no-sandbox', '--disable-gpu', '--window-size=1920,1080']
       }
     },
     singleRun: false

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -15,13 +15,11 @@
 
       <mat-divider></mat-divider>
 
-      <div class="sidenavMainMenu">
+      <div class="sidenavSubMenu">
         <a mat-button (click)="compose();" matTooltip="Compose">
           <mat-icon color="primary">edit</mat-icon></a>
         <a mat-button (click)="drafts();" matTooltip="Drafts">
           <mat-icon color="primary">drafts</mat-icon></a>
-        <a mat-button (click)="logoutservice.logout()" matTooltip="Log out">
-          <mat-icon>power_settings_new</mat-icon></a>
       </div>
 
       <mat-list-item (click)="compose();" id="composeButton">

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -6,16 +6,7 @@
       style="width: 330px"
       appResizable>
     <mat-nav-list dense>      
-      <div class="sidenavMainMenu">
-        <div id="sidenavLogoContainer">
-          <a mat-button routerLink="/" 
-             id="sidenavLogoButton"
-	     (click)="this.sidemenu.close();">
-            <img src="assets/runbox7.png" id="logoSidenav" alt="Runbox 7" />
-          </a>
-          <br />
-        </div>
-      </div>
+      <app-sidenav-menu (closeMenu)="sidemenu.close()"></app-sidenav-menu>
 
       <div id="sidenavGreeting">
         <p>Good {{timeOfDay}}, {{(rmmapi.me | async)?.user_address}}.</p>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -47,13 +47,12 @@ import { ConfirmDialog } from './dialog/confirmdialog.component';
 import { WebSocketSearchService } from './websocketsearch/websocketsearch.service';
 import { WebSocketSearchMailRow } from './websocketsearch/websocketsearchmailrow.class';
 
-import { MediaMatcher } from '@angular/cdk/layout';
-
 import { BUILD_TIMESTAMP } from './buildtimestamp';
 import { from, of } from 'rxjs';
 import { xapianLoadedSubject } from './xapian/xapianwebloader';
 import { SwPush } from '@angular/service-worker';
 import { exportKeysFromJWK } from './webpush/vapid.tools';
+import { MobileQueryService } from './mobile-query.service';
 import { ProgressService } from './http/progress.service';
 import { environment } from '../environments/environment';
 import { LogoutService } from './login/logout.service';
@@ -128,7 +127,6 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
   xapianDocCount: number;
   searchResultsCount: number;
 
-  mobileQuery: MediaQueryList;
   private mobileQueryListener: () => void;
 
   xapianLoaded = xapianLoadedSubject;
@@ -149,7 +147,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     private draftDeskService: DraftDeskService,
     public messagelistservice: MessageListService,
     changeDetectorRef: ChangeDetectorRef,
-    media: MediaMatcher,
+    public mobileQuery: MobileQueryService,
     private swPush: SwPush) {
     const savedColumnWidthsString = localStorage.getItem('rmmCanvasTableColumnWidths');
     if (savedColumnWidthsString) {
@@ -202,8 +200,6 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
 
     // Mobile media query for screen width
 
-    this.mobileQuery = media.matchMedia('(max-width: 1023px)');
-
     this.mobileQueryListener = () => {
       // Open sidenav if screen is wide enough and it was closed
       changeDetectorRef.detectChanges();
@@ -225,15 +221,11 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
       }
     };
 
-    // the non-deprecated addEventListener doesn't work on Safari, so...
-    // tslint:disable-next-line:deprecation
     this.mobileQuery.addListener(this.mobileQueryListener);
     this.updateTime();
   }
 
   ngOnDestroy() {
-    // the non-deprecated removeEventListener doesn't work on Safari, so...
-    // tslint:disable-next-line:deprecation
     this.mobileQuery.removeListener(this.mobileQueryListener);
   }
   ngDoCheck(): void {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -59,6 +59,7 @@ import { AccountAppModule } from './account-app/account-app.module';
 import { AccountAppComponent } from './account-app/account-app.component';
 import { ProgressService } from './http/progress.service';
 import { MessageListService } from './rmmapi/messagelist.service';
+import { MobileQueryService } from './mobile-query.service';
 import { DialogModule } from './dialog/dialog.module';
 import { FolderModule } from './folder/folder.module';
 import { RMMAuthGuardService } from './rmmapi/rmmauthguard.service';
@@ -153,6 +154,7 @@ const routes: Routes = [
     ],
   providers: [ProgressService,
     MessageListService,
+    MobileQueryService,
     RunboxWebmailAPI,
     RMMAuthGuardService,
     StorageService,

--- a/src/app/calendar-app/calendar-app.component.html
+++ b/src/app/calendar-app/calendar-app.component.html
@@ -49,6 +49,47 @@
     </button>
 </ng-template>
 
+<ng-template #previousPeriodButton>
+    <button mat-raised-button mwlCalendarPreviousView
+        id="previousPeriodButton"
+        class="calendarToolbarButton"
+        [view]="view"
+        [(viewDate)]="viewDate"
+        (viewDateChange)="activeDayIsOpen = false"
+    >
+        <mat-icon *ngIf="mobileQuery.matches; else desktopPrevious">
+            navigate_before
+        </mat-icon>
+        <ng-template #desktopPrevious>
+            Previous
+        </ng-template>
+    </button>
+</ng-template>
+
+<ng-template #nextPeriodButton>
+    <button mat-raised-button
+        id="nextPeriodButton"
+        class="calendarToolbarButton"
+        mwlCalendarNextView
+        [view]="view"
+        [(viewDate)]="viewDate"
+        (viewDateChange)="activeDayIsOpen = false"
+    >
+        <mat-icon *ngIf="mobileQuery.matches; else desktopNext">
+            navigate_next
+        </mat-icon>
+        <ng-template #desktopNext>
+            Next
+        </ng-template>
+    </button>
+</ng-template>
+
+<ng-template #calendarTitle>
+    <span class="calendarTitle" *ngIf="view">
+        {{ viewDate | calendarDate:(view + 'ViewTitle'):'en' }}
+    </span>
+</ng-template>
+
 <mat-sidenav-container autosize>
     <mat-sidenav #sidemenu
         [opened]="sideMenuOpened"
@@ -132,21 +173,14 @@
         </mat-nav-list>
     </mat-sidenav>
     <mat-sidenav-content>
-        <mat-toolbar style="display: flex; justify-content: space-between;">
+        <mat-toolbar>
             <button mat-icon-button (click)="sidemenu.toggle()">
                 <mat-icon>menu</mat-icon>
             </button>
 
-            <div>
-                <button mat-raised-button mwlCalendarPreviousView
-                    id="previousPeriodButton"
-                    class="calendarToolbarButton"
-                    [view]="view"
-                    [(viewDate)]="viewDate"
-                    (viewDateChange)="activeDayIsOpen = false"
-                >
-                    Previous
-                </button>
+            <div *ngIf="!mobileQuery.matches; else mobileHeader">
+                <ng-container *ngTemplateOutlet="previousPeriodButton">
+                </ng-container>
                 <button mat-raised-button
                     id="todayButton"
                     class="calendarToolbarButton"
@@ -155,25 +189,27 @@
                 >
                     Today
                 </button>
-                <button mat-raised-button
-                    id="nextPeriodButton"
-                    class="calendarToolbarButton"
-                    mwlCalendarNextView
-                    [view]="view"
-                    [(viewDate)]="viewDate"
-                    (viewDateChange)="activeDayIsOpen = false"
-                >
-                    Next
-                </button>
-            </div>
+                <ng-container *ngTemplateOutlet="nextPeriodButton">
+                </ng-container>
 
-            <span class="calendarTitle" *ngIf="view">
-                {{ viewDate | calendarDate:(view + 'ViewTitle'):'en' }}
-            </span>
+                <ng-container *ngTemplateOutlet="calendarTitle">
+                </ng-container>
 
-            <div *ngIf="!mobileQuery.matches">
                 <ng-container *ngTemplateOutlet="viewModeButtons"></ng-container>
             </div>
+
+            <ng-template #mobileHeader>
+                <div style="display: flex; justify-content: center; align-items: center; width: 100%;">
+                    <ng-container *ngTemplateOutlet="previousPeriodButton">
+                    </ng-container>
+
+                    <ng-container *ngTemplateOutlet="calendarTitle">
+                    </ng-container>
+
+                    <ng-container *ngTemplateOutlet="nextPeriodButton">
+                    </ng-container>
+                </div>
+            </ng-template>
         </mat-toolbar>
 
         <div [ngSwitch]="view">

--- a/src/app/calendar-app/calendar-app.component.html
+++ b/src/app/calendar-app/calendar-app.component.html
@@ -4,7 +4,7 @@
             <span class="cal-day-number">
                 {{ day.date | calendarDate:'monthViewDayNumber':locale }}
             </span>
-            <div *ngIf="!mobileQuery.matches" style="display: flex; flex-direction: column;">
+            <div style="display: flex; flex-direction: column;">
                 <div class="add-new-event">
                     <button mat-icon-button color="primary" (click)="addEvent(day.date); $event.stopPropagation()"> <mat-icon style="transform: scale(1.5);"> add_circle </mat-icon> </button>
                 </div>
@@ -20,11 +20,6 @@
                 <button mat-button *ngIf="day.events.length > 4" class="calendarMonthDayEvent">
                     ...and {{ day.events.length - 3 }} other events
                 </button>
-            </div>
-        </div>
-        <div *ngIf="mobileQuery.matches">
-            <div *ngIf="day.events.length" style="font-weight: bold; text-align: center;">
-                {{ day.events.length }} event<span *ngIf="day.events.length > 1">s</span>
             </div>
         </div>
     </div>
@@ -184,7 +179,7 @@
         <div [ngSwitch]="view">
           <mwl-calendar-month-view
             *ngSwitchCase="CalendarView.Month"
-            [cellTemplate]="dayViewTemplate"
+            [cellTemplate]="mobileQuery.matches ? undefined : dayViewTemplate"
             [viewDate]="viewDate"
             [events]="shown_events"
             [refresh]="refresh"

--- a/src/app/calendar-app/calendar-app.component.html
+++ b/src/app/calendar-app/calendar-app.component.html
@@ -1,11 +1,74 @@
+<ng-template #dayViewTemplate let-day="day" let-locale="locale">
+    <div class="calendarMonthDayView">
+        <div class="cal-cell-top">
+            <span class="cal-day-number">
+                {{ day.date | calendarDate:'monthViewDayNumber':locale }}
+            </span>
+            <div *ngIf="!mobileQuery.matches" style="display: flex; flex-direction: column;">
+                <div class="add-new-event">
+                    <button mat-icon-button color="primary" (click)="addEvent(day.date); $event.stopPropagation()"> <mat-icon style="transform: scale(1.5);"> add_circle </mat-icon> </button>
+                </div>
+                <button mat-button class="calendarMonthDayEvent"
+                    *ngFor="let event of (day.events.length > 4 ? day.events.slice(0, 3) : day.events)"
+                    (click)="openEvent(event); $event.stopPropagation()"
+                >
+                    <strong *ngIf="!event.allDay && event.start.getDay() == day.date.getDay()">
+                        {{ event.start.getHours() }}:{{ ('0' + event.start.getMinutes()).slice(-2) }}
+                    </strong>
+                    {{ event.title }}
+                </button>
+                <button mat-button *ngIf="day.events.length > 4" class="calendarMonthDayEvent">
+                    ...and {{ day.events.length - 3 }} other events
+                </button>
+            </div>
+        </div>
+        <div *ngIf="mobileQuery.matches">
+            <div *ngIf="day.events.length" style="font-weight: bold; text-align: center;">
+                {{ day.events.length }} event<span *ngIf="day.events.length > 1">s</span>
+            </div>
+        </div>
+    </div>
+</ng-template>
+
+<ng-template #viewModeButtons>
+    <button mat-raised-button
+        class="calendarToolbarButton"
+        (click)="view = CalendarView.Month"
+        [color]="view === CalendarView.Month ? 'primary' : ''"
+    >
+        Month
+    </button>
+    <button mat-raised-button
+        class="calendarToolbarButton"
+        (click)="view = CalendarView.Week"
+        [color]="view === CalendarView.Week ? 'primary' : ''"
+    >
+        Week
+    </button>
+    <button mat-raised-button
+        class="calendarToolbarButton"
+        (click)="view = CalendarView.Day"
+        [color]="view === CalendarView.Day ? 'primary' : ''"
+    >
+        Day
+    </button>
+</ng-template>
+
 <mat-sidenav-container autosize>
-    <style>
-        button {
-            margin: 0.5em;
-        }
-    </style>
-    <mat-sidenav #sidemenu mode="side" opened>
+    <mat-sidenav #sidemenu
+        [opened]="sideMenuOpened"
+        [mode]="mobileQuery.matches ? 'over' : 'side'"
+        [fixedInViewport]="mobileQuery.matches"
+        fixedTopGap="0"
+        id="sideMenu"
+        style="width: 330px"
+    >
         <mat-nav-list dense>
+            <app-sidenav-menu (closeMenu)="sideMenu.close()"></app-sidenav-menu>
+            <mat-list-item *ngIf="mobileQuery.matches">
+                View:
+                <ng-container *ngTemplateOutlet="viewModeButtons"></ng-container>
+            </mat-list-item>
             <mat-list-item>
                 <button id="addEventButton" mat-button (click)="addEvent()">
                     <mat-icon>add</mat-icon> Add event
@@ -74,85 +137,49 @@
         </mat-nav-list>
     </mat-sidenav>
     <mat-sidenav-content>
-        <mat-toolbar style="display: flex">
+        <mat-toolbar style="display: flex; justify-content: space-between;">
             <button mat-icon-button (click)="sidemenu.toggle()">
                 <mat-icon>menu</mat-icon>
             </button>
-            <button mat-raised-button mwlCalendarPreviousView
-                id="previousPeriodButton"
-                [view]="view"
-                [(viewDate)]="viewDate"
-                (viewDateChange)="activeDayIsOpen = false"
-            >
-                Previous
-            </button>
-            <button mat-raised-button
-                id="todayButton"
-                mwlCalendarToday
-                [(viewDate)]="viewDate"
-            >
-                Today
-            </button>
-            <button mat-raised-button
-                id="nextPeriodButton"
-                mwlCalendarNextView
-                [view]="view"
-                [(viewDate)]="viewDate"
-                (viewDateChange)="activeDayIsOpen = false"
-            >
-                Next
-            </button>
+
+            <div>
+                <button mat-raised-button mwlCalendarPreviousView
+                    id="previousPeriodButton"
+                    class="calendarToolbarButton"
+                    [view]="view"
+                    [(viewDate)]="viewDate"
+                    (viewDateChange)="activeDayIsOpen = false"
+                >
+                    Previous
+                </button>
+                <button mat-raised-button
+                    id="todayButton"
+                    class="calendarToolbarButton"
+                    mwlCalendarToday
+                    [(viewDate)]="viewDate"
+                >
+                    Today
+                </button>
+                <button mat-raised-button
+                    id="nextPeriodButton"
+                    class="calendarToolbarButton"
+                    mwlCalendarNextView
+                    [view]="view"
+                    [(viewDate)]="viewDate"
+                    (viewDateChange)="activeDayIsOpen = false"
+                >
+                    Next
+                </button>
+            </div>
 
             <span class="calendarTitle" *ngIf="view">
                 {{ viewDate | calendarDate:(view + 'ViewTitle'):'en' }}
             </span>
 
-            <button mat-raised-button
-                (click)="view = CalendarView.Month"
-                [color]="view === CalendarView.Month ? 'primary' : ''"
-            >
-                Month
-            </button>
-            <button mat-raised-button
-                (click)="view = CalendarView.Week"
-                [color]="view === CalendarView.Week ? 'primary' : ''"
-            >
-                Week
-            </button>
-            <button mat-raised-button
-                (click)="view = CalendarView.Day"
-                [color]="view === CalendarView.Day ? 'primary' : ''"
-            >
-                Day
-            </button>
-        </mat-toolbar>
-
-        <ng-template #dayViewTemplate let-day="day" let-locale="locale">
-            <div class="calendarMonthDayView">
-                <div class="cal-cell-top">
-                    <span class="cal-day-number">
-                        {{ day.date | calendarDate:'monthViewDayNumber':locale }}
-                    </span>
-                    <div style="display: flex; flex-direction: column;">
-                        <div class="add-new-event">
-                            <button mat-icon-button color="primary" (click)="addEvent(day.date); $event.stopPropagation()"> <mat-icon style="transform: scale(1.5);"> add_circle </mat-icon> </button>
-                        </div>
-                        <button mat-button class="calendarMonthDayEvent"
-                            *ngFor="let event of (day.events.length > 4 ? day.events.slice(0, 3) : day.events)"
-                            (click)="openEvent(event); $event.stopPropagation()"
-                        >
-                            <strong *ngIf="!event.allDay && event.start.getDay() == day.date.getDay()">
-                                {{ event.start.getHours() }}:{{ ('0' + event.start.getMinutes()).slice(-2) }}
-                            </strong>
-                            {{ event.title }}
-                        </button>
-                        <button mat-button *ngIf="day.events.length > 4" class="calendarMonthDayEvent">
-                            ...and {{ day.events.length - 3 }} other events
-                        </button>
-                    </div>
-                </div>
+            <div *ngIf="!mobileQuery.matches">
+                <ng-container *ngTemplateOutlet="viewModeButtons"></ng-container>
             </div>
-        </ng-template>
+        </mat-toolbar>
 
         <div [ngSwitch]="view">
           <mwl-calendar-month-view

--- a/src/app/calendar-app/calendar-app.component.spec.ts
+++ b/src/app/calendar-app/calendar-app.component.spec.ts
@@ -22,6 +22,7 @@ import { HttpClient } from '@angular/common/http';
 import { CalendarAppComponent } from './calendar-app.component';
 import { CalendarAppModule } from './calendar-app.module';
 import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
+import { LogoutService } from '../login/logout.service';
 import { MobileQueryService } from '../mobile-query.service';
 import { StorageService } from '../storage.service';
 import { RouterTestingModule } from '@angular/router/testing';
@@ -95,6 +96,8 @@ describe('CalendarAppComponent', () => {
                     { provide: HttpClient, useValue: {
                     } },
                     { provide: MatSnackBar, useValue: {
+                    } },
+                    { provide: LogoutService, useValue: {
                     } },
                 ],
             }).compileComponents();

--- a/src/app/calendar-app/calendar-app.component.spec.ts
+++ b/src/app/calendar-app/calendar-app.component.spec.ts
@@ -22,6 +22,7 @@ import { HttpClient } from '@angular/common/http';
 import { CalendarAppComponent } from './calendar-app.component';
 import { CalendarAppModule } from './calendar-app.module';
 import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
+import { MobileQueryService } from '../mobile-query.service';
 import { StorageService } from '../storage.service';
 import { RouterTestingModule } from '@angular/router/testing';
 import { of, Observable } from 'rxjs';
@@ -84,6 +85,7 @@ describe('CalendarAppComponent', () => {
                     RouterTestingModule.withRoutes([])
                   ],
                 providers: [
+                    MobileQueryService,
                     StorageService,
                     { provide: RunboxWebmailAPI, useValue: {
                         getCalendars:      (): Observable<RunboxCalendar[]> => of(mockData['calendars']),

--- a/src/app/calendar-app/calendar-app.component.ts
+++ b/src/app/calendar-app/calendar-app.component.ts
@@ -161,7 +161,9 @@ export class CalendarAppComponent implements OnDestroy {
     }
 
     addEvent(on?: Date): void {
-        const dialogRef = this.dialog.open(EventEditorDialogComponent, { data: { calendars: this.calendars, start: on } });
+        const dialogRef = this.dialog.open(EventEditorDialogComponent, {
+            data: { calendars: this.calendars, settings: this.settings, start: on } }
+        );
         dialogRef.afterClosed().subscribe(event => {
             console.log('Dialog result:', event);
             if (event) {
@@ -291,7 +293,7 @@ export class CalendarAppComponent implements OnDestroy {
             target = target.parent;
         }
         const dialogRef = this.dialog.open(EventEditorDialogComponent, {
-            data: { event: target.clone(), calendars: this.calendars }
+            data: { event: target.clone(), calendars: this.calendars, settings: this.settings }
         });
         dialogRef.afterClosed().subscribe(result => {
             if (result === 'DELETE') {
@@ -311,6 +313,7 @@ export class CalendarAppComponent implements OnDestroy {
             const desiredView = this.view;
             this.view = null;
             setTimeout(() => this.view = desiredView);
+            this.cdr.markForCheck();
         });
     }
 

--- a/src/app/calendar-app/calendar-app.component.ts
+++ b/src/app/calendar-app/calendar-app.component.ts
@@ -198,13 +198,11 @@ export class CalendarAppComponent implements OnDestroy {
     }
 
     dayClicked({ date, events }: { date: Date; events: CalendarEvent[] }): void {
-        if (isSameMonth(date, this.viewDate)) {
-            this.viewDate = date;
-            if ((isSameDay(this.viewDate, date) && this.activeDayIsOpen ) || events.length === 0) {
-                this.activeDayIsOpen = false;
-            } else {
-                this.activeDayIsOpen = true;
-            }
+        this.viewDate = date;
+        if ((isSameDay(this.viewDate, date) && this.activeDayIsOpen ) || events.length === 0) {
+            this.activeDayIsOpen = false;
+        } else {
+            this.activeDayIsOpen = true;
         }
     }
 

--- a/src/app/calendar-app/calendar-app.component.ts
+++ b/src/app/calendar-app/calendar-app.component.ts
@@ -30,6 +30,7 @@ import { ActivatedRoute } from '@angular/router';
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 
 import { MatDialog } from '@angular/material/dialog';
+import { MatSidenav } from '@angular/material/sidenav';
 import { MatSnackBar } from '@angular/material/snack-bar';
 
 import {
@@ -54,6 +55,7 @@ import { ViewPeriod } from 'calendar-utils';
 
 import { CalendarService } from './calendar.service';
 import { CalendarSettings } from './calendar-settings';
+import { MobileQueryService } from '../mobile-query.service';
 
 import { RunboxCalendar } from './runbox-calendar';
 import { RunboxCalendarEvent } from './runbox-calendar-event';
@@ -77,11 +79,13 @@ export class CalendarAppComponent implements OnDestroy {
     viewDate: Date = new Date();
     viewPeriod: ViewPeriod;
     activeDayIsOpen = false;
+    sideMenuOpened = true;
     settings = new CalendarSettings();
 
     refresh: Subject<any> = new Subject();
     viewRefreshInterval: any;
 
+    @ViewChild(MatSidenav,       { static: false }) sideMenu: MatSidenav;
     @ViewChild('icsUploadInput', { static: false }) icsUploadInput: any;
 
     activityList = [];
@@ -96,6 +100,7 @@ export class CalendarAppComponent implements OnDestroy {
         private cdr:      ChangeDetectorRef,
         private dialog:   MatDialog,
         private http:     HttpClient,
+        public  mobileQuery: MobileQueryService,
         private route:    ActivatedRoute,
         private snackBar: MatSnackBar,
     ) {
@@ -135,6 +140,12 @@ export class CalendarAppComponent implements OnDestroy {
         this.viewRefreshInterval = setInterval(() => {
             this.cdr.markForCheck();
         }, 60 * 1000);
+
+        this.sideMenuOpened = !mobileQuery.matches;
+        this.mobileQuery.changed.subscribe(mobile => {
+            this.sideMenuOpened = !mobile;
+            this.cdr.markForCheck()
+        });
 
         this.calendarservice.activitySubject.subscribe(activityset => {
             this.activityList = [];

--- a/src/app/calendar-app/calendar-app.component.ts
+++ b/src/app/calendar-app/calendar-app.component.ts
@@ -144,7 +144,7 @@ export class CalendarAppComponent implements OnDestroy {
         this.sideMenuOpened = !mobileQuery.matches;
         this.mobileQuery.changed.subscribe(mobile => {
             this.sideMenuOpened = !mobile;
-            this.cdr.markForCheck()
+            this.cdr.markForCheck();
         });
 
         this.calendarservice.activitySubject.subscribe(activityset => {

--- a/src/app/calendar-app/event-editor-dialog.component.html
+++ b/src/app/calendar-app/event-editor-dialog.component.html
@@ -34,6 +34,7 @@
         <owl-date-time
             #start_dt
             [pickerType]="event.allDay ? 'calendar' : 'both'"
+            [firstDayOfWeek]="settings.weekStartsOnSunday ? 0 : 1"
         ></owl-date-time>
     </p><p>
         <label class="calendarEventPeriodLabel">End: </label>
@@ -42,6 +43,7 @@
         <owl-date-time
             #end_dt
             [pickerType]="event.allDay ? 'calendar' : 'both'"
+            [firstDayOfWeek]="settings.weekStartsOnSunday ? 0 : 1"
         ></owl-date-time>
     </p><p>
         <mat-checkbox [(ngModel)]="event.allDay">All-day event</mat-checkbox>

--- a/src/app/calendar-app/event-editor-dialog.component.html
+++ b/src/app/calendar-app/event-editor-dialog.component.html
@@ -34,6 +34,7 @@
         <owl-date-time
             #start_dt
             [pickerType]="event.allDay ? 'calendar' : 'both'"
+            pickerMode="dialog"
             [firstDayOfWeek]="settings.weekStartsOnSunday ? 0 : 1"
         ></owl-date-time>
     </p><p>
@@ -43,6 +44,7 @@
         <owl-date-time
             #end_dt
             [pickerType]="event.allDay ? 'calendar' : 'both'"
+            pickerMode="dialog"
             [firstDayOfWeek]="settings.weekStartsOnSunday ? 0 : 1"
         ></owl-date-time>
     </p><p>

--- a/src/app/calendar-app/event-editor-dialog.component.ts
+++ b/src/app/calendar-app/event-editor-dialog.component.ts
@@ -21,6 +21,7 @@ import { Component, Inject } from '@angular/core';
 import { FormControl, Validators } from '@angular/forms';
 import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 
+import { CalendarSettings } from './calendar-settings';
 import { RunboxCalendar } from './runbox-calendar';
 import { RunboxCalendarEvent } from './runbox-calendar-event';
 import { DeleteConfirmationDialogComponent } from './delete-confirmation-dialog.component';
@@ -37,6 +38,7 @@ export class EventEditorDialogComponent {
     calendarFC = new FormControl('', Validators.required);
     event_start: Date;
     event_end: Date;
+    settings: CalendarSettings;
 
     recurring_frequency: string;
     recurrence_frequencies = [
@@ -76,6 +78,8 @@ export class EventEditorDialogComponent {
             this.event_start = moment(data['start']).hours(12).minutes(0).seconds(0).toDate();
             this.event_end   = moment(data['start']).hours(14).minutes(0).seconds(0).toDate();
         }
+
+        this.settings = data['settings'];
 
         this.recurring_frequency = this.event.recurringFrequency;
     }

--- a/src/app/mailviewer/singlemailviewer.component.spec.ts
+++ b/src/app/mailviewer/singlemailviewer.component.spec.ts
@@ -38,6 +38,7 @@ import { CommonModule } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
 import { RunboxWebmailAPI, MessageContents } from '../rmmapi/rbwebmail';
 import { ContactsService } from '../contacts-app/contacts.service';
+import { MobileQueryService } from '../mobile-query.service';
 import { ProgressService } from '../http/progress.service';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ContactCardComponent } from './contactcard.component';
@@ -73,6 +74,7 @@ describe('SingleMailViewerComponent', () => {
       ],
       declarations: [ContactCardComponent, SingleMailViewerComponent],
       providers: [
+        MobileQueryService,
         { provide: MessageListService, useValue: { spamFolderName: 'Spam' }},
         { provide: HttpClient, useValue: {} },
         { provide: RunboxWebmailAPI, useValue: {

--- a/src/app/mailviewer/singlemailviewer.component.ts
+++ b/src/app/mailviewer/singlemailviewer.component.ts
@@ -34,7 +34,7 @@ import { MatExpansionModule } from '@angular/material/expansion';
 import { MessageActions } from './messageactions';
 import { ProgressDialog } from '../dialog/progress.dialog';
 import { ProgressService } from '../http/progress.service';
-
+import { MobileQueryService } from '../mobile-query.service';
 
 import { SafeUrl } from '@angular/platform-browser';
 import { HorizResizerDirective } from '../directives/horizresizer.directive';
@@ -122,9 +122,6 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
   folder: string;
 
 
-  mobileQuery: MediaQueryList;
-  private mobileQueryListener: () => void;
-
   constructor(private _ngZone: NgZone,
     private domSanitizer: DomSanitizer,
     private http: HttpClient,
@@ -132,12 +129,9 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
     private rbwebmailapi: RunboxWebmailAPI,
     private progressService: ProgressService,
     public messagelistservice: MessageListService,
+    public mobileQuery: MobileQueryService,
     private router: Router,
-    media: MediaMatcher
   ) {
-    // Mobile media query for screen width
-
-    this.mobileQuery = media.matchMedia('(max-width: 1023px)');
   }
 
   public close(actionstring?: string) {

--- a/src/app/menu/menu.module.ts
+++ b/src/app/menu/menu.module.ts
@@ -24,8 +24,10 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { HeaderToolbarComponent} from './headertoolbar.component';
 import { RouterModule } from '@angular/router';
+
+import { HeaderToolbarComponent} from './headertoolbar.component';
+import { SidenavMenuComponent } from './sidenav-menu.component';
 
 @NgModule({
   imports: [
@@ -38,8 +40,14 @@ import { RouterModule } from '@angular/router';
       MatMenuModule,
       RouterModule
   ],
-  declarations: [HeaderToolbarComponent],
-  exports: [HeaderToolbarComponent]
+  declarations: [
+    HeaderToolbarComponent,
+    SidenavMenuComponent,
+  ],
+  exports: [
+    HeaderToolbarComponent,
+    SidenavMenuComponent,
+  ]
 })
 export class MenuModule {
 

--- a/src/app/menu/sidenav-menu.component.ts
+++ b/src/app/menu/sidenav-menu.component.ts
@@ -28,6 +28,15 @@ import { Component, EventEmitter, Output } from '@angular/core';
             <img src="assets/runbox7.png" id="logoSidenav" alt="Runbox 7" />
         </a>
         <br />
+        <div style="display: flex; justify-content: space-around;">
+            <button mat-mini-fab routerLink="/">
+                <mat-icon>email</mat-icon>
+            </button>
+            <button mat-mini-fab routerLink="/calendar">
+                <mat-icon>date_range</mat-icon>
+            </button>
+        </div>
+        <br />
     </div>
 </div>
     `,

--- a/src/app/menu/sidenav-menu.component.ts
+++ b/src/app/menu/sidenav-menu.component.ts
@@ -1,0 +1,37 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2019 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { Component, EventEmitter, Output } from '@angular/core';
+
+@Component({
+    selector: 'app-sidenav-menu',
+    template: `
+<div class="sidenavMainMenu">
+    <div id="sidenavLogoContainer">
+        <a mat-button id="sidenavLogoButton" (click)="closeMenu.emit()">
+            <img src="assets/runbox7.png" id="logoSidenav" alt="Runbox 7" />
+        </a>
+        <br />
+    </div>
+</div>
+    `,
+})
+export class SidenavMenuComponent {
+    @Output() closeMenu = new EventEmitter<void>();
+}

--- a/src/app/menu/sidenav-menu.component.ts
+++ b/src/app/menu/sidenav-menu.component.ts
@@ -18,6 +18,7 @@
 // ---------- END RUNBOX LICENSE ----------
 
 import { Component, EventEmitter, Output } from '@angular/core';
+import { LogoutService } from '../login/logout.service';
 
 @Component({
     selector: 'app-sidenav-menu',
@@ -35,6 +36,9 @@ import { Component, EventEmitter, Output } from '@angular/core';
             <button mat-mini-fab routerLink="/calendar">
                 <mat-icon>date_range</mat-icon>
             </button>
+            <button mat-mini-fab (click)="logoutservice.logout()">
+                <mat-icon>power_settings_new</mat-icon>
+            </button>
         </div>
         <br />
     </div>
@@ -43,4 +47,9 @@ import { Component, EventEmitter, Output } from '@angular/core';
 })
 export class SidenavMenuComponent {
     @Output() closeMenu = new EventEmitter<void>();
+
+    constructor(
+        public logoutservice: LogoutService,
+    ) {
+    }
 }

--- a/src/app/mobile-query.service.ts
+++ b/src/app/mobile-query.service.ts
@@ -36,6 +36,7 @@ export class MobileQueryService {
         private media: MediaMatcher,
     ) {
         this.mobileQuery = media.matchMedia('(max-width: 1023px)');
+        // tslint:disable-next-line:deprecation
         this.mobileQuery.addListener(() => this.changed.next(this.mobileQuery.matches));
     }
 

--- a/src/app/mobile-query.service.ts
+++ b/src/app/mobile-query.service.ts
@@ -1,0 +1,53 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2019 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { Injectable } from '@angular/core';
+import { MediaMatcher } from '@angular/cdk/layout';
+import { Subject } from 'rxjs';
+
+// just an injectable wrapper around a preconfigured MediaMatcher
+
+@Injectable()
+export class MobileQueryService {
+    public mobileQuery: MediaQueryList;
+    public changed = new Subject<boolean>();
+
+    get matches(): boolean {
+        return this.mobileQuery.matches;
+    }
+
+    constructor(
+        private media: MediaMatcher,
+    ) {
+        this.mobileQuery = media.matchMedia('(max-width: 1023px)');
+        this.mobileQuery.addListener(() => this.changed.next(this.mobileQuery.matches));
+    }
+
+    addListener(listener: () => void) {
+        // the non-deprecated addEventListener doesn't work on Safari, so...
+        // tslint:disable-next-line:deprecation
+        this.mobileQuery.addListener(listener);
+    }
+
+    removeListener(listener: () => void) {
+        // the non-deprecated removeEventListener doesn't work on Safari, so...
+        // tslint:disable-next-line:deprecation
+        this.mobileQuery.removeListener(listener);
+    }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -819,6 +819,10 @@ app-calendar-app-component mat-nav-list button {
     padding: 0 !important;
 }
 
+.calendarToolbarButton {
+    margin: 0.5em !important;
+}
+
 .calendarTitle {
     margin: 0 1em;
     font-size: 20px !important;
@@ -855,10 +859,6 @@ button.calendarMonthDayEvent {
     overflow: hidden;
     font-size: 12px !important;
     line-height: 1.2em;
-}
-
-app-calendar-app-component .mat-button .mat-button-wrapper>* {
-    vertical-align: top !important;
 }
 
 app-calendar-event-editor-dialog p {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -819,14 +819,22 @@ app-calendar-app-component mat-nav-list button {
     padding: 0 !important;
 }
 
-.calendarToolbarButton {
-    margin: 0.5em !important;
+@media(min-width: 1024px) {
+    .calendarToolbarButton {
+        margin: 0.5em !important;
+    }
 }
 
 .calendarTitle {
-    margin: 0 1em;
     font-size: 20px !important;
     font-weight: bold;
+    margin: 0 0.5em;
+}
+
+@media(min-width: 1024px) {
+    .calendarTitle {
+        margin: 0 1em;
+    }
 }
 
 div.calendarMonthDayView {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -430,12 +430,16 @@ mat-sidenav-container {
     }
     .sidenavMainMenu {
 	    display: inline;
-	    flex-grow: 1;
     }
 }
 
 .sidenavMainMenu a {
     width: 30%;
+}
+
+.sidenavSubMenu {
+    display: flex;
+    justify-content: space-evenly;
 }
 
 #sidenavLogoContainer {


### PR DESCRIPTION
This includes several refactors to the webmail to allow reusing its good ideas in other apps – this time it's gonna be the calendar :)

The sidemenu now behaves similarly to the one in the webmail: going over the content and becoming closable with the runbox logo. The month-day-view template was adjust to show less information: event details can still be read when clicking on individual days.

Notable missing bit is navigation between sub-apps in mobile view: this can now be done in app-sidenav-menu and thus shared between sub-apps.

Some screenshots:

![2019-11-01-175618_956x1053_scrot](https://user-images.githubusercontent.com/86378/68041467-ed87ae00-fcd0-11e9-8f80-cccec24c1f2f.png)

![2019-11-01-175336_956x1053_scrot](https://user-images.githubusercontent.com/86378/68041478-f37d8f00-fcd0-11e9-80f0-496c551a8147.png)
