### PR TITLE
perf(app): lazy-load non-core modules to improve load times

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -41,7 +41,7 @@
               "outputHashing": "all",
               "sourceMap": false,
               "extractCss": true,
-              "namedChunks": false,
+              "namedChunks": true,
               "aot": true,
               "extractLicenses": true,
               "vendorChunk": false,

--- a/src/app/account-app/account-app.module.ts
+++ b/src/app/account-app/account-app.module.ts
@@ -18,7 +18,6 @@
 // ---------- END RUNBOX LICENSE ----------
 
 import { CommonModule } from '@angular/common';
-import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { NgModule } from '@angular/core';
 import { MenuModule } from '../menu/menu.module';
@@ -86,7 +85,6 @@ import { MatTooltipModule } from '@angular/material/tooltip';
     StripePaymentDialogComponent,
   ],
   imports: [
-    BrowserModule,
     BrowserAnimationsModule,
     FormsModule,
     MenuModule,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -29,6 +29,7 @@ import { LoginComponent } from './login/login.component';
 import { MailViewerModule } from './mailviewer/mailviewer.module';
 import { WebSocketSearchModule } from './websocketsearch/websocketsearch.module';
 import { RMMHttpInterceptorService } from './rmmapi/rmmhttpinterceptor.service';
+import { ContactsService } from './contacts-app/contacts.service';
 import { StorageService } from './storage.service';
 import { RouterModule, Routes } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
@@ -50,10 +51,6 @@ import { CanvasTableModule } from './canvastable/canvastable';
 import { MoveMessageDialogComponent } from './actions/movemessage.action';
 import { RunboxWebmailAPI } from './rmmapi/rbwebmail';
 import { ComposeModule } from './compose/compose.module';
-import { ContactsAppModule } from './contacts-app/contacts-app.module';
-import { ContactsAppComponent } from './contacts-app/contacts-app.component';
-import { CalendarAppModule } from './calendar-app/calendar-app.module';
-import { CalendarAppComponent } from './calendar-app/calendar-app.component';
 import { DraftDeskComponent } from './compose/draftdesk.component';
 import { AccountAppModule } from './account-app/account-app.module';
 import { AccountAppComponent } from './account-app/account-app.component';
@@ -64,10 +61,6 @@ import { DialogModule } from './dialog/dialog.module';
 import { FolderModule } from './folder/folder.module';
 import { RMMAuthGuardService } from './rmmapi/rmmauthguard.service';
 import { ResizerModule } from './directives/resizer.module';
-import { DkimModule } from './dkim/dkim.module';
-import { DkimComponent } from './dkim/dkim.component';
-import { DomainRegisterModule } from './domainregister/domainregister.module';
-import { DomainRegisterComponent } from './domainregister/domainregister.component';
 import { MainContainerComponent } from './maincontainer.component';
 import { HeaderToolbarComponent } from './menu/headertoolbar.component';
 import { LocalSearchIndexModule } from './xapian/localsearchindex.module';
@@ -78,10 +71,6 @@ import { UpdateAlertModule } from './updatealert/updatealert.module';
 import { MultipleSearchFieldsInputModule } from './xapian/multiple-search-fields-input/multiple-search-fields-input.module';
 import { LoginLogoutModule } from './login/loginlogout.module';
 import { HotkeyModule } from 'angular2-hotkeys';
-import { ProfilesComponent } from './profiles/profiles.component';
-import { ProfilesModule } from './profiles/profiles.module';
-import { DevComponent } from './dev/dev.component';
-import { DevModule } from './dev/dev.module';
 import { RMM } from './rmm';
 
 window.addEventListener('dragover', (event) => event.preventDefault());
@@ -96,12 +85,6 @@ const routes: Routes = [
         path: '', outlet: 'headertoolbar',
         component: HeaderToolbarComponent
       },
-      { path: 'domainregistration', component: DomainRegisterComponent},
-      { path: 'identities', component: ProfilesComponent},
-      { path: 'dev', component: DevComponent},
-      { path: 'dev/:selected_component', component: DevComponent},
-      { path: 'dkim', component: DkimComponent},
-      { path: 'calendar', component: CalendarAppComponent },
       { path: 'index_dev.html', component: AppComponent },
       { path: 'app', component: AppComponent },
       { path: '',
@@ -112,7 +95,13 @@ const routes: Routes = [
             component: DraftDeskComponent
           }
         ]
-      }
+      },
+      { path: 'dev',                loadChildren: './dev/dev.module#DevModule' },
+      { path: 'dkim',               loadChildren: './dkim/dkim.module#DkimModule' },
+      { path: 'domainregistration', loadChildren: './domainregister/domainregister.module#DomainRegisterModule' },
+      { path: 'calendar',           loadChildren: './calendar-app/calendar-app.module#CalendarAppModule' },
+      { path: 'contacts',           loadChildren: './contacts-app/contacts-app.module#ContactsAppModule' },
+      { path: 'identities',         loadChildren: './profiles/profiles.module#ProfilesModule' },
     ]
   },
   { path: 'login', component: LoginComponent }
@@ -146,20 +135,14 @@ const routes: Routes = [
     WebSocketSearchModule,
     MailViewerModule,
     AccountAppModule,
-    CalendarAppModule,
-    ContactsAppModule,
-    ProfilesModule,
     ResizerModule,
-    DevModule,
-    DomainRegisterModule,
-    DkimModule,
     UpdateAlertModule,
     LoginLogoutModule,
     SearchExpressionBuilderModule,
     MultipleSearchFieldsInputModule,
     RouterModule.forRoot(routes),
     ServiceWorkerModule.register('/app/ngsw-worker.js', { enabled: environment.production }),
-      HotkeyModule.forRoot()
+    HotkeyModule.forRoot()
   ],
   declarations: [MainContainerComponent, AppComponent,
     MoveMessageDialogComponent
@@ -170,6 +153,7 @@ const routes: Routes = [
     RunboxWebmailAPI,
     RMM,
     RMMAuthGuardService,
+    ContactsService,
     StorageService,
     { provide: HTTP_INTERCEPTORS, useClass: RMMHttpInterceptorService, multi: true}
   ],

--- a/src/app/calendar-app/calendar-app.component.spec.ts
+++ b/src/app/calendar-app/calendar-app.component.spec.ts
@@ -21,6 +21,7 @@ import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { HttpClient } from '@angular/common/http';
 import { CalendarAppComponent } from './calendar-app.component';
 import { CalendarAppModule } from './calendar-app.module';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
 import { LogoutService } from '../login/logout.service';
 import { MobileQueryService } from '../mobile-query.service';
@@ -82,6 +83,7 @@ describe('CalendarAppComponent', () => {
     beforeEach(async(() => {
         TestBed.configureTestingModule({
                 imports: [
+                    NoopAnimationsModule,
                     CalendarAppModule,
                     RouterTestingModule.withRoutes([])
                   ],

--- a/src/app/calendar-app/calendar-app.module.ts
+++ b/src/app/calendar-app/calendar-app.module.ts
@@ -18,10 +18,8 @@
 // ---------- END RUNBOX LICENSE ----------
 
 import { CommonModule } from '@angular/common';
-
-import { BrowserModule } from '@angular/platform-browser';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
 import { MenuModule } from '../menu/menu.module';
 
 import { CalendarModule, DateAdapter } from 'angular-calendar';
@@ -66,8 +64,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
     ImportDialogComponent,
   ],
   imports: [
-    BrowserModule,
-    BrowserAnimationsModule,
+    CommonModule,
     FormsModule,
     MenuModule,
     MatButtonModule,
@@ -88,11 +85,11 @@ import { MatTooltipModule } from '@angular/material/tooltip';
     OwlDateTimeModule,
     OwlNativeDateTimeModule,
     // angular-calendar stuff
-    CommonModule,
     CalendarModule.forRoot({
       provide: DateAdapter,
       useFactory: adapterFactory
-    })
+    }),
+    RouterModule.forChild([ { path: '', component: CalendarAppComponent } ])
   ],
   entryComponents: [
     CalendarEditorDialogComponent,
@@ -105,7 +102,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
   providers: [
     CalendarService,
   ],
-  bootstrap: [CalendarAppComponent]
+  bootstrap: []
 })
 
 export class CalendarAppModule { }

--- a/src/app/contacts-app/contacts-app.module.ts
+++ b/src/app/contacts-app/contacts-app.module.ts
@@ -17,9 +17,8 @@
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
 
-import { BrowserModule } from '@angular/platform-browser';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MenuModule } from '../menu/menu.module';
 import { RouterModule } from '@angular/router';
@@ -56,8 +55,7 @@ import { VcfImportDialogComponent } from './vcf-import-dialog.component';
     VcfImportDialogComponent,
   ],
   imports: [
-    BrowserModule,
-    BrowserAnimationsModule,
+    CommonModule,
     FormsModule,
     MatBadgeModule,
     MatButtonModule,
@@ -74,30 +72,20 @@ import { VcfImportDialogComponent } from './vcf-import-dialog.component';
     ReactiveFormsModule,
     RouterModule.forChild([
       {
-        path: 'contacts',
-        canActivateChild: [RMMAuthGuardService],
+        path: '',
+        component: ContactsAppComponent,
         children: [
           {
-            path: '', outlet: 'headertoolbar',
-            component: HeaderToolbarComponent
+              path: '',
+              component: ContactsWelcomeComponent,
           },
           {
-            path: '',
-            component: ContactsAppComponent,
-            children: [
-              {
-                  path: '',
-                  component: ContactsWelcomeComponent,
-              },
-              {
-                  path: 'settings',
-                  component: ContactsSettingsComponent,
-              },
-              {
-                  path: ':id',
-                  component: ContactDetailsComponent,
-              }
-            ]
+              path: 'settings',
+              component: ContactsSettingsComponent,
+          },
+          {
+              path: ':id',
+              component: ContactDetailsComponent,
           }
         ]
       }
@@ -109,6 +97,6 @@ import { VcfImportDialogComponent } from './vcf-import-dialog.component';
   providers: [
     ContactsService,
   ],
-  bootstrap: [ContactsAppComponent]
+  bootstrap: []
 })
 export class ContactsAppModule { }

--- a/src/app/dev/dev.component.ts
+++ b/src/app/dev/dev.component.ts
@@ -17,48 +17,22 @@
 // You should have received a copy of the GNU General Public License
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
-import { timeout } from 'rxjs/operators';
-import { SecurityContext, Component, Input, TemplateRef, ElementRef, ContentChild,
-    Output, EventEmitter, NgZone, ViewChild, AfterViewInit } from '@angular/core';
-import { DomSanitizer } from '@angular/platform-browser';
+import { Component, Output, EventEmitter, ViewChild, AfterViewInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { ProgressService } from '../http/progress.service';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { BrowserModule } from '@angular/platform-browser';
-import { CommonModule } from '@angular/common';
-import { FormsModule } from '@angular/forms';
 import {
-  MatCardModule,
-  MatCheckboxModule,
-  MatDialogModule,
-  MatInputModule,
-  MatListModule,
-  MatPaginatorModule,
-  MatProgressBarModule,
-  MatProgressSpinnerModule,
-  MatSelectModule,
-  MatSnackBarModule,
-  MatTableModule,
-  MatTabsModule,
-  MatChipsModule,
   MatDialog,
   MatPaginator,
   MatSnackBar,
 } from '@angular/material';
 
-import { MatFormFieldModule } from '@angular/material/form-field';
 import { RMM } from '../rmm';
-import { RunboxIntroComponent } from '../runbox-components/runbox-intro';
-import { RunboxListComponent } from '../runbox-components/runbox-list';
 
 @Component({
   moduleId: 'angular2/app/dev/',
   selector: 'app-dev',
   templateUrl: 'dev.component.html'
 })
-
-export class DevComponent implements AfterViewInit {
-  panelOpenState = false;
+export class DevComponent implements AfterViewInit { panelOpenState = false;
   @ViewChild(MatPaginator, {static: false}) paginator: MatPaginator;
   @Output() Close: EventEmitter<string> = new EventEmitter();
   selected_component;

--- a/src/app/dev/dev.module.ts
+++ b/src/app/dev/dev.module.ts
@@ -18,8 +18,7 @@
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
 
-import { BrowserModule } from '@angular/platform-browser';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MenuModule } from '../menu/menu.module';
@@ -48,36 +47,39 @@ import { RunboxListComponent } from '../runbox-components/runbox-list';
 
 @NgModule({
     declarations: [
-    DevComponent,
-    RunboxIntroComponent,
-    RunboxListComponent,
+        DevComponent,
+        RunboxIntroComponent,
+        RunboxListComponent,
     ],
     imports: [
-    BrowserModule,
-    MatGridListModule,
-    MatCheckboxModule,
-    BrowserAnimationsModule,
-    FormsModule,
-    MatInputModule,
-    MatButtonModule,
-    MatCardModule,
-    MatMenuModule,
-    MatIconModule,
-    MatListModule,
-    MatProgressBarModule,
-    MatSelectModule,
-    MatSidenavModule,
-    MatToolbarModule,
-    MatTooltipModule,
-    MatTableModule,
-    MenuModule,
-    RouterModule
+        CommonModule,
+        MatGridListModule,
+        MatCheckboxModule,
+        FormsModule,
+        MatInputModule,
+        MatButtonModule,
+        MatCardModule,
+        MatMenuModule,
+        MatIconModule,
+        MatListModule,
+        MatProgressBarModule,
+        MatSelectModule,
+        MatSidenavModule,
+        MatToolbarModule,
+        MatTooltipModule,
+        MatTableModule,
+        MenuModule,
+        RouterModule.forChild([
+            { path: '',                    component: DevComponent },
+            { path: ':selected_component', component: DevComponent },
+        ])
     ],
     entryComponents: [
     ],
     providers: [
     ],
-    bootstrap: [DevComponent]
+    bootstrap: [
+    ]
 })
 export class DevModule { }
 

--- a/src/app/dkim/dkim.component.ts
+++ b/src/app/dkim/dkim.component.ts
@@ -30,7 +30,6 @@ import { HttpClient } from '@angular/common/http';
 import { Router } from '@angular/router';
 import { ProgressService } from '../http/progress.service';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { BrowserModule } from '@angular/platform-browser';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ConfirmDialog } from '../dialog/dialog.module';

--- a/src/app/dkim/dkim.module.ts
+++ b/src/app/dkim/dkim.module.ts
@@ -18,7 +18,7 @@
 // ---------- END RUNBOX LICENSE ----------
 
 import { NgModule } from '@angular/core';
-import { BrowserModule } from '@angular/platform-browser';
+import { RouterModule } from '@angular/router';
 import { DkimComponent } from './dkim.component';
 import { CommonModule } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
@@ -40,13 +40,10 @@ import { MatExpansionModule } from '@angular/material/expansion';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { FormsModule } from '@angular/forms';
 import { HttpClientModule } from '@angular/common/http';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 @NgModule({
     imports: [
         CommonModule,
-        BrowserModule,
-        BrowserAnimationsModule,
         FormsModule,
         HttpClientModule,
         MatSnackBarModule,
@@ -66,10 +63,10 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
         MatSelectModule,
         MatButtonModule,
         MatGridListModule,
-    ],
+        RouterModule.forChild([ { path: '', component: DkimComponent } ]) ],
     exports: [ DkimComponent ],
     declarations: [ DkimComponent ],
-    bootstrap: [ DkimComponent ]
+    bootstrap: [ ]
 })
 export class DkimModule {
 }

--- a/src/app/domainregister/domainregister.module.ts
+++ b/src/app/domainregister/domainregister.module.ts
@@ -18,7 +18,7 @@
 // ---------- END RUNBOX LICENSE ----------
 
 import { NgModule } from '@angular/core';
-import { BrowserModule } from '@angular/platform-browser';
+import { RouterModule } from '@angular/router';
 import { DomainRegisterComponent } from './domainregister.component';
 import { CommonModule } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
@@ -38,13 +38,10 @@ import { MatTabsModule } from '@angular/material/tabs';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { FormsModule } from '@angular/forms';
 import { HttpClientModule } from '@angular/common/http';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 @NgModule({
     imports: [
         CommonModule,
-        BrowserModule,
-        BrowserAnimationsModule,
         FormsModule,
         HttpClientModule,
         MatSnackBarModule,
@@ -62,10 +59,11 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
         MatChipsModule,
         MatSelectModule,
         MatButtonModule,
+        RouterModule.forChild([ { path: '', component: DomainRegisterComponent } ]),
     ],
     exports: [ DomainRegisterComponent ],
     declarations: [ DomainRegisterComponent ],
-    bootstrap: [ DomainRegisterComponent ]
+    bootstrap: [ ]
 })
 export class DomainRegisterModule {
 }

--- a/src/app/profiles/profiles.component.ts
+++ b/src/app/profiles/profiles.component.ts
@@ -22,7 +22,6 @@ import { DomSanitizer } from '@angular/platform-browser';
 import { Router } from '@angular/router';
 import { ProgressService } from '../http/progress.service';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { BrowserModule } from '@angular/platform-browser';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import {

--- a/src/app/profiles/profiles.module.ts
+++ b/src/app/profiles/profiles.module.ts
@@ -16,9 +16,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
-import { BrowserModule } from '@angular/platform-browser';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { MenuModule } from '../menu/menu.module';
 import { RouterModule } from '@angular/router';
@@ -55,10 +54,9 @@ import { AliasesEditorModalComponent } from '../aliases/aliases.editor.modal';
       AliasesEditorModalComponent,
     ],
     imports: [
-    BrowserModule,
+    CommonModule,
     MatGridListModule,
     MatCheckboxModule,
-    BrowserAnimationsModule,
     FormsModule,
     MatInputModule,
     MatButtonModule,
@@ -73,7 +71,7 @@ import { AliasesEditorModalComponent } from '../aliases/aliases.editor.modal';
     MatTooltipModule,
     MatTableModule,
     MenuModule,
-    RouterModule
+    RouterModule.forChild([ { path: '', component: ProfilesComponent } ]),
     ],
     entryComponents: [
       ProfilesEditorModalComponent,
@@ -81,7 +79,7 @@ import { AliasesEditorModalComponent } from '../aliases/aliases.editor.modal';
     ],
     providers: [
     ],
-    bootstrap: [ProfilesComponent]
+    bootstrap: []
 })
 export class ProfilesModule { }
 

--- a/src/tsconfig.app.json
+++ b/src/tsconfig.app.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../out-tsc/app",
     "baseUrl": "./",
-    "module": "es2015",
+    "module": "esNext",
     "types": []
   },
   "exclude": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
       "es2017",
       "dom"
     ],
-    "module": "es2015",
+    "module": "esNext",
     "baseUrl": "./"
   }
 }


### PR DESCRIPTION
Before this change, the build resulted in a 3.4 MB main.js bundle.
In transit (gzipped) it ended up being around 890 KB, and it took my
browser 120-130 ms to load it.

With these changes, main.js is 2.2 MB big (630 KB gzipped), and it loads
in around 100 ms -- giving us roughly a 30% smaller and 20% faster
initial page load.

Lazy loaded modules are sized as follows (uncompressed):

calendar.js:       688K
domainregister.js: 192K
contacts.js:       188K
profiles.js:       112K
dkim.js:           40K
dev.js:            20K

With calendar being understandably big (since it now includes the entire
angular-calendar package which is no longer loaded by default), the size
of remaining components is somewhat surprising(ly big). Perhaps further
improvements could be made by eliminating unnecessarily imported
modules.