### PR TITLE
fix(compose): handle ajax_send_msg errors

### DIFF
--- a/src/app/compose/compose.component.ts
+++ b/src/app/compose/compose.component.ts
@@ -489,6 +489,12 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
                 }
             ), send)
                 .subscribe((res) => {
+                    if (res[0] === '0') {
+                        this.snackBar.open(res[1], 'Dismiss');
+                        this.dialogService.closeProgressDialog();
+                        return;
+                    }
+
                     this.model.mid = parseInt(res[2], 10);
                     this.rmmapi.deleteCachedMessageContents(this.model.mid);
                     this.snackBar.open(res[1], null, { duration: 3000 });


### PR DESCRIPTION
The solution isn't too pretty since the API still uses the old
ajax_send_msg under the hood. Proper error handling can be introduced
when the endpoint is ported over to the REST API.

Fixes GH-428.