### PR TITLE
test(mailviewer): Add tests for reply/forwarding emails with empty To…

### DIFF
--- a/e2e/cypress/integration/mailviewer.ts
+++ b/e2e/cypress/integration/mailviewer.ts
@@ -11,7 +11,46 @@ describe('Interacting with mailviewer', () => {
 
         canvas().click({ x: 400, y: 350 });
         cy.get('button[mattooltip="Reply"]').click();
-        cy.contains("Re: No 'To', just 'CC'");
+        cy.location().should((loc) => {
+            expect(loc.pathname).to.eq('/compose');
+        });
+        cy.get('mat-card-actions div').should('contain', "Re: No 'To', just 'CC'");
+    });
+
+    it('can forward an email with no "To"', () => {
+        cy.visit('/');
+        cy.closeWelcomeDialog();
+
+        canvas().click({ x: 400, y: 350 });
+        cy.get('button[mattooltip="Forward"]').click();
+        cy.location().should((loc) => {
+            expect(loc.pathname).to.eq('/compose');
+        });
+        cy.get('mat-card-actions div').should('contain', "Fwd: No 'To', just 'CC'");
+    });
+
+    it('can reply to an email with no "To" or "Subject"', () => {
+        cy.visit('/');
+        cy.closeWelcomeDialog();
+
+        canvas().click({ x: 400, y: 420 });
+        cy.get('button[mattooltip="Reply"]').click();
+        cy.location().should((loc) => {
+            expect(loc.pathname).to.eq('/compose');
+        });
+        cy.get('mat-card-actions div').should('contain', "Re: ");
+    });
+
+    it('can forward an email with no "To" or "Subject"', () => {
+        cy.visit('/');
+        cy.closeWelcomeDialog();
+
+        canvas().click({ x: 400, y: 420 });
+        cy.get('button[mattooltip="Forward"]').click();
+        cy.location().should((loc) => {
+            expect(loc.pathname).to.eq('/compose');
+        });
+        cy.get('mat-card-actions div').should('contain', "Fwd: ");
     });
 
     it('Vertical to horizontal mode exposes full height button', () => {

--- a/e2e/mockserver/mockserver.ts
+++ b/e2e/mockserver/mockserver.ts
@@ -161,6 +161,13 @@ export class MockServer {
                     message_obj.result.headers['to'].text = "TESTMAIL@TESTMAIL.COM";
                     message_obj.result.headers['subject'] = "Default from fix test";
                 }
+                if (mailid === '13') {
+                    message_obj = JSON.parse(JSON.stringify(mail_message_obj));
+                    const to = message_obj.result.headers['to'];
+                    delete message_obj.result.headers['to'];
+                    message_obj.result.headers['cc'] = to;
+                    message_obj.result.headers['subject'] = "";
+                }
 
                 if (requesturl.endsWith('/html')) {
                     response.end(message_obj.result.text.html);
@@ -300,8 +307,14 @@ export class MockServer {
                 `Test2<test2@lalala.no>	No 'To', just 'CC'	709	n	 `);
 
         // id=12: email with capitalized "To" email
-        inboxlines.push(`12	1548071422	1547830043	Inbox	1	0	0	"Test" <test@runbox.com>	` +
+        inboxlines.push(`12	1548071423	1547830044	Inbox	1	0	0	"Test" <test@runbox.com>	` +
                 `Test2<test2@lalala.no>	Default from fix test	709	n	 `);
+
+        // id=13: email with no "To" or Subject
+        inboxlines.push(`13	1548071424	1547830045	Inbox	1	0	0	"Test" <test@runbox.com>	` +
+                `Test2<test2@lalala.no>		709	n	 `);
+
+
         return inboxlines.join('\n');
     }
 

--- a/src/app/compose/draftdesk.service.ts
+++ b/src/app/compose/draftdesk.service.ts
@@ -99,13 +99,8 @@ export class DraftFormModel {
                         addr.address : addr.name + '<' + addr.address + '>').join(',');
             }
         }
-        ret.from = (
-            [].concat(mailObj.to || []).concat(mailObj.cc || []).find(
-                addr => froms.find(fromObj => fromObj.email === addr.address.toLowerCase())
-            ) || { address: froms[0].email }
-        ).address.toLowerCase();
-
-        ret.subject = 'Re: ' + MessageInfo.getSubjectWithoutAbbreviation(mailObj.subject);
+        ret.setFromForResponse(mailObj, froms);
+        ret.setSubjectForResponse(mailObj, 'Re: ');
 
         let mailDate: Date = mailObj.date;
         const timezoneOffset: number = mailDate.getTimezoneOffset();
@@ -141,10 +136,9 @@ export class DraftFormModel {
 
     public static forward(mailObj, froms: FromAddress[], useHTML: boolean): DraftFormModel {
         const ret = new DraftFormModel();
-        ret.from = (mailObj.to.concat(mailObj.cc || []).find((addr) => froms.find(fromObj => fromObj.email === addr.address))
-            || { address: froms[0].email }).address;
+        ret.setFromForResponse(mailObj, froms);
 
-        ret.subject = 'Fwd: ' + mailObj.subject;
+        ret.setSubjectForResponse(mailObj, 'Fwd: ');
         if (!useHTML) {
             ret.msg_body = '\n\n----------------------------------------------\nForwarded message:\n' +
                 mailObj.origMailHeaderText + '\n\n' + mailObj.rawtext;
@@ -168,6 +162,18 @@ export class DraftFormModel {
             return true;
         }
         return false;
+    }
+
+    private setFromForResponse(mailObj, froms: FromAddress[]): void {
+        this.from = (
+            [].concat(mailObj.to || []).concat(mailObj.cc || []).find(
+                addr => froms.find(fromObj => fromObj.email === addr.address.toLowerCase())
+            ) || { address: froms[0].email }
+        ).address.toLowerCase();
+    }
+
+    private setSubjectForResponse(mailObj, prefix): void {
+        this.subject = prefix + MessageInfo.getSubjectWithoutAbbreviation(mailObj.subject);
     }
 }
 


### PR DESCRIPTION
…/Subject

Test for reported fwd/reply issues with emails containing no To field or Subject. (CC is set instead).

Fixes for issue now also included