### PR TITLE
fix(compose): Validate TO/CC/BCC fields on save/send

### DIFF
--- a/src/app/compose/compose.component.html
+++ b/src/app/compose/compose.component.html
@@ -78,16 +78,16 @@
             {{model.to}}
         </span>        
         <div style="display: flex;" class="fieldRecipient">
-            <mailrecipient-input *ngIf="editing" style="flex-grow: 1" [initialfocus] = "formGroup.value.to ? false : true" placeholder="To" [recipients]="formGroup.value.to" (change)="formGroup.controls.to.setValue($event)"></mailrecipient-input>
+            <mailrecipient-input *ngIf="editing" style="flex-grow: 1" [initialfocus] = "formGroup.value.to ? false : true" placeholder="To" [recipients]="formGroup.value.to" (updateRecipient)="formGroup.controls.to.setValue($event)"></mailrecipient-input>
             <button mat-button *ngIf="editing && formGroup.value.cc===null" (click)="formGroup.controls.cc.setValue('')" id="buttonCC">CC</button>
             <button mat-button *ngIf="editing && formGroup.value.bcc===null" (click)="formGroup.controls.bcc.setValue('')" id="buttonBCC">BCC</button>
         </div>
         <div style="display: flex;" *ngIf="editing && formGroup.value.cc!==null" class="fieldRecipient">
-            <mailrecipient-input *ngIf="editing" style="width: auto; flex-grow: 1" placeholder="CC" [recipients]="formGroup.value.cc" (change)="formGroup.controls.cc.setValue($event)"></mailrecipient-input>                            
+            <mailrecipient-input *ngIf="editing" style="width: auto; flex-grow: 1" placeholder="CC" [recipients]="formGroup.value.cc" (updateRecipient)="formGroup.controls.cc.setValue($event)"></mailrecipient-input>                            
             <button mat-icon-button (click)="formGroup.controls.cc.setValue(null)"><mat-icon>close</mat-icon></button>              
         </div>
         <div style="display: flex;" *ngIf="editing && formGroup.value.bcc!==null" class="fieldRecipient">
-            <mailrecipient-input *ngIf="editing"  style="width: auto; flex-grow: 1" placeholder="BCC" [recipients]="formGroup.value.bcc" (change)="formGroup.controls.bcc.setValue($event)"></mailrecipient-input>
+            <mailrecipient-input *ngIf="editing"  style="width: auto; flex-grow: 1" placeholder="BCC" [recipients]="formGroup.value.bcc" (updateRecipient)="formGroup.controls.bcc.setValue($event)"></mailrecipient-input>
             <button mat-icon-button (click)="formGroup.controls.bcc.setValue(null)"><mat-icon>close</mat-icon></button>
         </div>
     </mat-card-subtitle>    

--- a/src/app/compose/compose.component.ts
+++ b/src/app/compose/compose.component.ts
@@ -456,27 +456,31 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
     }
 
     public submit(send: boolean = false) {
-        let validemails = false;
-        validemails = isValidEmailList(this.formGroup.value.to);
-        if (!validemails) {
-            this.saveErrorMessage = 'Cannot save draft: TO field contains invalid email addresses';
-        }
-        if (validemails && this.formGroup.value.cc) {
-            validemails = isValidEmailList(this.formGroup.value.cc);
-            if (!validemails) {
-                this.saveErrorMessage = 'Cannot save draft: CC field contains invalid email addresses';
-            }
-        }
-        if (validemails && this.formGroup.value.bcc) {
-            validemails = isValidEmailList(this.formGroup.value.bcc);
-            if (!validemails) {
-                this.saveErrorMessage = 'Cannot save draft: BCC field contains invalid email addresses';
-            }
-        }
-        if (!validemails) {
-            return;
-        }
         if (send) {
+            let validemails = false;
+            validemails = isValidEmailList(this.formGroup.value.to);
+            if (!validemails) {
+                this.saveErrorMessage = 'Cannot send email: TO field contains invalid email addresses';
+            }
+            if (validemails && this.formGroup.value.cc) {
+                validemails = isValidEmailList(this.formGroup.value.cc);
+                if (!validemails) {
+                    this.saveErrorMessage = 'Cannot send email: CC field contains invalid email addresses';
+                }
+            }
+            if (validemails && this.formGroup.value.bcc) {
+                validemails = isValidEmailList(this.formGroup.value.bcc);
+                if (!validemails) {
+                    this.saveErrorMessage = 'Cannot send email: BCC field contains invalid email addresses';
+                }
+            }
+            if (!validemails) {
+                this.snackBar.open(
+                    `Error sending: ${this.saveErrorMessage}`,
+                    'Dismiss'
+                );
+                return;
+            }
             this.dialogService.openProgressDialog();
         }
         this.model.from = this.formGroup.value.from;

--- a/src/app/compose/compose.component.ts
+++ b/src/app/compose/compose.component.ts
@@ -34,6 +34,7 @@ import { FormGroup, FormBuilder } from '@angular/forms';
 import { debounceTime, mergeMap } from 'rxjs/operators';
 import { DialogService } from '../dialog/dialog.service';
 import { TinyMCEPlugin } from '../rmm/plugin/tinymce.plugin';
+import { isValidEmailList } from './emailvalidator';
 
 declare const tinymce: any;
 declare const MailParser;
@@ -455,6 +456,26 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
     }
 
     public submit(send: boolean = false) {
+        let validemails = false;
+        validemails = isValidEmailList(this.formGroup.value.to);
+        if (!validemails) {
+            this.saveErrorMessage = 'Cannot save draft: TO field contains invalid email addresses';
+        }
+        if (validemails && this.formGroup.value.cc) {
+            validemails = isValidEmailList(this.formGroup.value.cc);
+            if (!validemails) {
+                this.saveErrorMessage = 'Cannot save draft: CC field contains invalid email addresses';
+            }
+        }
+        if (validemails && this.formGroup.value.bcc) {
+            validemails = isValidEmailList(this.formGroup.value.bcc);
+            if (!validemails) {
+                this.saveErrorMessage = 'Cannot save draft: BCC field contains invalid email addresses';
+            }
+        }
+        if (!validemails) {
+            return;
+        }
         if (send) {
             this.dialogService.openProgressDialog();
         }

--- a/src/app/compose/emailvalidator.ts
+++ b/src/app/compose/emailvalidator.ts
@@ -22,7 +22,7 @@ const EMAIL_REGEXP =
     /^(?=.{1,254}$)(?=.{1,64}@)[-!#$%&'*+/0-9=?A-Z^_`a-z{|}~]+(\.[-!#$%&'*+/0-9=?A-Z^_`a-z{|}~]+)*@[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*$/;
 
 /**
- * Extract the email part of the input string (either plain email address or inside <>)
+ * Extract the email part of the input string (either plain email address or inside <>), and test it against the regexp.
  * @param email 
  */
 export function isValidEmail(email: string) {
@@ -34,4 +34,15 @@ export function isValidEmail(email: string) {
     } else {
         return EMAIL_REGEXP.test(email);
     }
+}
+
+/**
+ * Validate each email in the list, return true if all are valid
+ * @param emailList
+ */
+export function isValidEmailList(emailList: string) {
+  if (!emailList) {
+    return false;
+  }
+  return emailList.split(',').every((recipient => isValidEmail(recipient)));
 }

--- a/src/app/compose/emailvalidator.ts
+++ b/src/app/compose/emailvalidator.ts
@@ -41,8 +41,8 @@ export function isValidEmail(email: string) {
  * @param emailList
  */
 export function isValidEmailList(emailList: string) {
-  if (!emailList) {
-    return false;
-  }
-  return emailList.split(',').every((recipient => isValidEmail(recipient)));
+    if (!emailList) {
+        return false;
+    }
+    return emailList.split(',').every((recipient => isValidEmail(recipient)));
 }

--- a/src/app/compose/mailrecipientinput.component.ts
+++ b/src/app/compose/mailrecipientinput.component.ts
@@ -51,7 +51,7 @@ export class MailRecipientInputComponent implements OnInit, AfterViewInit {
     @Input() placeholder: string;
     @Input() initialfocus = false;
 
-    @Output() change: EventEmitter<string> = new EventEmitter();
+    @Output() updateRecipient: EventEmitter<string> = new EventEmitter();
 
     @ViewChild('searchTextInput') searchTextInput: ElementRef;
     @ViewChild('auto') auto: MatAutocomplete;
@@ -94,7 +94,7 @@ export class MailRecipientInputComponent implements OnInit, AfterViewInit {
     }
 
     notifyChangeListener() {
-        this.change.emit(this.recipientsList.join(','));
+        this.updateRecipient.emit(this.recipientsList.join(','));
     }
 
     removeRecipient(ndx: number) {


### PR DESCRIPTION
Prevents sending or saving draft emails when the TO field is empty or
contains invalid emails. (the latter should already be prevented by
EmailValidator). Event "change" was renamed to "updateRecipient" to
not clash with existing events and be less confusing.

Fixes #39