### PR TITLE
fix(rmmoffline): Close the offline notification snackbar after 10 seconds

### DIFF
--- a/src/app/rmmapi/rmmoffline.service.ts
+++ b/src/app/rmmapi/rmmoffline.service.ts
@@ -36,7 +36,8 @@ export class RMMOfflineService {
             this.snackbar.open(
                 'Runbox 7 is in offline mode due to a network or server issue. ' +
                 'It will automatically reconnect when the network is available again.',
-                'Okay'
+                'Okay',
+                { duration: 10_000 },
             );
         }
     }


### PR DESCRIPTION
Otherwise it may stay up longer than the API is offline and be a
confusing notification when everything works just fine.