### PR TITLE
feat(account-app): Offer a redirect back to rmm6 if stripe payment form fails to load

### DIFF
--- a/src/app/account-app/stripe-payment-dialog.component.html
+++ b/src/app/account-app/stripe-payment-dialog.component.html
@@ -28,6 +28,16 @@
 }
 </style>
 
+<ng-template #legacyFallback>
+    <p> Payment form not loading? </p>
+
+    <p>
+        Make sure your browser extensions are not blocking access to
+        <span style="font-family: monospace">stripe.com</span>, or
+        <a href="/payment/payment?tid={{tid}}&method=stripe" target="_blank"> try our legacy payment system instead. </a>
+    </p>
+</ng-template>
+
 <div mat-dialog-content style="width: 500px; height: 250px;">
     <div [style.display]="state === 'initial' ? 'block' : 'none'">
         <div id="payment-button-row" class="payment-row" [style.display]="paymentRequestsSupported ? 'block' : 'none'">
@@ -65,6 +75,8 @@
     <div [style.display]="state === 'loading' ? 'block' : 'none'">
         <div> Loading Stripe payment form... </div>
         <mat-spinner style="margin:0 auto;"></mat-spinner>
+
+        <ng-container *ngTemplateOutlet="legacyFallback"></ng-container>
     </div>
 
     <div [style.display]="state === 'processing' ? 'block' : 'none'">


### PR DESCRIPTION
@gtandersen I'm not sure about the wording here: I initially included "some browser extensions might be blocking it", which can be true in some cases (I've seen overly aggresive uBlock block the Stripe domain for no good reason), but it also may less technical users feel like we're doing something dishonest and the browser is right to block it. I couldn't think of any way to be helpful while not being misleadingly scary, so I just left it like this.