### PR TITLE
fix(mailviewer): Grow HTML view to proper size right away

### DIFF
--- a/src/app/mailviewer/singlemailviewer.component.css
+++ b/src/app/mailviewer/singlemailviewer.component.css
@@ -92,6 +92,12 @@
     color: rgb(131, 131, 131);
 }
 
+#iframe {
+    border: 0;
+    height: 0px;
+    width: 100%;
+}
+
 .menuradiobutton {
     margin: 5px;
 }  

--- a/src/app/mailviewer/singlemailviewer.component.html
+++ b/src/app/mailviewer/singlemailviewer.component.html
@@ -256,19 +256,6 @@
         </button>
       </span>
     </div>
-    <div *ngIf="showHTML && htmlObjectURL">
-      <div class="notificationContainer">
-	      <span class="inMessageNotification">This HTML message has been sanitized for your security.</span>
-      </div>
-      <iframe
-	        #htmliframe 
-         [src]="htmlObjectURL" 
-         (load)="adjustIframeHTMLHeight()"
-	        style="border: none; width: 100%"
-	        sandbox="allow-same-origin allow-popups allow-popups-to-escape-sandbox"
-	    >
-      </iframe>
-    </div>
 
     <!-- We have an HTML message -->
     <div *ngIf="showHTML && !htmlObjectURL">
@@ -276,6 +263,10 @@
 	<span class="inMessageNotification">This HTML message has been sanitized for your security.</span>
       </div>
       <div [innerHTML]="mailContentHTML"></div>
+    </div>
+
+    <div *ngIf="showHTML && htmlObjectURL" class="notificationContainer">
+      <span class="inMessageNotification">This HTML message has been sanitized for your security.</span>
     </div>
 
     <!-- We have an HTML message, but no text version and the user has not chosen to show HTML -->
@@ -290,6 +281,17 @@
 
     <!-- We have a plain text message or the user has chosen to show text -->
     <div *ngIf="!showHTML && mailObj.text !== 'undefined'" id="messageContent" style="white-space: pre-wrap" [innerHTML]='mailObj.text'>
+    </div>
+    
+    <div *ngIf="mailContentHTML && showHTML && htmlObjectURL" class="iframe-container">
+      <iframe
+	        #htmliframe 
+          [src]="htmlObjectURL" 
+          (load)="adjustIframeHTMLHeight()"
+          sandbox="allow-same-origin allow-popups allow-popups-to-escape-sandbox" 
+          id="iframe"
+	    >
+      </iframe>
     </div>      
 
     <mat-card *ngIf="mailObj.attachments && mailObj.attachments.length>0">

--- a/src/app/mailviewer/singlemailviewer.component.ts
+++ b/src/app/mailviewer/singlemailviewer.component.ts
@@ -426,9 +426,9 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
 
   adjustIframeHTMLHeight() {
     if (this.htmliframe) {
-      this.htmliframe.nativeElement.height = this.htmliframe.nativeElement.contentWindow.document.body
-        .scrollHeight + 20;
-      ProgressDialog.close();
+      const iframe = document.getElementById('iframe');
+      const newHeight = this.htmliframe.nativeElement.contentWindow.document.body.scrollHeight;
+      iframe.style.cssText = `height: ${newHeight + 20}px !important`;
     }
   }
 


### PR DESCRIPTION
Now the default height of the view is 0 until the function does it's job with figuring out what height it should give to the iframe. That way there is no size jumping in between, that could confuse the user.
I was trying to do it fully in CSS but iframe wasn't cooperating enough. 

Fixes: #519