### PR TITLE
fix(calendar): Don't try to import events when user cancelled it

### DIFF
--- a/src/app/calendar-app/calendar-app.component.ts
+++ b/src/app/calendar-app/calendar-app.component.ts
@@ -325,6 +325,9 @@ export class CalendarAppComponent implements OnDestroy {
             data: { ical: ics, calendars: this.calendars.slice() }
         });
         dialogRef.afterClosed().subscribe(result => {
+            if (!result) {
+                return;
+            }
             if (result instanceof RunboxCalendar) {
                 // create the new calendar first
                 this.calendarservice.addCalendar(result).then(


### PR DESCRIPTION
It resulted in tons of PUT queries peformed on /rest/v1/calendar/ics/undefined,
wasting time, bandwidth, and making our error logs look stupid ;)