### PR TITLE
feat(update-notifier): Include commit hash in app update data

### DIFF
--- a/ngsw-config.json
+++ b/ngsw-config.json
@@ -1,7 +1,8 @@
 {
   "index": "/index.html",
   "appData" : {
-    "commit": "__COMMIT_HASH__"
+    "commit": "__COMMIT_HASH__",
+    "build_time": "__BUILD_TIME__"
   },
   "assetGroups": [
     {

--- a/ngsw-config.json
+++ b/ngsw-config.json
@@ -1,5 +1,8 @@
 {
   "index": "/index.html",
+  "appData" : {
+    "commit": "__COMMIT_HASH__"
+  },
   "assetGroups": [
     {
       "name": "app",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "start-use-mockserver": "ng serve --aot --proxy-config backend-proxy-mock.conf.js runbox7",
     "mockserver": "tsc -p e2e/tsconfig.e2e.json && node out-tsc/e2e/mockserver/mockserver.main.js",
     "buildrmm6": "ng build --prod --base-href=/app/ rmm6",
-    "build": "node check-prod-bundle-dependencies.js && node updatebuildtimestamp.js && ng build --prod --base-href=/app/ && git checkout src/app/buildtimestamp.ts",
+    "build": "node src/build/pre-build.js && ng build --prod --base-href=/app/; node src/build/post-build.js",
     "policy": "node policy-tests/run-all.js",
     "test": "ng test",
     "lint": "ng lint",

--- a/src/app/updatealert/updatealert.component.html
+++ b/src/app/updatealert/updatealert.component.html
@@ -3,6 +3,9 @@
   An update of the application is available, and you may reload the app now to use the latest version.<br /><br />
 
   The new version is {{ data.available.appData.commit || data.available.hash }},
+  <span *ngIf="data.available.appData.build_time; let build_time">
+      built on {{ build_time }},
+  </span>
   and the changes can be seen <a href="https://github.com/runbox/runbox7/commits/master">here</a>.
 </mat-dialog-content>
 <mat-dialog-actions style="display: flex">

--- a/src/app/updatealert/updatealert.component.html
+++ b/src/app/updatealert/updatealert.component.html
@@ -1,8 +1,9 @@
 <h1 mat-dialog-title>App update available!</h1>
 <mat-dialog-content>
-  An update of the application has been downloaded and installed in your browser, and you may reload the app now to use the latest version.<br /><br />
+  An update of the application is available, and you may reload the app now to use the latest version.<br /><br />
 
-  The new version is {{buildtimestampstring}}, and the changes can be seen <a href="https://github.com/runbox/runbox7/commits/master">here</a>.
+  The new version is {{ data.available.appData.commit || data.available.hash }},
+  and the changes can be seen <a href="https://github.com/runbox/runbox7/commits/master">here</a>.
 </mat-dialog-content>
 <mat-dialog-actions style="display: flex">
     <span style="flex-grow: 1"></span>

--- a/src/app/updatealert/updatealert.component.html
+++ b/src/app/updatealert/updatealert.component.html
@@ -2,7 +2,7 @@
 <mat-dialog-content>
   An update of the application is available, and you may reload the app now to use the latest version.<br /><br />
 
-  The new version is {{ data.available.appData.commit || data.available.hash }},
+  The new version is name {{ data.available.appData.commit || data.available.hash }},
   <span *ngIf="data.available.appData.build_time; let build_time">
       built on {{ build_time }},
   </span>

--- a/src/app/updatealert/updatealert.component.ts
+++ b/src/app/updatealert/updatealert.component.ts
@@ -17,19 +17,18 @@
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
 
-import { Component } from '@angular/core';
-import { MatDialogRef } from '@angular/material/dialog';
-import { BUILD_TIMESTAMP } from '../buildtimestamp';
+import { Component, Inject } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 
 @Component({
     templateUrl: 'updatealert.component.html'
 })
 export class UpdateAlertComponent {
-    buildtimestampstring = BUILD_TIMESTAMP;
     constructor(
-        private dialogRef: MatDialogRef<UpdateAlertComponent>
+        private dialogRef: MatDialogRef<UpdateAlertComponent>,
+        @Inject(MAT_DIALOG_DATA) public data: any
     ) {
-
+        console.log('Update details:', data);
     }
 
 

--- a/src/app/updatealert/updatealert.module.ts
+++ b/src/app/updatealert/updatealert.module.ts
@@ -19,12 +19,14 @@
 
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialogModule } from '@angular/material/dialog';
+import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { UpdateAlertComponent } from './updatealert.component';
 import { UpdateAlertService } from './updatealert.service';
 
 @NgModule({
     imports: [
+        CommonModule,
         MatDialogModule,
         MatButtonModule
     ],

--- a/src/app/updatealert/updatealert.service.ts
+++ b/src/app/updatealert/updatealert.service.ts
@@ -32,8 +32,8 @@ export class UpdateAlertService {
     ) {
         if (environment.production) {
             console.log('UpdateAlertService started');
-            swupdate.available.subscribe(() => {
-                dialog.open(UpdateAlertComponent);
+            swupdate.available.subscribe(ev => {
+                dialog.open(UpdateAlertComponent, { data: ev });
             });
 
             this.checkForUpdates();

--- a/src/build/post-build.js
+++ b/src/build/post-build.js
@@ -1,0 +1,4 @@
+const execSync = require('child_process').execSync;
+
+execSync('git checkout src/app/buildtimestamp.ts');
+execSync('git checkout ngsw-config.json');

--- a/src/build/pre-build.js
+++ b/src/build/pre-build.js
@@ -20,9 +20,10 @@ Object.keys(packageJSON.dependencies).concat(Object.keys(packageJSON.devDependen
 console.log('All dependency versions ok. Will build production bundle.');
 
 console.log('Updating build timestamp');
-fs.writeFileSync('src/app/buildtimestamp.ts', "export const BUILD_TIMESTAMP = '" + new Date().toJSON() + "';\n");
+const build_time = new Date().toJSON();
+fs.writeFileSync('src/app/buildtimestamp.ts', "export const BUILD_TIMESTAMP = '" + build_time + "';\n");
 
-console.log('Updating appData commit hash');
+console.log('Updating appData');
 const dirty = execSync('git status --porcelain ngsw-config.json').toString().trim();
 
 if (dirty) {
@@ -36,4 +37,5 @@ let config = fs.readFileSync('ngsw-config.json').toString();
 const hash = execSync('git rev-parse --short HEAD').toString().trim();
 console.log(`Setting appData commit hash to ${hash}`);
 config = config.replace('__COMMIT_HASH__', hash);
+config = config.replace('__BUILD_TIME__', build_time);
 fs.writeFileSync('ngsw-config.json', config);

--- a/src/build/pre-build.js
+++ b/src/build/pre-build.js
@@ -1,0 +1,39 @@
+const execSync = require('child_process').execSync;
+const fs = require('fs');
+
+console.log('WARNING: Reverting to committed package-lock.json. If that means your changes are lost you should rebuild it.')
+execSync('git checkout package-lock.json');
+
+const packageLockJSON = JSON.parse(fs.readFileSync('package-lock.json'));
+const packageJSON = JSON.parse(fs.readFileSync('package.json'));
+
+Object.keys(packageJSON.dependencies).concat(Object.keys(packageJSON.devDependencies)).forEach(packagename => {
+    process.stdout.write(`checking integrity of package ${packagename}`);
+    const package = JSON.parse(fs.readFileSync(`node_modules/${packagename}/package.json`));
+    if(packageLockJSON.dependencies[packagename].integrity !== package._integrity) {
+        console.error(`${packagename} integrity does not match with package-lock.json. Please reinstall.`);
+        process.exit(1);
+    }
+    process.stdout.write(` ${package._integrity.substr(0, 20)}... - OK\r\n`);
+});
+
+console.log('All dependency versions ok. Will build production bundle.');
+
+console.log('Updating build timestamp');
+fs.writeFileSync('src/app/buildtimestamp.ts', "export const BUILD_TIMESTAMP = '" + new Date().toJSON() + "';\n");
+
+console.log('Updating appData commit hash');
+const dirty = execSync('git status --porcelain ngsw-config.json').toString().trim();
+
+if (dirty) {
+    console.log('You have local changes to ngsw-config.json!\n');
+    console.log('They will be lost during the automatic update of appData section');
+    console.log('Please commit your changes before the build');
+    process.exit(1);
+}
+
+let config = fs.readFileSync('ngsw-config.json').toString();
+const hash = execSync('git rev-parse --short HEAD').toString().trim();
+console.log(`Setting appData commit hash to ${hash}`);
+config = config.replace('__COMMIT_HASH__', hash);
+fs.writeFileSync('ngsw-config.json', config);


### PR DESCRIPTION
This way we can display the upcoming version properly in the update
notes (as opposed to the old build timestamp that we used to show).

Also, knowing both the previous and the next commit hash (after this has
been deployed for a while) we'll be able to link users to changelogs
generated on the fly from a given commit range.