### PR TITLE
fix(tests): Ensure that xapian is loaded in each testcase

### DIFF
--- a/src/app/xapian/searchservice.spec.ts
+++ b/src/app/xapian/searchservice.spec.ts
@@ -112,6 +112,8 @@ describe('SearchService', () => {
 
     it('should load searchservice, but no local index', async () => {
         const searchService = injector.get(SearchService);
+        await xapianLoadedSubject.toPromise();
+
         let req = httpMock.expectOne(`/rest/v1/me`);
         req.flush( { result: {
                 uid: 555


### PR DESCRIPTION
This (hopefully) fixes the dreaded "FS is not defined" flapping test.