### PR TITLE
refactor(authguard): Add a fast pass for previously logged in users

### DIFF
--- a/src/app/rmmapi/rmmauthguard.service.ts
+++ b/src/app/rmmapi/rmmauthguard.service.ts
@@ -21,12 +21,13 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { CanActivate, ActivatedRouteSnapshot, RouterStateSnapshot, Router, CanActivateChild } from '@angular/router';
 import { Observable, of } from 'rxjs';
-import { map, catchError, tap } from 'rxjs/operators';
+import { map, take, tap } from 'rxjs/operators';
 
 @Injectable()
 export class RMMAuthGuardService implements CanActivate, CanActivateChild {
 
     urlBeforeLogin = '';
+    wasLoggedIn = false;
 
     constructor(
         public http: HttpClient,
@@ -36,24 +37,45 @@ export class RMMAuthGuardService implements CanActivate, CanActivateChild {
     }
 
     isLoggedIn(): Observable<boolean> {
-        return this.http.get('/rest/v1/me')
-            .pipe(
-                map((res: any) => res && res.status === 'success'),
-            );
+        return this.http.get('/rest/v1/me').pipe(
+            map((res: any) => {
+                this.wasLoggedIn = res && res.status === 'success';
+                return this.wasLoggedIn;
+            }),
+        );
     }
 
     canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean | Observable<boolean> | Promise<boolean> {
         this.urlBeforeLogin = state.url;
 
-        return this.isLoggedIn()
-            .pipe(
-                tap((success) => {
+        // Asynchronously check in whether the user is logged in or not
+        const loginCheck = new Promise<boolean>((resolve, _reject) => {
+            this.isLoggedIn().pipe(take(1)).subscribe(
+                success => {
                     if (!success) {
                         this.redirectToLogin();
                     }
-                })
-        );
+                    resolve(success);
+                },
+                _error => {
+                    resolve(false);
+                }
+            );
+        });
 
+        // We don't want the success of the navigation to depend on the async check above every time,
+        // as that would add precious time to every route switch, causing noticable and annoying delays.
+        //
+        // So if we saw user being logged in before, we assume that they still are:
+        // the async login check will still continue in the background
+        // and kick the user out in case we were wrong.
+        if (this.wasLoggedIn) {
+            return true;
+        }
+
+        // If the user was not logged in last time we checked,
+        // then we actually block the navigation until we're sure.
+        return loginCheck;
     }
 
     canActivateChild(childRoute: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean | Observable<boolean> | Promise<boolean> {


### PR DESCRIPTION
We use to hold each navigation request until we're sure that the user is
still logged in -- effectively making the user wait until /rest/v1/me
responds, adding hundreds of miliseconds (at best!) to each route change,
and making the app appear sluggish on operations as trivial as viewing
the drafts or going to /compose.

This implements a "fast pass" for the auth checker. If we previously saw
the user being logged in, we assume they still are and immediately
direct them to where they want to be. Meanwhile, under the hood, we
check if they're actually logged in -- and if not, we kick them out to
login like we used to.

For users not previously logged in, the navigation will block like it
used to. If it does not, the redirect from login to / would result in a
dysfunctional webmail, as nothing in the system would know who's coming.