### PR TITLE
fix(calednar): Always set default dates when creating new calendar events

### DIFF
--- a/src/app/calendar-app/event-editor-dialog.component.ts
+++ b/src/app/calendar-app/event-editor-dialog.component.ts
@@ -77,6 +77,9 @@ export class EventEditorDialogComponent {
         if (data['start']) {
             this.event_start = moment(data['start']).hours(12).minutes(0).seconds(0).toDate();
             this.event_end   = moment(data['start']).hours(14).minutes(0).seconds(0).toDate();
+        } else {
+            this.event_start = moment().toDate();
+            this.event_end   = moment().toDate();
         }
 
         this.settings = data['settings'];


### PR DESCRIPTION
This prevents the case when start/end date would be left empty and
accidentally set to bogus values.

Fixes GH-343.