### PR TITLE
build(app): Enable sourcemaps for production builds

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -39,7 +39,7 @@
             "production": {
               "optimization": true,
               "outputHashing": "all",
-              "sourceMap": false,
+              "sourceMap": true,
               "extractCss": true,
               "namedChunks": true,
               "aot": true,
@@ -146,7 +146,7 @@
             "production": {
               "optimization": true,
               "outputHashing": "all",
-              "sourceMap": false,
+              "sourceMap": true,
               "extractCss": true,
               "namedChunks": false,
               "aot": true,


### PR DESCRIPTION
They're only loaded when needed anyway, and this makes debugging a lot
easier.