### PR TITLE
fix(webmail): Redraw folders properly after new item completed.

### DIFF
--- a/src/app/folder/folderlist.component.html
+++ b/src/app/folder/folderlist.component.html
@@ -40,16 +40,24 @@
               {{node.folderName}}
         </div>
         <span *ngIf="folderMessageCounts | async as messageCounts">
+          <span *ngIf="messageCounts[node.folderPath] !== undefined">
             <span
                 *ngIf="messageCounts[node.folderPath].unread > 0"
                 [matBadge]="messageCounts[node.folderPath].unread"
                 matBadgeOverlap="true" class="newMessagesCount" matBadgeSize="medium">
                 &nbsp;
             </span>
+          </span>
+         
         </span>
 	    <span style="flex-grow: 1"></span>
         <span *ngIf="folderMessageCounts | async as messageCounts">
+          <span *ngIf="messageCounts[node.folderPath] !== undefined; else NoTotalCountYet">
             <span class="foldersidebarcount">{{ messageCounts[node.folderPath].total }}</span>
+          </span>
+          <ng-template #NoTotalCountYet>
+            <span class="foldersidebarcount">N/A</span>
+          </ng-template>
         </span>
         
         <ng-container [ngSwitch]="node.folderType">

--- a/src/app/mailviewer/singlemailviewer.component.ts
+++ b/src/app/mailviewer/singlemailviewer.component.ts
@@ -81,7 +81,7 @@ export class ShowHTMLDialogComponent {
 export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit {
   static rememberHTMLChosenForMessagesIds: { [messageId: number]: boolean } = {};
 
-  _messageId; // Message id or filename
+  _messageId = null; // Message id or filename
 
   // tslint:disable-next-line:no-output-on-prefix
   @Output() onClose: EventEmitter<string> = new EventEmitter();


### PR DESCRIPTION
 #670 

Discovered why folders don't redraw - messageCounts has content (we check that) but it doesnt know about the new folder yet. Added html to cover that possibility.

I *think* this works now, passes existing tests! Needs a chunk of manual poking (and maybe more tests designing) to see if I broke anything..