### PR TITLE
fix(webmail): Display selected-mail operations whenever more than one…

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -233,7 +233,7 @@
   <router-outlet (activate)="hasChildRouterOutlet=true" (deactivate)="hasChildRouterOutlet=false"></router-outlet>
 </mat-sidenav-container>
 
-<div class="contextToolButtons" *ngIf="!hasChildRouterOutlet && showSelectOperations && !singlemailviewer.messageId">
+<div class="contextToolButtons" *ngIf="!hasChildRouterOutlet && showSelectOperations">
   <button mat-fab matTooltip="Move&nbsp;to&nbsp;folder" (click)="moveToFolder()">
     <mat-icon>folder</mat-icon>
   </button>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -249,7 +249,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
   }
   ngDoCheck(): void {
     this.showSelectOperations = Object.keys(this.selectedRowIds).reduce((prev, current) =>
-      (this.selectedRowIds[current] ? prev + 1 : prev), 0) > 0;
+      (this.selectedRowIds[current] ? prev + 1 : prev), 0) > 1;
 
     if (!this.usewebsocketsearch && this.searchService.api && this.xapianDocCount) {
       this.dynamicSearchFieldPlaceHolder = 'Start typing to search ' +
@@ -748,7 +748,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
   }
 
   singleMailViewerClosed(action: string): void {
-    this.clearSelection();
+  //  this.clearSelection();
   }
 
   searchTextFieldFocus() {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -99,7 +99,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
 
   conversationSearchText: string;
 
-  lastSelectedRowIndex: number;
+  openedRowIndex: number;
   selectedRowId: number;
   openedRowId: number;
   searchtextfieldfocused = false;
@@ -185,14 +185,14 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     this.renderer.listen(window, 'keydown', (evt: KeyboardEvent) => {
       if (this.singlemailviewer.messageId) {
         if (evt.code === 'ArrowUp') {
-          const newRowIndex = this.lastSelectedRowIndex - 1;
+          const newRowIndex = this.openedRowIndex - 1;
           if (newRowIndex >= 0) {
             this.rowSelected(newRowIndex, 3, this.canvastable.rows[newRowIndex], false);
             this.canvastable.hasChanges = true;
             evt.preventDefault();
           }
         } else if (evt.code === 'ArrowDown') {
-          const newRowIndex = this.lastSelectedRowIndex + 1;
+          const newRowIndex = this.openedRowIndex + 1;
           if (newRowIndex < this.canvastable.rows.length) {
             this.rowSelected(newRowIndex, 3, this.canvastable.rows[newRowIndex], false);
             this.canvastable.hasChanges = true;
@@ -646,7 +646,6 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     if (!rowContent) {
       return;
     }
-    this.lastSelectedRowIndex = rowIndex;
     let selectedRowId;
     if (this.showingSearchResults) {
       selectedRowId = rowContent[0];
@@ -691,6 +690,8 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
       // selectedRow will change when we click on other checkboxes, this one
       // stays attached to the opened email
       this.openedRowId = this.selectedRowId;
+      this.openedRowIndex = rowIndex;
+
       if (this.showingSearchResults) {
         this.singlemailviewer.expectedMessageSize = this.searchService.api.getNumericValue(this.openedRowId, 3);
         this.singlemailviewer.messageId = this.searchService.getMessageIdFromDocId(this.openedRowId);
@@ -775,7 +776,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
   }
 
   singleMailViewerClosed(action: string): void {
-  //  this.clearSelection();
+    this.openedRowId = null;
   }
 
   searchTextFieldFocus() {
@@ -817,6 +818,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
         this.searchService.updateIndexWithNewChanges();
         this.selectedRowIds = {};
         this.selectedRowId = null;
+        this.openedRowId = null;
         ProgressDialog.close();
       });
   }
@@ -836,6 +838,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
         this.searchService.updateIndexWithNewChanges();
         this.selectedRowIds = {};
         this.selectedRowId = null;
+        this.openedRowId = null;
       }
     });
   }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -101,6 +101,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
 
   lastSelectedRowIndex: number;
   selectedRowId: number;
+  openedRowId: number;
   searchtextfieldfocused = false;
 
   showMultipleSearchFields = false;
@@ -625,6 +626,17 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     return this.selectedRowIds[selectedRowId] === true;
   }
 
+  public isOpenedRow(rowObj: any): boolean {
+    let openedRowId;
+    if (this.showingSearchResults) {
+      openedRowId = rowObj[0];
+    } else {
+      const msg: MessageInfo = rowObj;
+      openedRowId = msg.id;
+    }
+    return this.openedRowId === openedRowId;
+  }
+
   public clearSelection() {
     this.selectedRowId = null;
     this.selectedRowIds = {};
@@ -676,9 +688,12 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
 
     // If we clicked right of the checkbox, we wanted to open the email:
     if (columnIndex > 0) {
+      // selectedRow will change when we click on other checkboxes, this one
+      // stays attached to the opened email
+      this.openedRowId = this.selectedRowId;
       if (this.showingSearchResults) {
-        this.singlemailviewer.expectedMessageSize = this.searchService.api.getNumericValue(this.selectedRowId, 3);
-        this.singlemailviewer.messageId = this.searchService.getMessageIdFromDocId(this.selectedRowId);
+        this.singlemailviewer.expectedMessageSize = this.searchService.api.getNumericValue(this.openedRowId, 3);
+        this.singlemailviewer.messageId = this.searchService.getMessageIdFromDocId(this.openedRowId);
       } else if (this.showingWebSocketSearchResults) {
         const msg = (rowContent as WebSocketSearchMailRow);
         this.singlemailviewer.messageId = msg.id;

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -577,6 +577,9 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
       .subscribe(() => {
         this.selectedRowIds = {};
         this.selectedRowId = null;
+        if (messageIds.find((id) => id === this.singlemailviewer.messageId)) {
+          this.singlemailviewer.close();
+        }
       });
   }
 

--- a/src/app/canvastable/canvastable.spec.ts
+++ b/src/app/canvastable/canvastable.spec.ts
@@ -39,6 +39,9 @@ describe('canvastable', () => {
             isSelectedRow: (rowObj: any): boolean => {
                 return false;
             },
+            isOpenedRow: (rowObj: any): boolean => {
+                return false;
+            },
             isBoldRow: (rowObj: any): boolean => {
                 return false;
             }

--- a/src/app/canvastable/canvastable.ts
+++ b/src/app/canvastable/canvastable.ts
@@ -52,6 +52,7 @@ const getCSSClassProperty = (className, propertyName) => {
 export interface CanvasTableSelectListener {
   rowSelected(rowIndex: number, colIndex: number, rowContent: any, multiSelect?: boolean): void;
   isSelectedRow(rowObj: any): boolean;
+  isOpenedRow(rowObj: any): boolean;
   isBoldRow(rowObj: any): boolean;
 }
 
@@ -187,13 +188,13 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
       this.recalculateColumnSections();
       this.calculateColumnFooterSums();
       this.hasSortColumns = columns.filter(col => col.sortColumn !== null).length > 0;
-      this.hasChanges = true;
-    }
+      this.hasChanges = true;    }
   }
 
   // Colors retrieved from css classes
   textColorLink: string = getCSSClassProperty('themePalettePrimary', 'color');
   selectedRowColor: string = getCSSClassProperty('themePaletteAccentLighter', 'color');
+  openedRowColor: string = getCSSClassProperty('themePaletteLighterGray', 'color');
   hoverRowColor: string = getCSSClassProperty('themePaletteLightGray', 'color');
   textColor: string = getCSSClassProperty('themePaletteBlack', 'color');
 
@@ -1044,11 +1045,15 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
 
         const isBoldRow = this.selectListener.isBoldRow(rowobj);
         const isSelectedRow = this.selectListener.isSelectedRow(rowobj);
+        const isOpenedRow = this.selectListener.isOpenedRow(rowobj);
         if (this.hoverRowIndex === rowIndex) {
           rowBgColor = this.hoverRowColor;
         }
         if (isSelectedRow) {
           rowBgColor = this.selectedRowColor;
+        }
+        if (isOpenedRow) {
+          rowBgColor = this.openedRowColor;
         }
 
         this.ctx.fillStyle = rowBgColor;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -172,8 +172,12 @@ mat-grid-tile.tableTitle {
 .themePaletteBackground {
     color: mat-color($rmm-default-background);
 }
+
+.themePaletteLighterGray {
+    color: #eeeeee;
+}
 .themePaletteLightGray {
-    color: #eee;
+    color: #f4f4f4;
 }
 .themePaletteDarkGray {
     color: #949494;


### PR DESCRIPTION
… message is selected

Fixes several reported issues, where selected row checkboxes will
uncheck when closing an open message. Also selecting multiple messages
with the message pane open, would not display the operations buttons
for acting on the selected emails.

Fixes (parts of) #10,#11,#303

* [x] Currently, opening an email (clicking on subject for example, not the checkbox), also "selects" the related checkbox. In order for this to not look strange, I made the "select operations" only appear when more than one email was selected - FIXED (see #542)
* [x] This fails existing tests, as we have one that  checks the "move" button appears when only one email is selected - FIXED (by the above)
* The changes made make the "select operations" buttons appear regardless of whether the mail view pane is open, closed, or being closed after it was previously open, as requested in the tagged issues.
* NB: These changes undo some obviously deliberate previous choices by @petersalomonsen (back before the code was on github), so we should be sure how we want the UI to act.
* [x] Possibly #542 should be rolled into this, and we should de-couple "view email" with "select emails for multi operations" - DONE
* This is because this PR (currently) makes things a bit weird if you:
    * View an email (thus opening the view pane, and causing the checkbox to be checked)
    * check some more checkboxes, up to / including unchecking the viewed email
* [x] We're left in a state where its not obvious which email is opened, as highlighting is applied to the checked rows, but nothing distinguishes the viewed email .. Extra highlight added
