### PR TITLE
Remember canvastable column widths

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -117,8 +117,6 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
   hasChildRouterOutlet: boolean;
   canvastable: CanvasTableComponent;
 
-  savedColumnWidths: Array<number> = [];
-
   messagelist: Array<MessageInfo> = [];
 
   messageActionsHandler: RMM7MessageActions = new RMM7MessageActions();
@@ -152,10 +150,6 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     public mobileQuery: MobileQueryService,
     private swPush: SwPush,
     private _hotkeysService: HotkeysService) {
-    const savedColumnWidthsString = localStorage.getItem('rmmCanvasTableColumnWidths');
-    if (savedColumnWidthsString) {
-      this.savedColumnWidths = JSON.parse(savedColumnWidthsString);
-    }
 
       this._hotkeysService.add(new Hotkey(['j', 'k'],
           (event: KeyboardEvent, combo: string): ExtendedKeyboardEvent => {
@@ -278,7 +272,6 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
       if (!this.showingSearchResults && !this.showingWebSocketSearchResults) {
         this.canvastable.rows = this.messagelist;
         this.canvastable.hasChanges = true;
-        // this.autoAdjustColumnWidths();
       }
     });
     this.canvastable.scrollLimitHit.subscribe((limit) =>
@@ -916,7 +909,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
 
   autoAdjustColumnWidths() {
     setTimeout(() =>
-      this.canvastable.autoAdjustColumnWidths(40, 1500, true), 0
+      this.canvastable.autoAdjustColumnWidths(40, true), 0
     );
   }
 

--- a/src/app/canvastable/canvastable.ts
+++ b/src/app/canvastable/canvastable.ts
@@ -742,59 +742,16 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck {
     this.hasChanges = true;
   }
 
-  public autoAdjustColumnWidths(minwidth: number, maxwidth: number, tryFitScreenWidth = false) {
+  public autoAdjustColumnWidths(minwidth: number, tryFitScreenWidth = false) {
     if (!this.canv) {
       return;
     }
-
 
     const padding = this.colpaddingleft + this.colpaddingright;
 
     const canvasWidth = Math.floor(this.wantedCanvasWidth / window.devicePixelRatio) - this.scrollbarwidth - 2;
 
     const columnsTotalWidth = () => this.columns.reduce((prev, curr) => prev + curr.width, 0);
-    /*
-    // Disabled measuring column widths from the contents -
-    // since it causes different column widths per folder
-    // Must have the correct font for measuring text
-    this.ctx.font = this.fontheight + 'px ' + this.fontFamily;
-
-    this.columns.forEach(c => {
-      let newwidth = Math.round(padding + ((this.ctx.measureText(c.name).width))) + padding;
-      if (newwidth > maxwidth) {
-        newwidth = maxwidth;
-      }
-      if (newwidth > minwidth && newwidth > c.width) {
-        c.width = newwidth;
-      }
-    });
-
-    for (let rowindex = this.topindex; rowindex <
-      this.topindex + this.canv.height / this.rowheight &&
-      rowindex < this.rows.length;
-      rowindex++) {
-      const row = this.rows[Math.floor(rowindex)];
-
-      this.columns.forEach(c => {
-        let valueWidth = Math.round(
-          ((this.ctx.measureText(
-            c.getFormattedValue ?
-              c.getFormattedValue(c.getValue(row)) :
-              c.getValue(row) + ''
-          ).width)) + padding
-        );
-
-        if (valueWidth > maxwidth) {
-          valueWidth = maxwidth;
-        }
-
-        if (valueWidth > c.width) {
-          c.width = valueWidth;
-        }
-      });
-
-    }
-    */
 
     if (!this.rowWrapMode && tryFitScreenWidth) {
       // Reduce the width of the widest column to fit screen

--- a/src/app/canvastable/canvastablecontainer.component.html
+++ b/src/app/canvastable/canvastablecontainer.component.html
@@ -96,6 +96,7 @@
         (columnresizestart)="colresizestart($event.clientx, $event.colindex)"
         (columnresizeend)="colresizeend()"
         (columnresize)="colresize($event)"
+        [columnWidths]="columnWidths"
         >
       </canvastable>
     </div>
@@ -107,7 +108,7 @@
         (click)="toggleSort(col.sortColumn)"
         class="footerColumn"
               
-        [style.width]="col.width+'px'"
+        [style.width]="columnWidths[col.name]+'px'"
         [style.backgroundColor]="col.backgroundColor ? col.backgroundColor : inherit"
         [style.left]="(sumWidthsBefore(colIndex))+'px'"
         

--- a/src/app/rmmapi/messagelist.service.ts
+++ b/src/app/rmmapi/messagelist.service.ts
@@ -219,7 +219,6 @@ export class MessageListService {
                 rowWrapModeHidden: false,
                 getValue: (rowobj: MessageInfo): any => app.isSelectedRow(rowobj),
                 checkbox: true,
-                width: 38,
                 draggable: true
             },
             {
@@ -227,20 +226,16 @@ export class MessageListService {
                 sortColumn: null,
                 rowWrapModeMuted: true,
                 getValue: (rowobj: MessageInfo): string => MessageTableRowTool.formatTimestamp(rowobj.messageDate.toJSON()),
-                width: app.canvastablecontainer.getSavedColumnWidth(1, 110)
             },
             {
                 name: this.currentFolder === 'Sent' ? 'To' : 'From',
                 sortColumn: null,
-                getValue: this.currentFolder === 'Sent' ? this.getToColumnValueForRow :
-                    this.getFromColumnValueForRow,
-                width: app.canvastablecontainer.getSavedColumnWidth(2, 200)
+                getValue: this.currentFolder === 'Sent' ? this.getToColumnValueForRow : this.getFromColumnValueForRow,
             },
             {
                 name: 'Subject',
                 sortColumn: null,
                 getValue: (rowobj: MessageInfo): string => rowobj.subject,
-                width: app.canvastablecontainer.getSavedColumnWidth(3, 300),
                 draggable: true
             },
             {
@@ -250,7 +245,6 @@ export class MessageListService {
                 textAlign: 1,
                 getValue: (rowobj: MessageInfo): number => rowobj.size,
                 getFormattedValue: MessageTableRowTool.formatBytes,
-                width: app.canvastablecontainer.getSavedColumnWidth(4, 80)
             },
             {
                 sortColumn: null,
@@ -259,7 +253,6 @@ export class MessageListService {
                 rowWrapModeHidden: true,
                 font: '16px \'Material Icons\'',
                 getValue: (rowobj: MessageInfo): boolean => rowobj.attachment,
-                width: app.canvastablecontainer.getSavedColumnWidth(6, 35),
                 getFormattedValue: (val) => val ? '\uE226' : ''
             },
             {
@@ -269,7 +262,6 @@ export class MessageListService {
                 rowWrapModeHidden: true,
                 font: '16px \'Material Icons\'',
                 getValue: (rowobj: MessageInfo): boolean => rowobj.answeredFlag,
-                width: app.canvastablecontainer.getSavedColumnWidth(5, 35),
                 getFormattedValue: (val) => val ? '\uE15E' : ''
             },
             {
@@ -279,7 +271,6 @@ export class MessageListService {
                 rowWrapModeHidden: true,
                 font: '16px \'Material Icons\'',
                 getValue: (rowobj: MessageInfo): boolean => rowobj.flaggedFlag,
-                width: app.canvastablecontainer.getSavedColumnWidth(6, 35),
                 getFormattedValue: (val) => val ? '\uE153' : ''
             }
         ];

--- a/src/app/websocketsearch/websocketsearch.service.ts
+++ b/src/app/websocketsearch/websocketsearch.service.ts
@@ -153,26 +153,22 @@ export class WebSocketSearchService {
                 rowWrapModeHidden: true,
                 getValue: (rowobj): any => app.isSelectedRow(rowobj),
                 checkbox: true,
-                width: 35
             },
             {
                 name: 'Date',
                 sortColumn: null,
                 rowWrapModeMuted: true,
                 getValue: (rowobj: WebSocketSearchMailRow): string => rowobj.dateTime,
-                width: app.canvastablecontainer.getSavedColumnWidth(1, 110)
             },
             {
                 name: 'From',
                 sortColumn: null,
                 getValue: (rowobj: WebSocketSearchMailRow): string => rowobj.fromName,
-                width: app.canvastablecontainer.getSavedColumnWidth(2, 300)
             },
             {
                 name: 'Subject',
                 sortColumn: null,
                 getValue: (rowobj: WebSocketSearchMailRow): string => rowobj.subject,
-                width: app.canvastablecontainer.getSavedColumnWidth(3, 300),
                 draggable: true
                 // tooltipText: "Tip: Drag subject to a folder to move message(s)"
             },
@@ -183,7 +179,6 @@ export class WebSocketSearchService {
                 textAlign: 1,
                 getValue: (rowobj: WebSocketSearchMailRow): number => rowobj.size,
                 getFormattedValue: MessageTableRowTool.formatBytes,
-                width: app.canvastablecontainer.getSavedColumnWidth(4, 80)
             }
         ];
 

--- a/src/app/xapian/searchservice.ts
+++ b/src/app/xapian/searchservice.ts
@@ -1187,7 +1187,6 @@ export class SearchService {
                   rowWrapModeHidden: false,
                   getValue: (rowobj): any => app.isSelectedRow(rowobj),
                   checkbox: true,
-                  width: 38
             },
             {
               name: 'Date',
@@ -1197,13 +1196,11 @@ export class SearchService {
                 const datestring = this.api.getStringValue(rowobj[0], 2);
                 return MessageTableRowTool.formatTimestampFromStringWithoutSeparators(datestring);
               },
-              width: app.canvastablecontainer.getSavedColumnWidth(1, 110)
             },
             (app.selectedFolder.indexOf('Sent') === 0 && !app.displayFolderColumn) ? {
               name: 'To',
               sortColumn: null,
               getValue: (rowobj): string => this.getDocData(rowobj[0]).recipients,
-              width:  app.canvastablecontainer.getSavedColumnWidth(2, 300)
             } :
             {
               name: 'From',
@@ -1211,7 +1208,6 @@ export class SearchService {
               getValue: (rowobj): string => {
                 return this.getDocData(rowobj[0]).from;
               },
-              width:  app.canvastablecontainer.getSavedColumnWidth(2, 300)
             },
             {
               name: 'Subject',
@@ -1219,7 +1215,6 @@ export class SearchService {
               getValue: (rowobj): string => {
                 return this.getDocData(rowobj[0]).subject;
               },
-              width:  app.canvastablecontainer.getSavedColumnWidth(3, 300),
               draggable: true,
               getContentPreviewText: (rowobj): string => {
                 const ret = this.getDocData(rowobj[0]).textcontent;
@@ -1266,7 +1261,6 @@ export class SearchService {
                 }
               },
               textAlign: 1,
-              width:  app.canvastablecontainer.getSavedColumnWidth(4, 80)
             });
         } else {
           columns.push(
@@ -1279,7 +1273,6 @@ export class SearchService {
                 return  `${this.api.getNumericValue(rowobj[0], 3)}`;
               },
               getFormattedValue: (val) => val === '-1' ? '\u267B' : MessageTableRowTool.formatBytes(val),
-              width: app.canvastablecontainer.getSavedColumnWidth(4, 80),
               tooltipText: (rowobj) => this.api.getNumericValue(rowobj[0], 3) === -1 ?
                           'This message is marked for deletion by an IMAP client' : null
             });


### PR DESCRIPTION
This is mostly a refactor under the hood: what used to happen here is
the column widths would be set by the providers of the columns
themselves: xapian, rmmapi, or websocket. Separation of concerns (and
basic code hygiene :)) dictates that data providers should have nothing
to do with the interface layout, so this removes that capability of
theirs -- it's now all set in the canvastable itself. An added bonus
is the fact they're now actually consistent: previously, because of the
"decentralization" of their widths, every provider would set them to
slightly different values :)

The original reason (I assume...) for having them there was that the
data providers actually know which column is which: "a 4th column"
can mean different things depending on what we're displaying. To fix
this, column widths are now stored based on their name rather than their
index. This has a weakness -- the columns that have an empty name
(checkbox, flag, reply marker etc) are now treated as if they were the
same thing. This could be a problem if a user chose to resize only one
of them, but since they all only display a tiny icon, there's little
reasons to have them in different sizes. If we really wanted to support
that, a proper implementation would have to have unique IDs associated
with each of the columns, and based on this ID we would assign them
names and widths. Perhaps that's something worth doing in the future if
it turns out to be needed -- and if we don't replace this with angular's
virtual tables by then :)

Because the widths are now stored by name and not by index, the
localStorage setting for them has changed: which likely won't impact
anyone given that it used to be mostly broken anyway.