### PR TITLE
fix(contacts): Make sure we pick up Runbox6 contacts when syncing

### DIFF
--- a/src/app/contacts-app/contacts.service.ts
+++ b/src/app/contacts-app/contacts.service.ts
@@ -104,7 +104,10 @@ export class ContactsService implements OnDestroy {
                         this.syncToken = syncResult.newSyncToken;
                         this.processContacts(syncResult.added);
                         resolve();
-                    } else if (this.syncToken === syncResult.newSyncToken) {
+                    // Check for syncResult.added even if the syncToken is the same,
+                    // since it may contain RMM6 contacts: they don't come from DAV
+                    // so they don't have their own syncToken, but they still need to be picked up.
+                    } else if (this.syncToken === syncResult.newSyncToken && syncResult.added.length === 0) {
                         // everything up-to-date, nothing to do
                         resolve();
                     } else {


### PR DESCRIPTION
They don't have their own syncTokens, so they may be included in the
result even if they syncToken itself was not updated. This is obviously
not ideal, but it's the best we can do given the limitations of the old
storage system.