### PR TITLE
fix(compose): Return user to origin when closing/trashing new drafts

### DIFF
--- a/e2e/cypress/integration/compose.ts
+++ b/e2e/cypress/integration/compose.ts
@@ -7,8 +7,8 @@ describe('Composing emails', () => {
     }
 
     function composeNew() {
-	cy.visit('/compose?new=true');
-	cy.closeWelcomeDialog();
+        cy.visit('/compose?new=true');
+        cy.closeWelcomeDialog();
     }
 
     it('should display draft card', () => {
@@ -58,12 +58,13 @@ describe('Composing emails', () => {
     });
 
     it('closing a newly composed email should return to draftdesk', () => {
-    	composeNew();
-	cy.get('button[mattooltip="Close draft"').click();
-	cy.location().should((loc) => {
-	    expect(loc.pathname).to.eq('/compose');
-	    expect(loc.search).to.eq('');
-	});
+        composeNew();
+        
+        cy.get('button[mattooltip="Close draft"').click();
+        cy.location().should((loc) => {
+            expect(loc.pathname).to.eq('/compose');
+            expect(loc.search).to.eq('');
+        });
     });
 
     it('closing a new reply should return to inbox', () => {
@@ -72,37 +73,37 @@ describe('Composing emails', () => {
         cy.get('canvastable canvas:first-of-type').click({ x: 300, y: 10 });
         cy.get('single-mail-viewer').should('exist');
         cy.get('button[mattooltip="Reply"]').click();
-	cy.get('button[mattooltip="Close draft"').click();
-	cy.location().should((loc) => {
-	    expect(loc.pathname).to.eq('/');
-	    expect(loc.search).to.eq('');
-	});
+        cy.get('button[mattooltip="Close draft"').click();
+        cy.location().should((loc) => {
+            expect(loc.pathname).to.eq('/');
+            expect(loc.search).to.eq('');
+        });
     });
 
     it('Send email on contacts page, composes an email', () => {
         cy.visit('/contacts');
         cy.contains('Welcome to Runbox 7 Contacts');
         cy.contains('Patrick Postcode').click();
-	cy.contains('Send an email to this address').click();
-	cy.location().should((loc) => {
-	    expect(loc.pathname).to.eq('/compose');
-	    expect(loc.search).to.eq('?to=patrick@post.no');
-	});
-	cy.get('mailrecipient-input mat-chip').should('contain', 'patrick@post.no');
+        cy.contains('Send an email to this address').click();
+        cy.location().should((loc) => {
+            expect(loc.pathname).to.eq('/compose');
+            expect(loc.search).to.eq('?to=patrick@post.no');
+        });
+        cy.get('mailrecipient-input mat-chip').should('contain', 'patrick@post.no');
     });
 
     it('closing a new email from contacts list, should return to contacts', () => {
         cy.visit('/contacts');
         cy.contains('Welcome to Runbox 7 Contacts');
         cy.contains('Patrick Postcode').click();
-	cy.contains('Send an email to this address').click();
-	// NB if we skip checking exist, we get an issue clicking the button
-	// not loaded??
-	cy.get('button[mattooltip="Close draft"').should('exist');
-	cy.get('button[mattooltip="Close draft"').click();
-	cy.location().should((loc) => {
-	    expect(loc.pathname).to.eq('/contacts');
-	    expect(loc.search).to.eq('');
-	});	
+        cy.contains('Send an email to this address').click();
+        // NB if we skip checking exist, we get an issue clicking the button
+        // not loaded??
+        cy.get('button[mattooltip="Close draft"').should('exist');
+        cy.get('button[mattooltip="Close draft"').click();
+        cy.location().should((loc) => {
+            expect(loc.pathname).to.eq('/contacts');
+            expect(loc.search).to.eq('');
+        }); 
     });
 });

--- a/e2e/cypress/integration/compose.ts
+++ b/e2e/cypress/integration/compose.ts
@@ -7,8 +7,8 @@ describe('Composing emails', () => {
     }
 
     function composeNew() {
-        cy.visit('/compose?new=true');
-        cy.closeWelcomeDialog();
+	cy.visit('/compose?new=true');
+	cy.closeWelcomeDialog();
     }
 
     it('should display draft card', () => {
@@ -55,5 +55,54 @@ describe('Composing emails', () => {
         cy.get('mat-option:contains(Postpat)').click();
         // ...but the resulting contact should not
         cy.get('mat-chip').should('not.contain', 'Postpat');
+    });
+
+    it('closing a newly composed email should return to draftdesk', () => {
+    	composeNew();
+	cy.get('button[mattooltip="Close draft"').click();
+	cy.location().should((loc) => {
+	    expect(loc.pathname).to.eq('/compose');
+	    expect(loc.search).to.eq('');
+	});
+    });
+
+    it('closing a new reply should return to inbox', () => {
+        cy.visit('/');
+        cy.closeWelcomeDialog();
+        cy.get('canvastable canvas:first-of-type').click({ x: 300, y: 10 });
+        cy.get('single-mail-viewer').should('exist');
+        cy.get('button[mattooltip="Reply"]').click();
+	cy.get('button[mattooltip="Close draft"').click();
+	cy.location().should((loc) => {
+	    expect(loc.pathname).to.eq('/');
+	    expect(loc.search).to.eq('');
+	});
+    });
+
+    it('Send email on contacts page, composes an email', () => {
+        cy.visit('/contacts');
+        cy.contains('Welcome to Runbox 7 Contacts');
+        cy.contains('Patrick Postcode').click();
+	cy.contains('Send an email to this address').click();
+	cy.location().should((loc) => {
+	    expect(loc.pathname).to.eq('/compose');
+	    expect(loc.search).to.eq('?to=patrick@post.no');
+	});
+	cy.get('mailrecipient-input mat-chip').should('contain', 'patrick@post.no');
+    });
+
+    it('closing a new email from contacts list, should return to contacts', () => {
+        cy.visit('/contacts');
+        cy.contains('Welcome to Runbox 7 Contacts');
+        cy.contains('Patrick Postcode').click();
+	cy.contains('Send an email to this address').click();
+	// NB if we skip checking exist, we get an issue clicking the button
+	// not loaded??
+	cy.get('button[mattooltip="Close draft"').should('exist');
+	cy.get('button[mattooltip="Close draft"').click();
+	cy.location().should((loc) => {
+	    expect(loc.pathname).to.eq('/contacts');
+	    expect(loc.search).to.eq('');
+	});	
     });
 });

--- a/e2e/cypress/integration/compose.ts
+++ b/e2e/cypress/integration/compose.ts
@@ -57,7 +57,8 @@ describe('Composing emails', () => {
         cy.get('mat-chip').should('not.contain', 'Postpat');
     });
 
-    it('closing a newly composed email should return to draftdesk', () => {
+    it('closing a newly composed email should return where we started', () => {
+        cy.visit('/compose');
         composeNew();
         
         cy.get('button[mattooltip="Close draft"').click();
@@ -102,7 +103,7 @@ describe('Composing emails', () => {
         cy.get('button[mattooltip="Close draft"').should('exist');
         cy.get('button[mattooltip="Close draft"').click();
         cy.location().should((loc) => {
-            expect(loc.pathname).to.eq('/contacts');
+            expect(loc.pathname).to.eq('/contacts/ID-MR-POSTCODE');
             expect(loc.search).to.eq('');
         }); 
     });

--- a/src/app/compose/compose.component.html
+++ b/src/app/compose/compose.component.html
@@ -38,7 +38,7 @@
     <mat-card-actions style="display: flex; flex-wrap: wrap; align-items: center; justify-content: flex-end; margin-right: 5px;">
         <div style="flex-grow: 1; padding-left: 15px; font-size: 24px;">
             {{model.subject ? model.subject : "New message"}}
-        </div>           
+        </div>
         <mat-checkbox *ngIf="editing" formControlName="useHTML" (change)="htmlToggled()" id="useHTML">HTML</mat-checkbox>    
         <button *ngIf="editing" mat-icon-button matTooltip="Attach files" (click)="attachFilesClicked()">
             <mat-icon>attachment</mat-icon>

--- a/src/app/compose/compose.component.html
+++ b/src/app/compose/compose.component.html
@@ -50,13 +50,13 @@
             <mat-icon *ngIf="!saved && !saveErrorMessage">save</mat-icon>
             <mat-icon *ngIf="!saved && saveErrorMessage" color="warn" [matTooltip]="saveErrorMessage">save</mat-icon>
         </button>
-        <button *ngIf="!isNew" mat-icon-button matTooltip="Move draft to trash" (click)="trashDraft()">
+        <button *ngIf="!isUnsaved" mat-icon-button matTooltip="Move draft to trash" (click)="trashDraft()">
             <mat-icon>delete</mat-icon>
         </button>
         <button *ngIf="editing" mat-icon-button matTooltip="Close draft" (click)="close()">
             <mat-icon>close</mat-icon>
         </button>
-        <button *ngIf="editing && isNew" mat-icon-button matTooltip="Cancel draft" (click)="cancelDraft()">
+        <button *ngIf="editing && isUnsaved" mat-icon-button matTooltip="Cancel draft" (click)="cancelDraft()">
             <mat-icon>delete</mat-icon>
         </button>
         <button *ngIf="!editing" mat-icon-button (click)="editDraft()" matTooltip="Edit draft" id="editDraftIcon">

--- a/src/app/compose/compose.component.ts
+++ b/src/app/compose/compose.component.ts
@@ -400,12 +400,10 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
     exitIfNeeded() {
         if (this.shouldExitToTable) {
             this.exitToTable();
-        }
-        else if (this.shouldExitToDrafts) {
+        } else if (this.shouldExitToDrafts) {
             this.router.navigate(['/compose']);
-        }
-        else if (this.shouldExitToContacts) {
-            this.router.navigate(['/contacts'])
+        } else if (this.shouldExitToContacts) {
+            this.router.navigate(['/contacts']);
         }
     }
 

--- a/src/app/compose/compose.component.ts
+++ b/src/app/compose/compose.component.ts
@@ -70,9 +70,7 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
 
     saveErrorMessage: string;
 
-    @Input() shouldExitToTable = false;
-    @Input() shouldExitToDrafts = false;
-    @Input() shouldExitToContacts = false;
+    shouldReturnToPreviousPage = false;
 
     public formGroup: FormGroup;
 
@@ -96,15 +94,7 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
         if (this.model.isUnsaved()) {
             this.editing = true;
             this.isUnsaved = true;
-            if (this.model.isUnsavedReply()) {
-                this.shouldExitToTable = true;
-            }
-            if (this.model.isUnsavedUntargetedDraft()) {
-                this.shouldExitToDrafts = true;
-            }
-            if (this.model.isUnsavedContactDraft()) {
-                this.shouldExitToContacts = true;
-            }
+            this.shouldReturnToPreviousPage = true;
             const from: FromAddress = this.draftDeskservice.froms.find((f) =>
                 f.nameAndAddress === this.model.from || f.email === this.model.from);
 
@@ -398,12 +388,8 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
     }
 
     exitIfNeeded() {
-        if (this.shouldExitToTable) {
-            this.exitToTable();
-        } else if (this.shouldExitToDrafts) {
-            this.router.navigate(['/compose']);
-        } else if (this.shouldExitToContacts) {
-            this.router.navigate(['/contacts']);
+        if (this.shouldReturnToPreviousPage) {
+            this.location.back();
         }
     }
 

--- a/src/app/compose/draftdesk.service.spec.ts
+++ b/src/app/compose/draftdesk.service.spec.ts
@@ -59,7 +59,7 @@ describe('DraftDesk', () => {
         expect(draft.isUnsaved()).toBe(true);
         expect(draft.isUnsavedUntargetedDraft()).toBe(false);
         expect(draft.isUnsavedContactDraft()).toBe(false);
-        expect(draft.isUnsavedReply()).toBe(false);
+        expect(draft.isUnsavedReply()).toBe(true);
         expect(draft.isReply()).toBe(true);
         draft = DraftFormModel.reply({
                 headers: {
@@ -89,7 +89,7 @@ describe('DraftDesk', () => {
         expect(draft.isUnsaved()).toBe(true);
         expect(draft.isUnsavedUntargetedDraft()).toBe(false);
         expect(draft.isUnsavedContactDraft()).toBe(false);
-        expect(draft.isUnsavedReply()).toBe(false);
+        expect(draft.isUnsavedReply()).toBe(true);
         expect(draft.isReply()).toBe(true);
         done();
     });

--- a/src/app/compose/draftdesk.service.spec.ts
+++ b/src/app/compose/draftdesk.service.spec.ts
@@ -99,7 +99,7 @@ describe('DraftDesk', () => {
         // compose?new=true
         let draft = DraftFormModel.create(
             -1,
-            'test2@runbox.com',
+            FromAddress.fromEmailAddress('test2@runbox.com'),
             null,
             '');
         expect(draft.isUnsaved()).toBe(true);
@@ -111,7 +111,7 @@ describe('DraftDesk', () => {
         // Link on contact page:
         draft = DraftFormModel.create(
             -1,
-            'test2@runbox.com',
+            FromAddress.fromEmailAddress('test2@runbox.com'),
             '"Test Runbox" <test2@runbox.com>',
             '');
         expect(draft.isUnsaved()).toBe(true);
@@ -123,7 +123,7 @@ describe('DraftDesk', () => {
         // refreshDrafts
         draft = DraftFormModel.create(
             12345,
-            'test2@runbox.com',
+            FromAddress.fromEmailAddress('test2@runbox.com'),
             '"Test Runbox" <test2@runbox.com>',
             'Some blahblah');
         expect(draft.isUnsaved()).toBe(false);

--- a/src/app/compose/draftdesk.service.spec.ts
+++ b/src/app/compose/draftdesk.service.spec.ts
@@ -56,6 +56,11 @@ describe('DraftDesk', () => {
         expect(draft.subject).toBe('Re: Test subject');
         expect(draft.to).toBe('Test1<test1@runbox.com>');
         expect(draft.msg_body).toBe(`\n2017-07-01 00:00 ${timezoneOffsetString} Test1<test1@runbox.com>:\n> blabla\n> abcde`);
+        expect(draft.isUnsaved()).toBe(true);
+        expect(draft.isUnsavedUntargetedDraft()).toBe(false);
+        expect(draft.isUnsavedContactDraft()).toBe(false);
+        expect(draft.isUnsavedReply()).toBe(false);
+        expect(draft.isReply()).toBe(true);
         draft = DraftFormModel.reply({
                 headers: {
                     'message-id': 'themessageid112414',
@@ -81,6 +86,50 @@ describe('DraftDesk', () => {
                                     '> \n' +
                                     `> 2017-07-01 00:00 ${timezoneOffsetString} Test1<test1@runbox.com>:\n` +
                                     '>> blabla\n>> abcde');
+        expect(draft.isUnsaved()).toBe(true);
+        expect(draft.isUnsavedUntargetedDraft()).toBe(false);
+        expect(draft.isUnsavedContactDraft()).toBe(false);
+        expect(draft.isUnsavedReply()).toBe(false);
+        expect(draft.isReply()).toBe(true);
         done();
+    });
+
+    it('Create', (done) => {
+        console.log('Create test');
+        // compose?new=true
+        let draft = DraftFormModel.create(
+            -1, 
+            [ FromAddress.fromEmailAddress('test2@runbox.com')],
+            null,
+            '');
+        expect(draft.isUnsaved()).toBe(true);
+        expect(draft.isUnsavedUntargetedDraft()).toBe(true);
+        expect(draft.isUnsavedContactDraft()).toBe(false);
+        expect(draft.isUnsavedReply()).toBe(false);
+        expect(draft.isReply()).toBe(false);
+
+        // Link on contact page:
+        draft = DraftFormModel.create(
+            -1,
+            [ FromAddress.fromEmailAddress('test2@runbox.com')],
+            '"Test Runbox" <test2@runbox.com>',
+            '');
+        expect(draft.isUnsaved()).toBe(true);
+        expect(draft.isUnsavedUntargetedDraft()).toBe(false);
+        expect(draft.isUnsavedContactDraft()).toBe(true);
+        expect(draft.isUnsavedReply()).toBe(false);
+        expect(draft.isReply()).toBe(false);
+
+        // refreshDrafts
+        draft = DraftFormModel.create(
+            12345,
+            [ FromAddress.fromEmailAddress('test2@runbox.com')],
+            '"Test Runbox" <test2@runbox.com>',
+            'Some blahblah');
+        expect(draft.isUnsaved()).toBe(false);
+        expect(draft.isUnsavedUntargetedDraft()).toBe(false);
+        expect(draft.isUnsavedContactDraft()).toBe(false);
+        expect(draft.isUnsavedReply()).toBe(false);
+        expect(draft.isReply()).toBe(false);
     });
 });

--- a/src/app/compose/draftdesk.service.spec.ts
+++ b/src/app/compose/draftdesk.service.spec.ts
@@ -57,10 +57,6 @@ describe('DraftDesk', () => {
         expect(draft.to).toBe('Test1<test1@runbox.com>');
         expect(draft.msg_body).toBe(`\n2017-07-01 00:00 ${timezoneOffsetString} Test1<test1@runbox.com>:\n> blabla\n> abcde`);
         expect(draft.isUnsaved()).toBe(true);
-        expect(draft.isUnsavedUntargetedDraft()).toBe(false);
-        expect(draft.isUnsavedContactDraft()).toBe(false);
-        expect(draft.isUnsavedReply()).toBe(true);
-        expect(draft.isReply()).toBe(true);
         draft = DraftFormModel.reply({
                 headers: {
                     'message-id': 'themessageid112414',
@@ -87,10 +83,6 @@ describe('DraftDesk', () => {
                                     `> 2017-07-01 00:00 ${timezoneOffsetString} Test1<test1@runbox.com>:\n` +
                                     '>> blabla\n>> abcde');
         expect(draft.isUnsaved()).toBe(true);
-        expect(draft.isUnsavedUntargetedDraft()).toBe(false);
-        expect(draft.isUnsavedContactDraft()).toBe(false);
-        expect(draft.isUnsavedReply()).toBe(true);
-        expect(draft.isReply()).toBe(true);
         done();
     });
 
@@ -103,10 +95,6 @@ describe('DraftDesk', () => {
             null,
             '');
         expect(draft.isUnsaved()).toBe(true);
-        expect(draft.isUnsavedUntargetedDraft()).toBe(true);
-        expect(draft.isUnsavedContactDraft()).toBe(false);
-        expect(draft.isUnsavedReply()).toBe(false);
-        expect(draft.isReply()).toBe(false);
 
         // Link on contact page:
         draft = DraftFormModel.create(
@@ -115,10 +103,6 @@ describe('DraftDesk', () => {
             '"Test Runbox" <test2@runbox.com>',
             '');
         expect(draft.isUnsaved()).toBe(true);
-        expect(draft.isUnsavedUntargetedDraft()).toBe(false);
-        expect(draft.isUnsavedContactDraft()).toBe(true);
-        expect(draft.isUnsavedReply()).toBe(false);
-        expect(draft.isReply()).toBe(false);
 
         // refreshDrafts
         draft = DraftFormModel.create(
@@ -127,10 +111,6 @@ describe('DraftDesk', () => {
             '"Test Runbox" <test2@runbox.com>',
             'Some blahblah');
         expect(draft.isUnsaved()).toBe(false);
-        expect(draft.isUnsavedUntargetedDraft()).toBe(false);
-        expect(draft.isUnsavedContactDraft()).toBe(false);
-        expect(draft.isUnsavedReply()).toBe(false);
-        expect(draft.isReply()).toBe(false);
         done();
     });
 });

--- a/src/app/compose/draftdesk.service.spec.ts
+++ b/src/app/compose/draftdesk.service.spec.ts
@@ -131,5 +131,6 @@ describe('DraftDesk', () => {
         expect(draft.isUnsavedContactDraft()).toBe(false);
         expect(draft.isUnsavedReply()).toBe(false);
         expect(draft.isReply()).toBe(false);
+        done();
     });
 });

--- a/src/app/compose/draftdesk.service.spec.ts
+++ b/src/app/compose/draftdesk.service.spec.ts
@@ -98,8 +98,8 @@ describe('DraftDesk', () => {
         console.log('Create test');
         // compose?new=true
         let draft = DraftFormModel.create(
-            -1, 
-            [ FromAddress.fromEmailAddress('test2@runbox.com')],
+            -1,
+            'test2@runbox.com',
             null,
             '');
         expect(draft.isUnsaved()).toBe(true);
@@ -111,7 +111,7 @@ describe('DraftDesk', () => {
         // Link on contact page:
         draft = DraftFormModel.create(
             -1,
-            [ FromAddress.fromEmailAddress('test2@runbox.com')],
+            'test2@runbox.com',
             '"Test Runbox" <test2@runbox.com>',
             '');
         expect(draft.isUnsaved()).toBe(true);
@@ -123,7 +123,7 @@ describe('DraftDesk', () => {
         // refreshDrafts
         draft = DraftFormModel.create(
             12345,
-            [ FromAddress.fromEmailAddress('test2@runbox.com')],
+            'test2@runbox.com',
             '"Test Runbox" <test2@runbox.com>',
             'Some blahblah');
         expect(draft.isUnsaved()).toBe(false);

--- a/src/app/compose/draftdesk.service.ts
+++ b/src/app/compose/draftdesk.service.ts
@@ -54,41 +54,6 @@ export class DraftFormModel {
     save = 'Save';
     attachments: any[];
 
-    public isUnsaved(): boolean {
-        if (this.mid <= -1) {
-            return true;
-        }
-        return false;
-    }
-
-    public isReply(): boolean {
-        if (this.in_reply_to) {
-            return true;
-        }
-        return false;
-    }
-
-    public isUnsavedUntargetedDraft(): boolean {
-        if (this.isUnsaved() && !this.isReply() && !this.to) {
-            return true;
-        }
-        return false;
-    }
-
-    public isUnsavedReply(): boolean {
-        if (this.isUnsaved() && this.isReply()) {
-            return true;
-        }
-        return false;
-    }
-
-    public isUnsavedContactDraft(): boolean {
-        if (this.isUnsaved() && !this.isReply() && this.to) {
-            return true;
-        }
-        return false;
-    }
-
     public static create(draftId: number, fromAddress: FromAddress, to: string, subject: string, preview?: string): DraftFormModel {
         const ret = new DraftFormModel();
         ret.from = fromAddress.email;
@@ -196,6 +161,41 @@ export class DraftFormModel {
             new ForwardedAttachment(mailObj.mid, ndx, attachment.cid)
         );
         return ret;
+    }
+
+    public isUnsaved(): boolean {
+        if (this.mid <= -1) {
+            return true;
+        }
+        return false;
+    }
+
+    public isReply(): boolean {
+        if (this.in_reply_to) {
+            return true;
+        }
+        return false;
+    }
+
+    public isUnsavedUntargetedDraft(): boolean {
+        if (this.isUnsaved() && !this.isReply() && !this.to) {
+            return true;
+        }
+        return false;
+    }
+
+    public isUnsavedReply(): boolean {
+        if (this.isUnsaved() && this.isReply()) {
+            return true;
+        }
+        return false;
+    }
+
+    public isUnsavedContactDraft(): boolean {
+        if (this.isUnsaved() && !this.isReply() && this.to) {
+            return true;
+        }
+        return false;
     }
 }
 

--- a/src/app/compose/draftdesk.service.ts
+++ b/src/app/compose/draftdesk.service.ts
@@ -54,6 +54,41 @@ export class DraftFormModel {
     save = 'Save';
     attachments: any[];
 
+    public isUnsaved(): boolean {
+        if (this.mid <= -1) {
+            return true;
+        }
+        return false;
+    }
+
+    public isReply(): boolean {
+        if (this.in_reply_to) {
+            return true;
+        }
+        return false;
+    }
+
+    public isUnsavedUntargetedDraft(): boolean {
+        if (this.isUnsaved() && !this.isReply() && !this.to) {
+            return true;
+        }
+        return false;
+    }
+
+    public isUnsavedReply(): boolean {
+        if (this.isUnsaved() && this.isReply()) {
+            return true;
+        }
+        return false;
+    }
+
+    public isUnsavedContactDraft(): boolean {
+        if (this.isUnsaved() && !this.isReply() && this.to) {
+            return true;
+        }
+        return false;
+    }
+
     public static create(draftId: number, fromAddress: FromAddress, to: string, subject: string, preview?: string): DraftFormModel {
         const ret = new DraftFormModel();
         ret.from = fromAddress.email;

--- a/src/app/compose/draftdesk.service.ts
+++ b/src/app/compose/draftdesk.service.ts
@@ -169,34 +169,6 @@ export class DraftFormModel {
         }
         return false;
     }
-
-    public isReply(): boolean {
-        if (this.in_reply_to) {
-            return true;
-        }
-        return false;
-    }
-
-    public isUnsavedUntargetedDraft(): boolean {
-        if (this.isUnsaved() && !this.isReply() && !this.to) {
-            return true;
-        }
-        return false;
-    }
-
-    public isUnsavedReply(): boolean {
-        if (this.isUnsaved() && this.isReply()) {
-            return true;
-        }
-        return false;
-    }
-
-    public isUnsavedContactDraft(): boolean {
-        if (this.isUnsaved() && !this.isReply() && this.to) {
-            return true;
-        }
-        return false;
-    }
 }
 
 @Injectable()


### PR DESCRIPTION
Logic for closing / trashing drafts is now:
If its was a new draft (not yet saved when we open it)
* If we started from "Compose", return to draftdesk (/compose)
* If we started from a "reply", return to inbox (/)
* If we started from a "email contact", return to (/contacts)
** This would be better as "the contact", need to figure out if we can do that
* Otherwise: return to drafts desk
