### PR TITLE
fix(calendar): Make short events appear to be longer

### DIFF
--- a/src/app/calendar-app/runbox-calendar-event.ts
+++ b/src/app/calendar-app/runbox-calendar-event.ts
@@ -100,6 +100,11 @@ export class RunboxCalendarEvent implements CalendarEvent {
             return undefined;
         }
 
+        // GH-252 workaround until https://github.com/mattlewis92/angular-calendar/issues/1192 solves it better :)
+        if (this.dtend.diff(this.dtstart, 'minutes') < 30) {
+            return moment(this.dtstart).add(30, 'minutes').toDate();
+        }
+
         const shownEnd = moment(this.dtend);
         if (this.allDay) {
             shownEnd.subtract(1, 'days');


### PR DESCRIPTION
Events under 30 minutes were pretty much invisible in day/week view.
This makes them pretend they last the whole 30 so that they're
sufficiently readable and clickable.

Fixes GH-252.