### PR TITLE
fix(mailviewer): Ensure default horizontal pane is not invisible

### DIFF
--- a/src/app/mailviewer/singlemailviewer.component.ts
+++ b/src/app/mailviewer/singlemailviewer.component.ts
@@ -553,10 +553,13 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
         if (this.messageContents) {
           this.messageContents.nativeElement.scroll(0, 0);
         }
-        if (this.previousHeight) {
-          this.resizer.resizePixels(this.previousHeight);
-        } else {
-          this.resizer.resizePercentage(50);
+        // Only care about the horizontal pane height in horizontal mode
+        if (this.adjustableHeight) {
+          if (this.previousHeight) {
+            this.resizer.resizePixels(this.previousHeight);
+          } else {
+            this.resizer.resizePercentage(50);
+          }
         }
       }, 0);
     }


### PR DESCRIPTION
Aka: Don't store the height of the horizontal pane when we're in
vertical mode, as that becomes "invisible" (33 pixels) when the pane
is actually used.

Fixes (newly reported bug)