### PR TITLE
fix(folderlist): handle draft subfolders

### DIFF
--- a/src/app/folder/folderlist.component.ts
+++ b/src/app/folder/folderlist.component.ts
@@ -110,7 +110,7 @@ export class FolderListComponent {
 
         const foldertreedataobservable = this.folders
             .pipe(
-                map(folders => folders.filter(f => f.folderPath !== 'Drafts')),
+                map(folders => folders.filter(f => f.folderPath.indexOf('Drafts') !== 0)),
                 map((folders) => {
                 const treedata: FolderNode[] = [];
 


### PR DESCRIPTION
folder list crashed if there were draft subfolders

This is an updated version of https://github.com/runbox/runbox7/pull/126