### PR TITLE
build(tests): Allow Electron and Chrome(ium) in unit tests

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -7,6 +7,8 @@ module.exports = function (config) {
     frameworks: ['jasmine', '@angular-devkit/build-angular'],
     plugins: [
       require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-electron-launcher'),
       require('karma-firefox-launcher'),
       require('karma-jasmine-html-reporter'),
       require('karma-coverage-istanbul-reporter'),
@@ -27,7 +29,24 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['Firefox'],
+    browsers: ['Chrome', 'Electron', 'Firefox'],
+    electronOpts: {
+      width: 1920,
+      height: 1080,
+    },
+    customLaunchers: {
+      ChromeHeadlessCI: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox', '--disable-gpu', '--window-size=1920,1080']
+      },
+      ElectronHeadless: {
+        base: 'Electron',
+        electronOpts: {
+          show: false
+        }
+      },
+    },
+
     singleRun: false
   });
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10391,6 +10391,15 @@
         }
       }
     },
+    "karma-chrome-launcher": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-3.1.0.tgz",
+      "integrity": "sha512-3dPs/n7vgz1rxxtynpzZTvb9y/GIaW8xjAwcIGttLbycqoFtI7yo1NGnQi6oFTherRE+GIhCAHZC4vEqWGhNvg==",
+      "dev": true,
+      "requires": {
+        "which": "^1.2.1"
+      }
+    },
     "karma-coverage-istanbul-reporter": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/karma-coverage-istanbul-reporter/-/karma-coverage-istanbul-reporter-2.0.6.tgz",
@@ -10399,6 +10408,25 @@
       "requires": {
         "istanbul-api": "^2.1.6",
         "minimatch": "^3.0.4"
+      }
+    },
+    "karma-electron-launcher": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/karma-electron-launcher/-/karma-electron-launcher-0.3.0.tgz",
+      "integrity": "sha512-+IESj8bNN+oHvVdEpkuHQU9jgUGdnH74TvmGrGOKb4nGJHNUSzjsriD0E/6Jn6dt5JmQDvl2vGNJFWVFlGsArQ==",
+      "dev": true,
+      "requires": {
+        "async": "^0.9.0",
+        "merge": "^1.2.0",
+        "ncp": "^2.0.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+          "dev": true
+        }
       }
     },
     "karma-firefox-launcher": {
@@ -11088,6 +11116,12 @@
         "trim-newlines": "^1.0.0"
       }
     },
+    "merge": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
+      "dev": true
+    },
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -11460,6 +11494,12 @@
         "snapdragon": "^0.8.1",
         "to-regex": "^3.0.1"
       }
+    },
+    "ncp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+      "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
+      "dev": true
     },
     "negotiator": {
       "version": "0.6.2",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,8 @@
     "jasmine-spec-reporter": "~4.2.1",
     "karma": "^5.0.2",
     "karma-coverage-istanbul-reporter": "~2.0.5",
+    "karma-chrome-launcher": "^3.1.0",
+    "karma-electron-launcher": "^0.3.0",
     "karma-firefox-launcher": "^1.3.0",
     "karma-jasmine": "~2.0.1",
     "karma-jasmine-html-reporter": "^1.4.0",


### PR DESCRIPTION
This partially reverts 161b66f5dec0740ec11bf5d7f2b63e862ac86334.

Firefox is still the default browser in run-ci-tests, but
Chrome/Electron can be used when launching `ng test` directly.