### PR TITLE
fix(compose): Push draft action buttons further apart

### DIFF
--- a/src/app/compose/compose.component.html
+++ b/src/app/compose/compose.component.html
@@ -4,7 +4,10 @@
             {{model.subject ? model.subject : "New message"}}
         </div>
         <div class="draft-buttons">
-           <button *ngIf="editing" [disabled]="saved" mat-icon-button matTooltip="Save draft" id="saveDraft" (click)="submit()">
+            <button *ngIf="editing" mat-icon-button matTooltip="Attach files" id="attachDesktop" (click)="attachFilesClicked()">
+                <mat-icon>attachment</mat-icon>
+            </button>
+            <button *ngIf="editing" [disabled]="saved" mat-icon-button matTooltip="Save draft" id="saveDraft" (click)="submit()">
                 <mat-icon *ngIf="saved">cloud_done</mat-icon>
                 <mat-icon *ngIf="!saved && !saveErrorMessage">save</mat-icon>
                 <mat-icon *ngIf="!saved && saveErrorMessage" color="warn" [matTooltip]="saveErrorMessage">save</mat-icon>
@@ -15,7 +18,7 @@
             <button *ngIf="editing" mat-icon-button matTooltip="Close draft" id="closeDraft" (click)="close()">
                 <mat-icon>close</mat-icon>
             </button>
-            <button *ngIf="editing && isUnsaved" mat-icon-button matTooltip="Cancel draft" (click)="cancelDraft()">
+            <button *ngIf="editing && isUnsaved" mat-icon-button matTooltip="Cancel draft" id="cancelDraft" (click)="cancelDraft()">
                 <mat-icon>delete</mat-icon>
             </button>
             <button *ngIf="!editing" mat-icon-button (click)="editDraft()" matTooltip="Edit draft" id="editDraftIcon">
@@ -126,7 +129,7 @@
         <div [hidden]="!editing">
             <div class="draft-buttons">
                 <mat-checkbox *ngIf="editing" formControlName="useHTML" (change)="htmlToggled()" id="useHTML">HTML</mat-checkbox>    
-                <button *ngIf="editing" mat-icon-button matTooltip="Attach files" (click)="attachFilesClicked()">
+                <button *ngIf="editing" mat-icon-button matTooltip="Attach files" id="attachMobile" (click)="attachFilesClicked()">
                     <mat-icon>attachment</mat-icon>
                 </button>
                 <input #attachmentFileUploadInput type="file" [hidden]="true" multiple (change)="onFilesSelected($event)" />

--- a/src/app/compose/compose.component.scss
+++ b/src/app/compose/compose.component.scss
@@ -117,6 +117,12 @@ mat-form-field {
     justify-content: flex-end;
     flex-grow: 1;
 
+    button {
+        width: 50px;
+        display: flex;
+        justify-content: flex-end;
+    }
+
     #trashDraft { order: 1 }
     #closeDraft { order: 2 }
     #saveDraft { order: 3 }

--- a/src/app/compose/compose.component.scss
+++ b/src/app/compose/compose.component.scss
@@ -119,16 +119,35 @@ mat-form-field {
 
     button {
         width: 50px;
-        display: flex;
-        justify-content: flex-end;
     }
 
-    #trashDraft { order: 1 }
-    #closeDraft { order: 2 }
-    #saveDraft { order: 3 }
-    #sendMail { order: 4 }
-    #useHTML { flex-grow: 1 }
+    #attachDesktop { order: 1 }
+    #trashDraft { order: 2 }
+    #cancelDraft { order: 3 }
+    #closeDraft { order: 4 }
+    #saveDraft { order: 5 }
+    #sendMail { order: 6 }
+
+    @media only screen and (min-width: 769px) {
+        #attachMobile {
+            display: none;
+        }
+        #useHTML {
+            justify-content: flex-end;
+            padding: 5px 0;
+        }
+    }
+
+    @media only screen and (max-width: 768px) {
+        #attachDesktop {
+            display: none;
+        }
+        #useHTML {
+            flex-grow: 1;
+        }
+    }
 }
+
 .attachment { 
     padding-top: 5px;
     display: flex;


### PR DESCRIPTION
As discussed with @gtandersen in [pull/649](https://github.com/runbox/runbox7/pull/649).

Edit: And little fix for desktop, because the mobile positions didn't look well on a bigger screen.