### PR TITLE
style(canvastable): Fix overflow and adjustment of column headers

### DIFF
--- a/src/app/canvastable/canvastablecontainer.component.html
+++ b/src/app/canvastable/canvastablecontainer.component.html
@@ -38,6 +38,7 @@
             (touchend)="colresizeend()"            
             (click)="toggleSort(col.sortColumn)"
           style="
+              display: flex;
               position: absolute;
               top: 0px;
               user-select: none;
@@ -48,6 +49,7 @@
               padding-top: 5px;
               padding-left: 10px;
               text-align: left;
+              overflow: hidden;
             "
             
             [style.width]="col.width+'px'"


### PR DESCRIPTION
Flex prevents the optionally displayed sorting arrow
from shifting the text downwards.

Overflow does what the overflow does :)

Takes us from this:

![2019-11-29-173506_156x32_scrot](https://user-images.githubusercontent.com/86378/69881929-d687ac00-12ce-11ea-9c10-66f01047d699.png)

To this:

![2019-11-29-173522_146x28_scrot](https://user-images.githubusercontent.com/86378/69881935-da1b3300-12ce-11ea-95c0-8afbd0f91576.png)

I tried to give it a little bit of padding on the right too, so that it doesn't cut off pixel-perfectly, but my CSS “skills” failed me :/