### PR TITLE
fix(draftdesk): Fix text overflowing after closing draft

### DIFF
--- a/src/app/compose/compose.component.html
+++ b/src/app/compose/compose.component.html
@@ -1,42 +1,6 @@
-<style>
-    mat-form-field {
-        width: 100%;
-    }
-    .dropzonehighlight {
-        border: #155D97 dashed 5px;
-        border-radius: 20px;
-        height: 100px;
-        text-align: center;
-        padding-top: 30px;
-    }
-    .overdropzone {
-        border: #5D9715 solid 5px;        
-    }
-    #useHTML div.mat-checkbox-inner-container {
-        margin-right: 4px !important;
-    }
-    #sendMail .mat-icon {
-        font-size: 36px;
-    }
-    button {
-        float: right !important;
-    }
-    #dropZoneText {
-        margin: 10px 0;
-    }
-    #deleteAttachment {
-        height: 16px;
-        line-height: 16px;
-    }
-    #deleteAttachment mat-icon {
-        margin-top: -5px;
-        font-size: 20px;
-    }
-
-</style>
-<mat-card [ngClass]="{'draftPreview': !editing}" [formGroup]="formGroup">
-    <mat-card-actions style="display: flex; flex-wrap: wrap; align-items: center; justify-content: flex-end; margin-right: 5px;">
-        <div style="flex-grow: 1; padding-left: 15px; font-size: 24px;">
+<mat-card [ngClass]="{'draftPreview': !editing}" class="draft-card" [formGroup]="formGroup">
+    <mat-card-actions class="draft-actions">
+        <div class="draft-title">
             {{model.subject ? model.subject : "New message"}}
         </div>
         <mat-checkbox *ngIf="editing" formControlName="useHTML" (change)="htmlToggled()" id="useHTML">HTML</mat-checkbox>    

--- a/src/app/compose/compose.component.scss
+++ b/src/app/compose/compose.component.scss
@@ -3,3 +3,14 @@
     border: 1px solid #949494;
     padding: 10px;
 }
+.draftPreview {
+    max-height: 100px;
+    overflow: hidden;
+
+    span {
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+    }
+}

--- a/src/app/compose/compose.component.scss
+++ b/src/app/compose/compose.component.scss
@@ -3,6 +3,25 @@
     border: 1px solid #949494;
     padding: 10px;
 }
+
+.draft-card {
+    margin-bottom: 20px;
+}
+
+.draft-title {
+    flex-grow: 1;
+    padding-left: 15px;
+    font-size: 24px;
+}
+
+.draft-actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: flex-end;
+    margin-right: 5px;
+}
+
 .draftPreview {
     max-height: 100px;
     overflow: hidden;
@@ -13,4 +32,46 @@
         -webkit-box-orient: vertical;
         overflow: hidden;
     }
+}
+
+mat-form-field {
+    width: 100%;
+}
+
+.dropzonehighlight {
+    border: #155d97 dashed 5px;
+    border-radius: 20px;
+    height: 100px;
+    text-align: center;
+    padding-top: 30px;
+}
+
+.overdropzone {
+    border: #5d9715 solid 5px;
+}
+
+#useHTML div.mat-checkbox-inner-container {
+    margin-right: 4px !important;
+}
+
+#sendMail .mat-icon {
+    font-size: 36px;
+}
+
+button {
+    float: right !important;
+}
+
+#dropZoneText {
+    margin: 10px 0;
+}
+
+#deleteAttachment {
+    height: 16px;
+    line-height: 16px;
+}
+
+#deleteAttachment mat-icon {
+    margin-top: -5px;
+    font-size: 20px;
 }

--- a/src/app/compose/draftdesk.component.html
+++ b/src/app/compose/draftdesk.component.html
@@ -1,6 +1,6 @@
-<div style="position: absolute; top: 64px; bottom: 0px; left: 0px; right: 0px; display: flex; flex-wrap: wrap; padding: 0 10px 10px 0;">
-    <compose [model]="draftModel" (draftDeleted)="draftDeleted($event)" #draft [style.width]="draft.editing ? '100%' : 'auto'" *ngFor="let draftModel of draftModelsInView"></compose>
-    <div *ngIf="hasMoreDrafts" style="width: 180px; height: 180px; text-align: center; padding-top: 80px">            
+<div class="draftdesk-container">
+    <compose [model]="draftModel" (draftDeleted)="draftDeleted($event)" #draft *ngFor="let draftModel of draftModelsInView"></compose>
+    <div *ngIf="hasMoreDrafts" class="has-more-drafts">            
         <button mat-icon-button mat-tooltip="Show more" (click)="showMore()" style="transform: scale(4,4);">
             <mat-icon>more_horiz</mat-icon>
         </button>        

--- a/src/app/compose/draftdesk.component.scss
+++ b/src/app/compose/draftdesk.component.scss
@@ -1,0 +1,15 @@
+.draftdesk-container {
+    position: absolute;
+    top: 64px;
+    bottom: 0px;
+    left: 0px;
+    right: 0px;
+    padding: 15px;
+}
+
+.more-drafts {
+    width: 180px;
+    height: 180px;
+    text-align: center;
+    padding-top: 80px;
+}

--- a/src/app/compose/draftdesk.component.ts
+++ b/src/app/compose/draftdesk.component.ts
@@ -29,7 +29,8 @@ const MAX_DRAFTS_IN_VIEW = 10;
 @Component({
     moduleId: 'angular2/app/compose/',
     templateUrl: 'draftdesk.component.html',
-    providers: [RecipientsService]
+    providers: [RecipientsService],
+    styleUrls: ['draftdesk.component.scss']
 })
 export class DraftDeskComponent implements OnInit, AfterViewInit {
     public draftModelsInView: DraftFormModel[];

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -800,24 +800,6 @@ mat-expansion-panel {
     padding: 0 10px 30px 10px !important;
 }
 
-    
-/* Draft Desk */
-
-compose {
-    margin: 10px 0 0 10px;
-}
-
-compose .draftPreview {
-    height: 150px;
-}
-
-#editDraftIcon {
-    height: 20px;
-    line-height: 20px;
-    vertical-align: top;
-}
-
-
 /* Compose */
 
 @media(min-width: 1025px) {


### PR DESCRIPTION
Overflow is hidden now, only 2 lines of the email are shown in the preview.
Removed blank spaces between the drafts and improved styling in general. Drafts now take up the entire width and the look throughout the page is more consistent.

Fixes: #508