### PR TITLE
fix(canvastable): Keep columns from overlapping in the wrapped view

### DIFF
--- a/src/app/canvastable/canvastable.ts
+++ b/src/app/canvastable/canvastable.ts
@@ -1174,7 +1174,7 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
                   this.ctx.restore();
                 } else if (col.rowWrapModeMuted) {
                   // Date/time
-                  x -= 8; // Decrease padding before Date
+                  x = 42; // sufficiently away from the checkbox
                   this.ctx.save();
                   this.ctx.font = this.fontheightSmaller + 'px ' + this.fontFamily;
                   this.ctx.fillStyle = this.textColor;
@@ -1183,7 +1183,7 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
                     );
                   this.ctx.restore();
                 } else {
-                  x += 10; // Increase padding before From
+                  x = 128; // far enough to make the date above fit nicely
                   this.ctx.font = this.fontheightSmall + 'px ' + this.fontFamily;
                   this.ctx.fillText(formattedVal, x, rowy + halfrowheight - 10
                     - (this.showContentTextPreview ? 8 : 0));


### PR DESCRIPTION
Note: this only affects the auto-squashed view that shows up when the
canvas is being resized, and has no effect on the "Inline previews" mode
or the regular columned view.

This replaces two magic numbers with the new magic numbers which end
up working better :) Before this patch, the x of Date was dependent
on the width of the checkbox plus some padding minus the magic number
8 that made it looked good. This time the magic number is 42, which
happens to be the exact same number that was there before: it's just
more obvious now.

The x of From however used to be dependent on col.width of Date: meaning
that if in the non-wrapped view the user set the column too narrow, the
Subject would overlap the Date in the wrapped view: and since in wrapped
view the columns are not resizable, the UI didn't exactly make it
obvious why it happens and how to fix it. This ignores the width of the
previous column (which usually was Date) and just sets the value to
something that makes the Date fit nicely and leaves some space for the
padding.

I'm not a fan of putting magic numbers like this in the code (which is
why I just spent two paragraphs in a commit message explaining myself),
but since canvastable is already very much hardcoded to the correct,
pixel-perfect values (especially in the wrapped mode), this doesn't
really make matters any worse -- I'd say having them hardcoded in
obvious places actually makes it more clear :)