### PR TITLE
fix(webmail): Only recount folder unread counts after content change

### DIFF
--- a/src/app/rmmapi/messagelist.service.ts
+++ b/src/app/rmmapi/messagelist.service.ts
@@ -218,6 +218,8 @@ export class MessageListService {
         if (hasChanges) {
             this.messagesInViewSubject.next(this.folderMessageLists[this.currentFolder]);
             this.refreshFolderList();
+            console.log('New/Moved messages, updating folder counts');
+            this.refreshFolderCounts();
         }
     }
 

--- a/src/app/xapian/searchservice.ts
+++ b/src/app/xapian/searchservice.ts
@@ -990,7 +990,6 @@ export class SearchService {
         console.error('Failed updating with new changes (will retry in 10 secs)', err);
       }
       this.notifyOnNewMessages = true;
-      this.messagelistservice.refreshFolderCounts();
       this.indexUpdateIntervalId = setTimeout(() => this.updateIndexWithNewChanges(), 10000);
     }
 


### PR DESCRIPTION
Should help with 10sec pauses/slow down when folders with large
contents exist.