### PR TITLE
fix(calendar): Load timezones data from Icals instead of moment.js

### DIFF
--- a/src/app/calendar-app/calendar-app.component.spec.ts
+++ b/src/app/calendar-app/calendar-app.component.spec.ts
@@ -38,41 +38,41 @@ describe('CalendarAppComponent', () => {
     let fixture: ComponentFixture<CalendarAppComponent>;
 
     const simpleEvents = [
-        new RunboxCalendarEvent('test-calendar/event0', [ 'vevent', [
+        new RunboxCalendarEvent('test-calendar/event0', ['vcalendar', [], [ [ 'vevent', [
             [ 'dtstart', {}, 'date-time', moment().toISOString() ],
             [ 'summary', {}, 'text',      'Test Event #0'        ],
-        ]]),
-        new RunboxCalendarEvent('test-calendar/event1', [ 'vevent', [
+        ]]]]),
+        new RunboxCalendarEvent('test-calendar/event1', ['vcalendar', [], [ [ 'vevent', [
             [ 'dtstart', {}, 'date-time', moment().add(1, 'month').add(14, 'day').toISOString() ],
             [ 'summary', {}, 'text',      'Event #1, next month' ],
-        ]]),
+        ]]]]),
     ];
 
     const recurringEvents = [
-        new RunboxCalendarEvent('test-calendar/recurring', [ 'vevent', [
+        new RunboxCalendarEvent('test-calendar/recurring', ['vcalendar', [], [ [ 'vevent', [
             [ 'dtstart', {}, 'date-time', moment().date(1).toISOString() ],
             [ 'summary', {}, 'text',      'Weekly Event #0' ],
             [ 'rrule',   {}, 'text',      'FREQ=WEEKLY'     ],
-        ]]),
+        ]]]]),
     ];
 
     const GH_179_recurring_yearly = [
-        new RunboxCalendarEvent('test-calendar/recurring-yearly', [ 'vevent', [
+        new RunboxCalendarEvent('test-calendar/recurring-yearly', ['vcalendar', [], [ [ 'vevent', [
             [ 'dtstart', {}, 'date',  moment().date(5).toISOString().split('T')[0] ],
             [ 'dtend',   {}, 'date',  moment().date(6).toISOString().split('T')[0] ],
             [ 'summary', {}, 'text',  'Yearly event' ],
             [ 'rrule',   {}, 'text',  'FREQ=YEARLY'  ],
-        ]]),
+        ]]]]),
     ];
 
     // the test below only makes sense when the event start date is not now()
     const not_today = moment().date() === 2 ? 3 : 2;
 
     const GH_181_setting_recurrence = [
-        new RunboxCalendarEvent('test-calendar/not-recurring-yet', [ 'vevent', [
+        new RunboxCalendarEvent('test-calendar/not-recurring-yet', ['vcalendar', [], [ [ 'vevent', [
             [ 'dtstart', {}, 'date-time', moment.utc().date(not_today).hour(12).minute(34).toISOString() ],
             [ 'summary', {}, 'text',      'One-shot event' ],
-        ]]),
+        ]]]]),
     ];
 
     const mockData = {

--- a/src/app/calendar-app/calendar.service.ts
+++ b/src/app/calendar-app/calendar.service.ts
@@ -67,7 +67,7 @@ export class CalendarService implements OnDestroy {
             }
             console.log('Cache version:', cache['version']);
             // tslint:disable-next-line:triple-equals
-            if (cache['version'] != 2) {
+            if (cache['version'] != 3) {
                 console.log('Old cache format found, removing');
                 storage.set('caldavCache', undefined);
                 return;
@@ -270,7 +270,7 @@ export class CalendarService implements OnDestroy {
 
     saveCache() {
         const cache = {
-            version:   2,
+            version:   3,
             calendars: this.calendars,
             events:    this.events,
         };

--- a/src/app/calendar-app/runbox-calendar-event.spec.ts
+++ b/src/app/calendar-app/runbox-calendar-event.spec.ts
@@ -23,10 +23,12 @@ import * as moment from 'moment';
 describe('RunboxCalendarEvent', () => {
     it('should be possible to add/remove a recurrence rule', async () => {
         const sut = new RunboxCalendarEvent(
-            'testcal/testev', [ 'vevent', [
-            [ 'dtstart', {}, 'date',  moment().toISOString().split('T')[0] ],
-            [ 'dtend',   {}, 'date',  moment().toISOString().split('T')[0] ],
-            [ 'summary', {}, 'text',  'One-time event' ],
+            'testcal/testev', ['vcalendar', [], [
+                [ 'vevent', [
+                    [ 'dtstart', {}, 'date',  moment().toISOString().split('T')[0] ],
+                    [ 'dtend',   {}, 'date',  moment().toISOString().split('T')[0] ],
+                    [ 'summary', {}, 'text',  'One-time event' ],
+                ] ]
             ]]
         );
         sut.recurringFrequency = 'WEEKLY';


### PR DESCRIPTION
This fixes a (real) problem of non-standard timezone names in events,
as well as a theoretical problem of moment.tz timezone data actually
differing from the one we encounter in real world.

It also bumps the cache version for calendars since we now need to store
the entire jcal (not just vevent) to preserve the timezone information
in local cache.

Tests fixes required by this also mean that we're now cheating in them
much less :)

Fixes GH-478.