### PR TITLE
test(e2e): Make a flapping compose test more consistent

### DIFF
--- a/e2e/cypress/integration/compose.ts
+++ b/e2e/cypress/integration/compose.ts
@@ -59,7 +59,8 @@ describe('Composing emails', () => {
 
     it('closing a newly composed email should return where we started', () => {
         cy.visit('/compose');
-        composeNew();
+        cy.closeWelcomeDialog();
+        cy.visit('/compose?new=true');
         
         cy.get('button[mattooltip="Close draft"').click();
         cy.location().should((loc) => {

--- a/e2e/cypress/integration/compose.ts
+++ b/e2e/cypress/integration/compose.ts
@@ -1,11 +1,6 @@
 /// <reference types="cypress" />
 
 describe('Composing emails', () => {
-    function closeWelcomeDialog() {
-        cy.get('confirm-dialog').should('contain', 'Welcome to Runbox 7');
-        cy.get('confirm-dialog .mat-dialog-actions button:nth-child(3)').click();
-    }
-
     function composeNew() {
         cy.visit('/compose?new=true');
         cy.closeWelcomeDialog();
@@ -111,7 +106,7 @@ describe('Composing emails', () => {
 
     it('should find the same address in original "To" and our "From" field in Reply', () => {
         cy.visit('/');
-        closeWelcomeDialog();
+        cy.closeWelcomeDialog();
         cy.get('canvastable canvas:first-of-type').click({ x: 300, y: 360 });
         cy.get('single-mail-viewer').should('exist');
         const address = 'testmail@testmail.com';

--- a/e2e/cypress/support/commands.ts
+++ b/e2e/cypress/support/commands.ts
@@ -1,4 +1,4 @@
 Cypress.Commands.add('closeWelcomeDialog', () => {
     cy.get('confirm-dialog').should('contain', 'Welcome to Runbox 7');
-    cy.get('confirm-dialog .mat-dialog-actions button:nth-child(3)').click();
+    cy.get('confirm-dialog .mat-dialog-actions button').contains('cancel').click();
 });


### PR DESCRIPTION
Sometimes the welcome dialog would not show up after location change,
failing the assumption in composeNew().

Tested locally this makes the test run at 100% consistency, up from the existing ~40%, so hopefully it will also make Travis runs a bit more representative :)