### PR TITLE
fix(account): Fix an edgecase where payment would not start due to currency mismatch

### DIFF
--- a/src/app/account-app/shopping-cart.component.ts
+++ b/src/app/account-app/shopping-cart.component.ts
@@ -158,7 +158,10 @@ export class ShoppingCartComponent implements OnInit {
 
         for (const i of cartItems) {
             const product = products.find(p => p.pid === i.pid);
-            i.product = product || {};
+            if (!product) {
+                throw new Error(`Failed to find product info for PID ${i.pid}`);
+            }
+            i.product = product;
         }
 
         return cartItems;
@@ -203,15 +206,15 @@ export class ShoppingCartComponent implements OnInit {
             let dialogRef: MatDialogRef<any>;
             if (method === 'stripe') {
                 dialogRef = this.dialog.open(StripePaymentDialogComponent, {
-                    data: { tx: tx, currency: currency, method: method }
+                    data: { tx }
                 });
             } else if (method === 'bitpay') {
                 dialogRef = this.dialog.open(BitpayPaymentDialogComponent, {
-                    data: { tx: tx }
+                    data: { tx }
                 });
             } else if (method === 'paypal') {
                 dialogRef = this.dialog.open(PaypalPaymentDialogComponent, {
-                    data: { tx: tx }
+                    data: { tx }
                 });
             } else if (method === 'giro') {
                 this.router.navigateByUrl('/account/receipt/' + tx.tid);

--- a/src/app/account-app/stripe-payment-dialog.component.ts
+++ b/src/app/account-app/stripe-payment-dialog.component.ts
@@ -60,10 +60,10 @@ export class StripePaymentDialogComponent implements AfterViewInit {
         public dialogRef: MatDialogRef<StripePaymentDialogComponent>,
         @Inject(MAT_DIALOG_DATA) public data: any
     ) {
-        this.method = data.method;
+        console.log('Opening stripe form for transaction', data.tx);
         this.tid    = data.tx.tid;
         this.total  = data.tx.total;
-        this.currency = data.currency;
+        this.currency = data.tx.currency;
 
         if (stripeLoader === null) {
             stripeLoader = new AsyncSubject<void>();


### PR DESCRIPTION
From now on we'll rely on the `tx` object alone in all payment flows,
which should finally respect the currency that may have been forced into
USD (or something else) for a particular payment because of the products
being ordered.

We're also more strict now when loading the payment products, which
should fail earlier and produce better error messages.