### PR TITLE
fix(webmail): Make switching to the current folder a no-op

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -889,13 +889,17 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
   }
 
   private switchToFolder(folder: string): void {
-    let doResetColumns = false;
-    if (folder !== this.selectedFolder) {
-      this.clearSelection();
-      if (folder.startsWith('Sent') || this.selectedFolder.startsWith('Sent')) {
-        doResetColumns = true;
-      }
+    if (folder === this.selectedFolder) {
+        return;
     }
+
+    this.clearSelection();
+
+    let doResetColumns = false;
+    if (folder.startsWith('Sent') || this.selectedFolder.startsWith('Sent')) {
+      doResetColumns = true;
+    }
+
     this.selectedFolder = folder;
 
     this.messagelistservice.messagesInViewSubject


### PR DESCRIPTION
This fixes a bug where opening new messages
(which updates the URL fragment) would keep switching to the existing
folder and scrolling to the top of the message list each time.