### PR TITLE
fix(compose): From-specific reply-to addresses saved/stored if setup

### DIFF
--- a/src/app/compose/compose.component.ts
+++ b/src/app/compose/compose.component.ts
@@ -536,6 +536,9 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
         const from = this.draftDeskservice.froms.find(
             (f) => this.model.from === f.nameAndAddress);
 
+        if (from.reply_to !== null && from.reply_to.length > 0) {
+            this.model.reply_to = from.reply_to;
+        }
         if (send) {
             if (this.model.useHTML) {
                 // Replace RBWUL with ContentId
@@ -596,6 +599,7 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
                     msg_body: this.model.msg_body,
                     in_reply_to: this.model.in_reply_to,
                     reply_to_id: this.model.reply_to_id,
+                    reply_to: this.model.reply_to,
                     tags: [],
                     ctype: this.model.useHTML ? 'html' : null,
                     save: send ? 'Send' : 'Save',

--- a/src/app/compose/draftdesk.service.ts
+++ b/src/app/compose/draftdesk.service.ts
@@ -44,6 +44,7 @@ export class DraftFormModel {
     to: MailAddressInfo[] = [];
     cc: MailAddressInfo[] = [];
     bcc: MailAddressInfo[] = [];
+    reply_to: string = null;
     subject: string = null;
     msg_body = '';
     preview: string;

--- a/src/app/rmmapi/rbwebmail.ts
+++ b/src/app/rmmapi/rbwebmail.ts
@@ -488,6 +488,9 @@ export class RunboxWebmailAPI {
             if (draftModel.subject) {
                 params.append('subject', draftModel.subject);
             }
+            if (draftModel.reply_to) {
+                params.append('reply_to', draftModel.reply_to);
+            }
             if (draftModel.in_reply_to) {
                 params.append('in_reply_to', draftModel.in_reply_to);
             }


### PR DESCRIPTION
Sends the "reply_to" field for the chosen From (alias/identity) to the backend. However this seems to need a patch on the backend too, as the output isn't changed.

For #663 