### PR TITLE
Fix changelog `since` filtering

### DIFF
--- a/ngsw-config.json
+++ b/ngsw-config.json
@@ -2,7 +2,8 @@
   "index": "/index.html",
   "appData" : {
     "commit": "__COMMIT_HASH__",
-    "build_time": "__BUILD_TIME__"
+    "build_time": "__BUILD_TIME__",
+    "build_epoch": "__BUILD_EPOCH__"
   },
   "assetGroups": [
     {

--- a/src/app/changelog/changelog.component.ts
+++ b/src/app/changelog/changelog.component.ts
@@ -66,10 +66,8 @@ export class ChangelogComponent implements AfterViewInit, OnInit {
         this.route.queryParams.subscribe(params => {
             this.since = params['since'];
             if (this.since) {
-                const index = changelog.findIndex(c => c.hash === this.since);
-                if (index !== -1) {
-                    this.loadChangelog(changelog.slice(0, index));
-                }
+                const entries = changelog.filter(c => c.epoch > parseInt(this.since, 10));
+                this.loadChangelog(entries);
             } else {
                 this.loadChangelog(changelog);
             }

--- a/src/app/changelog/changes.ts
+++ b/src/app/changelog/changes.ts
@@ -48,12 +48,12 @@ export class ChangelogEntry {
 
     constructor(
         public hash:        string,
-               datetime:    number,
+        public epoch:       number,
         public type:        EntryType,
         public component:   string,
         public description: string,
     ) {
-        this.datetime = moment(datetime * 1000); // in ms
+        this.datetime = moment(this.epoch * 1000); // in ms
     }
 
     get url(): string {

--- a/src/app/updatealert/updatealert.component.html
+++ b/src/app/updatealert/updatealert.component.html
@@ -7,7 +7,7 @@
       built on {{ build_time }},
   </span> <br>
   and the changes can be seen in the new Runbox 7 version
-  <a href="/app/changelog?since={{ data.current.appData.commit }}">here</a>.
+  <a href="/app/changelog?since={{ data.current.appData.build_epoch }}">here</a>.
 </mat-dialog-content>
 <mat-dialog-actions style="display: flex">
     <span style="flex-grow: 1"></span>

--- a/src/build/pre-build.js
+++ b/src/build/pre-build.js
@@ -43,7 +43,9 @@ if (dirty) {
 
 let config = fs.readFileSync('ngsw-config.json').toString();
 const hash = cp.execSync('git rev-parse --short HEAD').toString().trim();
+const epoch = cp.execSync('git show --pretty="%ct" --no-patch').toString().trim();
 console.log(`Setting appData commit hash to ${hash}`);
 config = config.replace('__COMMIT_HASH__', hash);
 config = config.replace('__BUILD_TIME__', build_time);
+config = config.replace('__BUILD_EPOCH__', epoch);
 fs.writeFileSync('ngsw-config.json', config);


### PR DESCRIPTION
We used to rely on commit hashes to determine previous releases and filter the changelog. This meant that filtering broke when the previous release was a commit not included in the changelog (for example merge commits, which usually happen before releases).

This switches us over to time-based filtering, including the timestamp epoch of the last commit in the `ngsw-config.json`, which is then compared to the timestamps kept in `changes.ts`: meaning it should work regardless of whether a particular commit is in the changelog or not.