### PR TITLE
fix(canvastable): Make it possible to open email from the bottom

### DIFF
--- a/src/app/canvastable/canvastablecontainer.component.html
+++ b/src/app/canvastable/canvastablecontainer.component.html
@@ -6,8 +6,8 @@
         -webkit-user-select: none;
         color: this.textColor;                        
         white-space: nowrap;
-        height: 25px;
-        padding-top: 5px;            
+        height: 0;
+        padding: 0;            
         text-align: right;
         font-weight: bold;   
     }


### PR DESCRIPTION
The footer overlapped with message on the bottom, but wasn't visible.
Clicking on it resulted in reordering emails (just like you would click
on the corresponding header).
The footer has now 0 height, so it's not possible to click on it
anymore.

Fixes: #456