### PR TITLE
fix(compose): Display email localpart for contact with no name details

### DIFF
--- a/src/app/compose/recipient.ts
+++ b/src/app/compose/recipient.ts
@@ -29,10 +29,10 @@ export class Recipient {
 
     static fromContact(contact: Contact, email: string) {
         // Use the display_name() (which includes nickname) for autocompletion purposes,
-        // but full_name() (which does not) as the address to send to.
+        // but external_display_name() (which does not) as the address to send to.
         // https://github.com/runbox/runbox7/issues/313#issuecomment-548483028
         return new this(
-            [`"${contact.full_name()}" <${email}>`],
+            [`"${contact.external_display_name()}" <${email}>`],
             `"${contact.display_name()}" <${email}>`
         );
     }

--- a/src/app/contacts-app/contact.ts
+++ b/src/app/contacts-app/contact.ts
@@ -126,6 +126,17 @@ export class Contact {
         }
     }
 
+    external_display_name(): string {
+        if (this.full_name()) {
+            return this.full_name();
+        }
+        if (this.primary_email()) {
+            const parts = this.primary_email().split('@');
+            return parts[0];
+        }
+        return 'Unnamed contact';
+    }
+
     primary_email(): string {
         if (this.emails.length > 0) {
             return this.emails[0].value;


### PR DESCRIPTION
A contact stored with no fullname / first name / last name was being
displayed as "null" <email> in the To field of compose. This amends it
to the email localpart if it would otherwise be null