### PR TITLE
style(webmail): Hide nav submenu in mobile view

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -15,7 +15,7 @@
 
       <mat-divider></mat-divider>
 
-      <div class="sidenavSubMenu">
+      <div class="sidenavSubMenu" *ngIf="mobileQuery.matches">
         <a mat-button (click)="compose();" matTooltip="Compose">
           <mat-icon color="primary">edit</mat-icon></a>
         <a mat-button (click)="drafts();" matTooltip="Drafts">


### PR DESCRIPTION
This fixes a regression introduced in e3506cb2c88d4994d71ef176d6dee6e065b412b0.

Without it the submenu is visible twice in webmail:

![2019-11-21-152155_330x182_scrot](https://user-images.githubusercontent.com/86378/69346182-a9098580-0c72-11ea-9c19-a293557b4dcd.png)
