### PR TITLE
fix(account-app): Use ngOnInit consistently when loading async resources

### DIFF
--- a/src/app/account-app/account-addons.component.html
+++ b/src/app/account-app/account-addons.component.html
@@ -11,13 +11,20 @@
 }
 </style>
 
+<ng-template #addonsLoading>
+    <app-runbox-loading
+        text="Loading available addons..."
+    >
+    </app-runbox-loading>
+</ng-template>
+
 <h1> Add-ons </h1>
 
 <h2> Main account add-ons </h2>
 
 <p> Add-ons are individual upgrades that can be added to your main account. </p>
 
-<div class="productGrid">
+<div class="productGrid" *ngIf="emailaddons | async as emailaddons; else addonsLoading">
     <app-account-product
         *ngFor="let p of emailaddons"
         class="productCard"
@@ -35,7 +42,7 @@
     To add sub-accounts that are tied to your main subscription, please select one or more sub-account products below.
 </p>
 
-<div class="productGrid">
+<div class="productGrid" *ngIf="subaccounts | async as subaccounts; else addonsLoading">
     <app-account-product
         *ngFor="let p of subaccounts"
         class="productCard"

--- a/src/app/account-app/account-addons.component.ts
+++ b/src/app/account-app/account-addons.component.ts
@@ -17,31 +17,36 @@
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
 
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 
 import { RunboxMe, RunboxWebmailAPI } from '../rmmapi/rbwebmail';
 import { PaymentsService } from './payments.service';
 import { Product } from './product';
+import { AsyncSubject } from 'rxjs';
 
 @Component({
     selector: 'app-account-addons-component',
     templateUrl: './account-addons.component.html',
 })
-export class AccountAddonsComponent {
+export class AccountAddonsComponent implements OnInit {
     me: RunboxMe = new RunboxMe();
 
-    subaccounts:   Product[];
-    emailaddons:   Product[];
-    hostingaddons: Product[];
+    subaccounts    = new AsyncSubject<Product[]>();
+    emailaddons    = new AsyncSubject<Product[]>();
 
     constructor(
         private paymentsservice: PaymentsService,
         private rmmapi:          RunboxWebmailAPI,
     ) {
+    }
+
+    ngOnInit() {
         this.paymentsservice.products.subscribe(products => {
-            this.subaccounts   = products.filter(p => p.subtype === 'subaccount');
-            this.emailaddons   = products.filter(p => p.subtype === 'emailaddon');
-            this.hostingaddons = products.filter(p => p.subtype === 'hosting');
+            this.subaccounts.next(products.filter(p => p.subtype === 'subaccount'));
+            this.emailaddons.next(products.filter(p => p.subtype === 'emailaddon'));
+
+            this.subaccounts.complete();
+            this.emailaddons.complete();
         });
 
         this.rmmapi.me.subscribe(me => this.me = me);

--- a/src/app/account-app/account-receipt.component.ts
+++ b/src/app/account-app/account-receipt.component.ts
@@ -17,7 +17,7 @@
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
 
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { RunboxMe, RunboxWebmailAPI } from '../rmmapi/rbwebmail';
 import { AsyncSubject } from 'rxjs';
@@ -27,7 +27,7 @@ import { take } from 'rxjs/operators';
     selector: 'app-account-receipt-component',
     templateUrl: './account-receipt.component.html',
 })
-export class AccountReceiptComponent {
+export class AccountReceiptComponent implements OnInit {
     receipt: any;
     me: RunboxMe;
     ready = new AsyncSubject<boolean>();
@@ -41,10 +41,9 @@ export class AccountReceiptComponent {
         private rmmapi: RunboxWebmailAPI,
         private route:  ActivatedRoute,
     ) {
-        this.loadReceiptData();
     }
 
-    async loadReceiptData() {
+    async ngOnInit() {
         this.me = await this.rmmapi.me.toPromise();
 
         const params = await this.route.params.pipe(take(1)).toPromise();

--- a/src/app/account-app/account-transactions.component.ts
+++ b/src/app/account-app/account-transactions.component.ts
@@ -17,7 +17,7 @@
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
 
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
 import { AsyncSubject } from 'rxjs';
 
@@ -27,7 +27,7 @@ import * as moment from 'moment';
     selector: 'app-account-transactions-component',
     templateUrl: './account-transactions.component.html',
 })
-export class AccountTransactionsComponent {
+export class AccountTransactionsComponent implements OnInit {
     transactions = new AsyncSubject<any[]>();
 
     methods = {
@@ -47,6 +47,9 @@ export class AccountTransactionsComponent {
     constructor(
         private rmmapi: RunboxWebmailAPI,
     ) {
+    }
+
+    ngOnInit() {
         this.rmmapi.getTransactions().subscribe(transactions => {
             const txns = transactions.map(t => {
                 t.time = moment(t.time, moment.ISO_8601);

--- a/src/app/account-app/account-upgrades.component.ts
+++ b/src/app/account-app/account-upgrades.component.ts
@@ -17,7 +17,7 @@
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
 
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 
 import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
 import { PaymentsService } from './payments.service';
@@ -28,13 +28,16 @@ import { AsyncSubject } from 'rxjs';
     selector: 'app-account-upgrades-component',
     templateUrl: './account-upgrades.component.html',
 })
-export class AccountUpgradesComponent {
+export class AccountUpgradesComponent implements OnInit {
     subscriptions = new AsyncSubject<Product[]>();
 
     constructor(
         private paymentsservice: PaymentsService,
         public rmmapi:           RunboxWebmailAPI,
     ) {
+    }
+
+    ngOnInit() {
         this.paymentsservice.products.subscribe(products => {
             this.subscriptions.next(products.filter(p => p.type === 'subscription'));
             this.subscriptions.complete();


### PR DESCRIPTION
Following the footsteps of c14aac7d, this ensures that data won't be
provided to the component before it's fully loaded: which could (and
sometimes did) result in the component code not noticing that it
arrived and showing the loading screen forever.

Also adds loading indicators to account-addons :)