### PR TITLE
fix(draftdesk): Ensure we store Draft data correctly post save

### DIFF
--- a/src/app/compose/compose.component.ts
+++ b/src/app/compose/compose.component.ts
@@ -549,7 +549,7 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
             }
             )).subscribe((res: any) => {
                     if (res.mid) {
-                        this.model.mid = res.mid;
+                        this.model.mid = typeof res.mid === 'string' ? parseInt(res.mid, 10) : res.mid;
                     }
                     this.rmmapi.deleteCachedMessageContents(this.model.mid);
 


### PR DESCRIPTION
Drafts were not being deleted because when saving the mid value ended
up set to a string rather than a number. This meant the delete (from
local copy) filter didnt find it.

Fixes #58