### PR TITLE
feat(webmail): Give folders and messages URL fragments (take two)

### DIFF
--- a/e2e/cypress/integration/compose.ts
+++ b/e2e/cypress/integration/compose.ts
@@ -1,19 +1,18 @@
 /// <reference types="cypress" />
 
 describe('Composing emails', () => {
-    function composeNew() {
-        cy.visit('/compose?new=true');
-        cy.closeWelcomeDialog();
-    }
+    beforeEach(() => {
+        localStorage.setItem('localSearchPromptDisplayed221', 'true');
+    });
 
     it('should display draft card', () => {
-        composeNew();
+        cy.visit('/compose?new=true');
         cy.get('mat-card-actions div').should('contain', 'New message');
         cy.focused().should('have.attr', 'placeholder', 'To');
     });
 
     it('should update action bar text to subject', () => {
-        composeNew();
+        cy.visit('/compose?new=true');
 
         cy.get('mat-card-actions div').should('contain', 'New message');
         cy.get('input[placeholder="Subject"]').type('Email about Subject X');
@@ -21,7 +20,7 @@ describe('Composing emails', () => {
     });
 
     it('should complain on invalid email address', () => {
-        composeNew();
+        cy.visit('/compose?new=true');
 
         cy.get('mailrecipient-input input').type('invalidaddress{enter}');
         cy.get('mailrecipient-input mat-error').should('contain', 'Please enter a valid email address');
@@ -31,9 +30,7 @@ describe('Composing emails', () => {
     });
 
     it('should open reply draft with HTML editor', () => {
-        cy.visit('/');
-        cy.closeWelcomeDialog();
-        cy.get('canvastable canvas:first-of-type').click({ x: 300, y: 10 });
+        cy.visit('/#Inbox:1');
         cy.get('single-mail-viewer').should('exist');
         cy.get('mat-checkbox[mattooltip="Toggle HTML view"]').click();
         cy.contains('Manually toggle HTML').click();
@@ -44,7 +41,7 @@ describe('Composing emails', () => {
     });
 
     it('emailing a contact should not use their nickname', () => {
-        composeNew();
+        cy.visit('/compose?new=true');
         cy.get('mailrecipient-input input').clear().type('postpat');
         // autocompletion should show the nickname...
         cy.get('mat-option:contains(Postpat)').click();
@@ -54,7 +51,6 @@ describe('Composing emails', () => {
 
     it('closing a newly composed email should return where we started', () => {
         cy.visit('/compose');
-        cy.closeWelcomeDialog();
         cy.visit('/compose?new=true');
         
         cy.get('button[mattooltip="Close draft"').click();
@@ -65,8 +61,7 @@ describe('Composing emails', () => {
     });
 
     it('closing a new reply should return to inbox', () => {
-        cy.visit('/');
-        cy.closeWelcomeDialog();
+        cy.visit('/#Inbox:1');
         cy.get('canvastable canvas:first-of-type').click({ x: 300, y: 10 });
         cy.get('single-mail-viewer').should('exist');
         cy.get('button[mattooltip="Reply"]').click();
@@ -105,9 +100,7 @@ describe('Composing emails', () => {
     });
 
     it('should find the same address in original "To" and our "From" field in Reply', () => {
-        cy.visit('/');
-        cy.closeWelcomeDialog();
-        cy.get('canvastable canvas:first-of-type').click({ x: 300, y: 360 });
+        cy.visit('/#Inbox:12');
         cy.get('single-mail-viewer').should('exist');
         const address = 'testmail@testmail.com';
         cy.get('.messageHeaderTo rmm7-contact-card a').contains(address, { matchCase: false });

--- a/e2e/cypress/integration/mailviewer.ts
+++ b/e2e/cypress/integration/mailviewer.ts
@@ -5,11 +5,26 @@ describe('Interacting with mailviewer', () => {
         return cy.get('canvastable canvas:first-of-type');
     }
 
-    it('can reply to an email with no "To"', () => {
-        cy.visit('/');
-        cy.closeWelcomeDialog();
+    beforeEach(() => {
+        localStorage.setItem('localSearchPromptDisplayed221', 'true');
+    });
 
-        canvas().click({ x: 400, y: 350 });
+    it('can open an email and go back and forth in browser history', () => {
+        cy.visit('/');
+
+        cy.wait(1000); // should be long enough for the canvas to appear
+        canvas().click({ x: 400, y: 300 });
+
+        cy.hash().should('be', '#Inbox:9');
+        cy.go('back');
+        cy.hash().should('not.contain', 'Inbox:9');
+        cy.go('forward');
+        cy.hash().should('be', '#Inbox:9');
+    });
+
+    it('can reply to an email with no "To"', () => {
+        cy.visit('/#Inbox:11');
+
         cy.get('button[mattooltip="Reply"]').click();
         cy.location().should((loc) => {
             expect(loc.pathname).to.eq('/compose');
@@ -18,10 +33,8 @@ describe('Interacting with mailviewer', () => {
     });
 
     it('can forward an email with no "To"', () => {
-        cy.visit('/');
-        cy.closeWelcomeDialog();
+        cy.visit('/#Inbox:11');
 
-        canvas().click({ x: 400, y: 350 });
         cy.get('button[mattooltip="Forward"]').click();
         cy.location().should((loc) => {
             expect(loc.pathname).to.eq('/compose');
@@ -30,10 +43,8 @@ describe('Interacting with mailviewer', () => {
     });
 
     it('can reply to an email with no "To" or "Subject"', () => {
-        cy.visit('/');
-        cy.closeWelcomeDialog();
+        cy.visit('/#Inbox:13');
 
-        canvas().click({ x: 400, y: 420 });
         cy.get('button[mattooltip="Reply"]').click();
         cy.location().should((loc) => {
             expect(loc.pathname).to.eq('/compose');
@@ -42,10 +53,8 @@ describe('Interacting with mailviewer', () => {
     });
 
     it('can forward an email with no "To" or "Subject"', () => {
-        cy.visit('/');
-        cy.closeWelcomeDialog();
+        cy.visit('/#Inbox:13');
 
-        canvas().click({ x: 400, y: 420 });
         cy.get('button[mattooltip="Forward"]').click();
         cy.location().should((loc) => {
             expect(loc.pathname).to.eq('/compose');
@@ -54,10 +63,8 @@ describe('Interacting with mailviewer', () => {
     });
 
     it('Vertical to horizontal mode exposes full height button', () => {
-        cy.visit('/');
-        cy.closeWelcomeDialog();
+        cy.visit('/#Inbox:11');
 
-        canvas().click({ x: 400, y: 350 });
         // Make sure we're in vertical mode
         cy.get('button[mattooltip="Horizontal preview"]').click();
 
@@ -65,10 +72,8 @@ describe('Interacting with mailviewer', () => {
     });
 
     it('Changing viewpane height is stored', () => {
-        cy.visit('/');
-        cy.closeWelcomeDialog();
+        cy.visit('/#Inbox:11');
 
-        canvas().click({ x: 400, y: 350 });
         // Make sure we're in horizontal mode
         cy.get('button[mattooltip="Horizontal preview"]').click();
         // set full height
@@ -81,10 +86,8 @@ describe('Interacting with mailviewer', () => {
     });
 
     it('Half height reduces stored pane height', () => {
-        cy.visit('/');
-        cy.closeWelcomeDialog();
+        cy.visit('/#Inbox:11');
 
-        canvas().click({ x: 400, y: 350 });
         // Make sure we're in horizontal mode
         cy.get('button[mattooltip="Horizontal preview"]').click();
         // set full height
@@ -106,4 +109,3 @@ describe('Interacting with mailviewer', () => {
         });
     });
 })
-

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -151,24 +151,26 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     changeDetectorRef: ChangeDetectorRef,
     public mobileQuery: MobileQueryService,
     private swPush: SwPush,
-    private _hotkeysService: HotkeysService) {
-
-      this._hotkeysService.add(new Hotkey(['j', 'k'],
-          (event: KeyboardEvent, combo: string): ExtendedKeyboardEvent => {
-              if (combo === 'k') {
-                  this.canvastable.scrollUp();
-                  combo = null;
-              }
-              if (combo === 'j') {
-                  this.canvastable.scrollDown();
-              }
-              const e: ExtendedKeyboardEvent = event;
-              e.returnValue = false;
-              return e;
-          }));
+    private hotkeysService: HotkeysService
+  ) {
+    this.hotkeysService.add(
+        new Hotkey(['j', 'k'],
+        (event: KeyboardEvent, combo: string): ExtendedKeyboardEvent => {
+            if (combo === 'k') {
+                this.canvastable.scrollUp();
+                combo = null;
+            }
+            if (combo === 'j') {
+                this.canvastable.scrollDown();
+            }
+            const e: ExtendedKeyboardEvent = event;
+            e.returnValue = false;
+            return e;
+        })
+    );
 
     this.mdIconRegistry.addSvgIcon('movetofolder',
-      this.sanitizer.bypassSecurityTrustResourceUrl('assets/movetofolder.svg'));
+    this.sanitizer.bypassSecurityTrustResourceUrl('assets/movetofolder.svg'));
 
     this.messageActionsHandler.dialog = dialog;
     this.messageActionsHandler.draftDeskService = draftDeskService;
@@ -241,7 +243,6 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     if (messagePaneSetting) {
       this.keepMessagePaneOpen = messagePaneSetting === 'true';
     }
-
   }
 
   ngOnDestroy() {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -577,18 +577,18 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
       this.selectedRowIds[this.selectedRowId] = true;
 
       if (!multiSelect && columnIndex > 1) {
+        let messageId: number;
         if (this.showingSearchResults) {
-          this.singlemailviewer.expectedMessageSize = this.searchService.api.getNumericValue(this.selectedRowId, 3);
-          this.singlemailviewer.messageId = this.searchService.getMessageIdFromDocId(this.selectedRowId);
+          messageId = this.searchService.getMessageIdFromDocId(this.selectedRowId);
         } else if (this.showingWebSocketSearchResults) {
           const msg = (rowContent as WebSocketSearchMailRow);
-          this.singlemailviewer.messageId = msg.id;
-          this.singlemailviewer.expectedMessageSize = msg.size;
+          messageId = msg.id;
         } else {
           const msg: MessageInfo = rowContent;
-          this.singlemailviewer.messageId = msg.id;
-          this.singlemailviewer.expectedMessageSize = msg.size;
+          messageId = msg.id;
         }
+
+        this.singlemailviewer.messageId = messageId;
 
         if (!this.mobileQuery.matches && !localStorage.getItem('messageSubjectDragTipShown')) {
           this.snackBar.open('Tip: Drag subject to a folder to move message(s)' , 'Got it');

--- a/src/app/mailviewer/singlemailviewer.component.ts
+++ b/src/app/mailviewer/singlemailviewer.component.ts
@@ -107,7 +107,6 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
 
   public mailContentHTML: string = null;
   public htmlObjectURL: SafeUrl = null;
-  public expectedMessageSize: number;
   public fullMailDownloaded = false;
 
   public showHTMLDecision = 'dontask';
@@ -158,12 +157,6 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
       this.onClose.emit(actionstring);
     }
 
-  }
-
-  public shouldPreviewSmallVersion(): boolean {
-    // Only preview small version of messages if more than  30kb
-    // return this.expectedMessageSize>30*1024;
-    return false; // Always download full message
   }
 
   public get messageId() {


### PR DESCRIPTION
This allows linking to specific folders/messages
as well as going back and forth between messages with browser buttons.

It also attempts to fix our e2e tests to make them pass (or fail) more consistently.

This is a new, improved version of #599 with more atomic commits.