### PR TITLE
fix(messagetable): Display time instead of the date for messages received after midnight

### DIFF
--- a/src/app/messagetable/messagetablerow.ts
+++ b/src/app/messagetable/messagetablerow.ts
@@ -28,7 +28,7 @@ export class MessageTableRowTool {
         const timezoneadjustedJSONDateString = mailTime.toJSON();
 
         const currentDateString: string = new Date().toJSON().substr(0, datelen);
-        if (timezoneadjustedJSONDateString.substr(0, datelen) === currentDateString) {
+        if (timezoneadjustedJSONDateString.substr(0, datelen) >= currentDateString) {
             return timezoneadjustedJSONDateString.substr(datelen + 1, 5);
         } else {
             return timezoneadjustedJSONDateString.substr(0, datelen);


### PR DESCRIPTION
If the last time user refreshed the page was before midnight, messages they receive after midnight will now have the time shown in the table instead of today's date (that is different than the date when user refreshed the page).

Fixes: #455