### PR TITLE
Webmail settings, disabling recipients list

### DIFF
--- a/src/app/app-settings.ts
+++ b/src/app/app-settings.ts
@@ -1,0 +1,28 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2020 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+export interface AppSettings {
+    showPopularRecipients: boolean;
+}
+
+export function defaultAppSettings(): AppSettings {
+    return {
+        showPopularRecipients: true,
+    };
+}

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -8,9 +8,28 @@
     <mat-nav-list dense>      
       <app-sidenav-menu (closeMenu)="sidemenu.close()"></app-sidenav-menu>
 
-      <div id="sidenavGreeting">
-        <p>Good {{timeOfDay}}, {{(rmmapi.me | async)?.user_address}}.</p>
-	<p id="sidenavGreetingContent"><a routerLink="/welcome" class="textLink">Welcome</a> to Runbox 7 (beta)! Please <a href="https://community.runbox.com/" target="forum" class="textLink">visit our forum</a> for help, suggestions, and more information.</p>
+      <mat-menu #settingsMenu="matMenu" xPosition="before">
+          <mat-list>
+              <mat-list-item>
+                <mat-checkbox
+                  [(ngModel)]="webmailSettings.showPopularRecipients"
+                  (change)="onSettingsChanged()"
+                  (click)="$event.stopPropagation()"
+                > Show popular recipients </mat-checkbox>
+              </mat-list-item>
+          </mat-list>
+      </mat-menu>
+
+      <div style="display: flex;">
+        <div id="sidenavGreeting">
+            <p>Good {{timeOfDay}}, {{(rmmapi.me | async)?.user_address}}.</p>
+            <p id="sidenavGreetingContent"><a routerLink="/welcome" class="textLink">Welcome</a> to Runbox 7 (beta)! Please <a href="https://community.runbox.com/" target="forum" class="textLink">visit our forum</a> for help, suggestions, and more information.</p>
+        </div>
+        <div>
+            <button mat-icon-button [matMenuTriggerFor]="settingsMenu">
+                <mat-icon> settings_applications </mat-icon>
+            </button>
+        </div>
       </div>
 
       <mat-divider></mat-divider>
@@ -36,6 +55,7 @@
     </mat-nav-list>
 
     <app-popular-recipients
+        [ngStyle]="{ 'display': webmailSettings.showPopularRecipients ? 'block' : 'none' }"
         (recipientClicked)="searchFor($event)"
     ></app-popular-recipients>
 

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -26,7 +26,7 @@
             <p id="sidenavGreetingContent"><a routerLink="/welcome" class="textLink">Welcome</a> to Runbox 7 (beta)! Please <a href="https://community.runbox.com/" target="forum" class="textLink">visit our forum</a> for help, suggestions, and more information.</p>
         </div>
         <div>
-            <button mat-icon-button [matMenuTriggerFor]="settingsMenu">
+            <button mat-icon-button [matMenuTriggerFor]="settingsMenu" matTooltip="Show webmail settings">
                 <mat-icon> settings_applications </mat-icon>
             </button>
         </div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -57,7 +57,9 @@ import { ProgressService } from './http/progress.service';
 import { RMM } from './rmm';
 import { environment } from '../environments/environment';
 import { LogoutService } from './login/logout.service';
-import {Hotkey, HotkeysService} from 'angular2-hotkeys';
+import { Hotkey, HotkeysService } from 'angular2-hotkeys';
+import { StorageService } from './storage.service';
+import { AppSettings, defaultAppSettings } from './app-settings';
 
 const LOCAL_STORAGE_SETTING_MAILVIEWER_ON_RIGHT_SIDE_IF_MOBILE = 'mailViewerOnRightSideIfMobile';
 const LOCAL_STORAGE_SETTING_MAILVIEWER_ON_RIGHT_SIDE = 'mailViewerOnRightSide';
@@ -113,6 +115,8 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
   mailViewerRightSideWidth = '40%';
   allowMailViewerOrientationChange = true;
 
+  webmailSettings: AppSettings = defaultAppSettings();
+
   buildtimestampstring = BUILD_TIMESTAMP;
 
   @ViewChild(SingleMailViewerComponent) singlemailviewer: SingleMailViewerComponent;
@@ -158,7 +162,8 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     changeDetectorRef: ChangeDetectorRef,
     public mobileQuery: MobileQueryService,
     private swPush: SwPush,
-    private hotkeysService: HotkeysService
+    private hotkeysService: HotkeysService,
+    private storageService: StorageService,
   ) {
     this.hotkeysService.add(
         new Hotkey(['j', 'k'],
@@ -244,6 +249,10 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
               .getItem(LOCAL_STORAGE_SETTING_MAILVIEWER_ON_RIGHT_SIDE_IF_MOBILE) === `${true}`;
       }
     };
+
+    this.storageService.getSubject('webmailSettings').pipe(filter(s => s)).subscribe(
+      settings => this.webmailSettings = settings
+    );
 
     this.mobileQuery.addListener(this.mobileQueryListener);
     this.updateTime();
@@ -1112,6 +1121,10 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
       fragment += `:${this.singlemailviewer.messageId}`;
     }
     this.router.navigate(['/'], { fragment });
+  }
+
+  public onSettingsChanged(): void {
+    this.storageService.set('webmailSettings', this.webmailSettings);
   }
 }
 

--- a/src/app/compose/compose.component.html
+++ b/src/app/compose/compose.component.html
@@ -62,7 +62,10 @@
                 id="buttonBCC"
             > BCC </button>
         </div>
-        <div class="recipientSuggestionContainer" *ngIf="suggestedRecipients.length > 0 && editing">
+        <div class="recipientSuggestionContainer"
+           [ngStyle]="{ 'display': webmailSettings.showPopularRecipients ? 'block' : 'none' }"
+           *ngIf="suggestedRecipients.length > 0 && editing"
+        >
             <span>Recently used</span>
             <div class="recipientSuggestionList">
                 <div *ngFor="let recipient of filteredSuggestions" class="suggestionItem">

--- a/src/app/compose/compose.component.ts
+++ b/src/app/compose/compose.component.ts
@@ -31,12 +31,14 @@ import { DraftDeskService, DraftFormModel } from './draftdesk.service';
 import { HttpClient, HttpEventType, HttpHeaders, HttpRequest } from '@angular/common/http';
 
 import { FormGroup, FormBuilder } from '@angular/forms';
-import { debounceTime, mergeMap } from 'rxjs/operators';
+import { debounceTime, mergeMap, filter } from 'rxjs/operators';
 import { DialogService } from '../dialog/dialog.service';
 import { TinyMCEPlugin } from '../rmm/plugin/tinymce.plugin';
 import { RecipientsService } from './recipients.service';
 import { isValidEmailArray } from './emailvalidator';
 import { MailAddressInfo } from '../common/mailaddressinfo';
+import { AppSettings, defaultAppSettings } from '../app-settings';
+import { StorageService } from '../storage.service';
 
 declare const tinymce: any;
 declare const MailParser;
@@ -83,6 +85,7 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
     // to not include the recipients already picked
     filteredSuggestions: MailAddressInfo[] = [];
 
+    webmailSettings: AppSettings = defaultAppSettings();
 
     public formGroup: FormGroup;
 
@@ -98,6 +101,7 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
         private location: Location,
         private dialogService: DialogService,
         recipientservice: RecipientsService,
+        private storageService: StorageService,
     ) {
         this.tinymce_plugin = new TinyMCEPlugin();
         this.editorId = 'tinymceinstance_' + (ComposeComponent.tinymceinstancecount++);
@@ -106,6 +110,10 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
             this.suggestedRecipients = suggestions;
             this.updateSuggestions();
         });
+
+        this.storageService.getSubject('webmailSettings').pipe(filter(s => s)).subscribe(
+            settings => this.webmailSettings = settings
+        );
     }
 
     ngOnInit() {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -518,7 +518,7 @@ mat-sidenav-container {
 }
 
 #sidenavGreeting {
-    margin: 10px;
+    margin-left: 10px;
 }
 
 #sidenavGreeting p {


### PR DESCRIPTION
Looks like this (when opened):

![2020-07-21-132559_327x128_scrot](https://user-images.githubusercontent.com/86378/88049727-e69e1580-cb55-11ea-88e6-45e7d8d588ec.png)

We could eventually add more things to it (maybe index synchronization as well?), and also expose the same thing as a full-page settings editor, with detailed explanations and such.