### PR TITLE
feat(mailviewer): Store mailviewer pane height across sessions

### DIFF
--- a/e2e/cypress/integration/mailviewer.ts
+++ b/e2e/cypress/integration/mailviewer.ts
@@ -17,7 +17,6 @@ describe('Interacting with mailviewer', () => {
     it('Vertical to horizontal mode exposes full height button', () => {
         cy.visit('/');
         cy.closeWelcomeDialog();
-        cy.clearLocalStorage();
 
         canvas().click({ x: 400, y: 350 });
         // Make sure we're in vertical mode
@@ -29,15 +28,43 @@ describe('Interacting with mailviewer', () => {
     it('Changing viewpane height is stored', () => {
         cy.visit('/');
         cy.closeWelcomeDialog();
-        cy.clearLocalStorage();
 
         canvas().click({ x: 400, y: 350 });
-        // Make sure we're in vertical mode
+        // Make sure we're in horizontal mode
         cy.get('button[mattooltip="Horizontal preview"]').click();
         // set full height
         cy.get('button[mattooltip="Full height"]').click().should(() => {
-            expect(localStorage.getItem('rmm7resizerheight').to.exist());
+            // full height 
+            const resizerHeight = parseInt(localStorage.getItem('rmm7resizerheight'), 10);
+            expect(resizerHeight).to.be.greaterThan(100);
+
         });
-        
+    });
+
+    it('Half height reduces stored pane height', () => {
+        cy.visit('/');
+        cy.closeWelcomeDialog();
+
+        canvas().click({ x: 400, y: 350 });
+        // Make sure we're in horizontal mode
+        cy.get('button[mattooltip="Horizontal preview"]').click();
+        // set full height
+        var resizerHeight = 0;
+        cy.get('button[mattooltip="Full height"]').click().and(() => {
+        // full height 
+            resizerHeight = parseInt(localStorage.getItem('rmm7resizerheight'), 10);
+        });
+        // half height 
+        cy.get('button[mattooltip="Half height"]').click().should(() => {
+            expect(parseInt(localStorage.getItem('rmm7resizerheight'), 10)).to.be.lessThan(resizerHeight);
+        // collect new value
+            resizerHeight = parseInt(localStorage.getItem('rmm7resizerheight'), 10);
+        });
+
+        // doesnt go away on pane close (persist for other emails)
+        cy.get('button[mattooltip="Close"]').click().should(() => {
+            expect(parseInt(localStorage.getItem('rmm7resizerheight'), 10)).to.equal(resizerHeight);
+        });
     });
 })
+

--- a/e2e/cypress/integration/mailviewer.ts
+++ b/e2e/cypress/integration/mailviewer.ts
@@ -12,5 +12,32 @@ describe('Interacting with mailviewer', () => {
         canvas().click({ x: 400, y: 350 });
         cy.get('button[mattooltip="Reply"]').click();
         cy.contains("Re: No 'To', just 'CC'");
-    })
+    });
+
+    it('Vertical to horizontal mode exposes full height button', () => {
+        cy.visit('/');
+        cy.closeWelcomeDialog();
+        cy.clearLocalStorage();
+
+        canvas().click({ x: 400, y: 350 });
+        // Make sure we're in vertical mode
+        cy.get('button[mattooltip="Horizontal preview"]').click();
+
+        cy.get('button[mattooltip="Full height"]').should('exist');        
+    });
+
+    it('Changing viewpane height is stored', () => {
+        cy.visit('/');
+        cy.closeWelcomeDialog();
+        cy.clearLocalStorage();
+
+        canvas().click({ x: 400, y: 350 });
+        // Make sure we're in vertical mode
+        cy.get('button[mattooltip="Horizontal preview"]').click();
+        // set full height
+        cy.get('button[mattooltip="Full height"]').click().should(() => {
+            expect(localStorage.getItem('rmm7resizerheight').to.exist());
+        });
+        
+    });
 })

--- a/src/app/mailviewer/singlemailviewer.component.ts
+++ b/src/app/mailviewer/singlemailviewer.component.ts
@@ -47,6 +47,7 @@ import { loadLocalMailParser } from './mailparser';
 
 const SUPPORTS_IFRAME_SANDBOX = 'sandbox' in document.createElement('iframe');
 const showHtmlDecisionKey = 'rmm7showhtmldecision';
+const resizerHeightKey = 'rmm7resizerheight';
 
 @Component({
   template: `
@@ -172,6 +173,7 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
   public ngOnInit() {
     this.messageActionsHandler.mailViewerComponent = this;
     this.showHTMLDecision = localStorage.getItem(showHtmlDecisionKey);
+    this.previousHeight = parseInt(localStorage.getItem(resizerHeightKey), 10);
   }
 
   public ngAfterViewInit() {
@@ -565,6 +567,7 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
     this.height = height;
     if (height > 0) {
       this.previousHeight = height;
+      localStorage.setItem(resizerHeightKey, height.toString());
     }
   }
 


### PR DESCRIPTION
The user can set the mailviewer pane to be full height, or drag it
larger, this change is now stored in localStorage for future sessions.

Closes #518 