### PR TITLE
build(calendar): Update to the newest angular-calendar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4964,16 +4964,23 @@
       "dev": true
     },
     "angular-calendar": {
-      "version": "0.28.13",
-      "resolved": "https://registry.npmjs.org/angular-calendar/-/angular-calendar-0.28.13.tgz",
-      "integrity": "sha512-Cm4vZ0Lqbv4OxpVb+tuw4zFKxhqJSeOuaZzYNKK8dxkAQ/5m3PqPpd6XQqZUlLHbCkkuy95eDTIRw4tADK7Uew==",
+      "version": "0.29.0-beta.1",
+      "resolved": "https://registry.npmjs.org/angular-calendar/-/angular-calendar-0.29.0-beta.1.tgz",
+      "integrity": "sha512-zy/Yrl1d2KoIGturMyTBdSqlYbaFqgHHBNAink/5WxcdissAUMCt3OXC1kifvBCG6JD4RPUPKLBUXv26iEom2w==",
       "requires": {
-        "@scarf/scarf": "^1.0.4",
+        "@scarf/scarf": "^1.0.5",
         "angular-draggable-droppable": "^4.4.4",
         "angular-resizable-element": "^3.3.0",
-        "calendar-utils": "^0.7.2",
+        "calendar-utils": "^0.8.0",
         "positioning": "^2.0.1",
-        "tslib": "^1.10.0"
+        "tslib": "^1.13.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        }
       }
     },
     "angular-draggable-droppable": {
@@ -5958,9 +5965,9 @@
       "dev": true
     },
     "calendar-utils": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/calendar-utils/-/calendar-utils-0.7.2.tgz",
-      "integrity": "sha512-LaDJzJMkICj4/KWCx4NEh+YqVTKnREl3KlaOCmQDXCvCGMBCwDij5C4+vXqVyGZiIdQkU2my1Je86KC/swU6cQ=="
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/calendar-utils/-/calendar-utils-0.8.0.tgz",
+      "integrity": "sha512-hZ0PgXeC87HlyJVhcZLP/Km1E1Z5o5hzwkmlJa/40DTyVKXDwR8dyvkNafQu8zFm6pkX9rWnUgsWoonyF/Kfmg=="
     },
     "caller-callsite": {
       "version": "2.0.0",
@@ -7392,8 +7399,8 @@
       "integrity": "sha512-Kmtdw3h+eJo5OxDRD0OvrV8tZu3vj9T2BM1uGcoVtNFjH7zT5RIAaM0mQp00+Wp3heFVtcuBNIxx7fxm8TNtiw==",
       "dev": true,
       "requires": {
-        "chalk": "3.0.0",
-        "methods": "1.1.2"
+        "chalk": "^3.0.0",
+        "methods": "^1.1.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -7402,8 +7409,8 @@
           "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
           "dev": true,
           "requires": {
-            "@types/color-name": "1.1.1",
-            "color-convert": "2.0.1"
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
           }
         },
         "chalk": {
@@ -7412,8 +7419,8 @@
           "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
           "dev": true,
           "requires": {
-            "ansi-styles": "4.2.1",
-            "supports-color": "7.1.0"
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
           }
         },
         "color-convert": {
@@ -7422,7 +7429,7 @@
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
-            "color-name": "1.1.4"
+            "color-name": "~1.1.4"
           }
         },
         "color-name": {
@@ -7443,7 +7450,7 @@
           "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
           "dev": true,
           "requires": {
-            "has-flag": "4.0.0"
+            "has-flag": "^4.0.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@danielmoncada/angular-datetime-picker": "^9.3.1",
     "@sentry/browser": "^5.15.5",
     "@types/moment-timezone": "^0.5.13",
-    "angular-calendar": "^0.28.13",
+    "angular-calendar": "^0.29.0-beta.1",
     "angular2-hotkeys": "2.2.0",
     "array-flat-polyfill": "^1.0.1",
     "base64-js": "^1.3.0",

--- a/src/app/calendar-app/runbox-calendar-event.ts
+++ b/src/app/calendar-app/runbox-calendar-event.ts
@@ -102,11 +102,6 @@ export class RunboxCalendarEvent implements CalendarEvent {
             return undefined;
         }
 
-        // GH-252 workaround until https://github.com/mattlewis92/angular-calendar/issues/1192 solves it better :)
-        if (this.dtend.diff(this.dtstart, 'minutes') < 30) {
-            return moment(this.dtstart).add(30, 'minutes').toDate();
-        }
-
         const shownEnd = moment(this.dtend);
         if (this.allDay) {
             shownEnd.subtract(1, 'days');


### PR DESCRIPTION
This eliminates our local need for a short event fix.

We can hold it off until 0.29 becomes a non-beta, but it seems to work just fine for us anyway (unless Travis is about to prove me wrong).