### PR TITLE
feat(webmail): Show folder count for drafts

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -30,6 +30,8 @@
       <mat-list-item (click)="drafts()" id="draftsButton" [ngClass]="{'selectedFolder' : selectedFolder == 'Drafts'}">
         <mat-icon mat-list-icon class="folderIconStandard">drafts</mat-icon>
         <p mat-line class="folderName">Drafts</p>
+        <span style="flex-grow: 1"></span>
+        <span class="foldersidebarcount" style="margin-right: 24px"> {{ draftDeskService.draftModels.length }} </span>
       </mat-list-item>
 
       <mat-divider></mat-divider>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -153,7 +153,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     private ngZone: NgZone,
     public logoutservice: LogoutService,
     public websocketsearchservice: WebSocketSearchService,
-    private draftDeskService: DraftDeskService,
+    public draftDeskService: DraftDeskService,
     public messagelistservice: MessageListService,
     changeDetectorRef: ChangeDetectorRef,
     public mobileQuery: MobileQueryService,


### PR DESCRIPTION
Fixes GH-647.

Looks like this:

![2020-07-21-162741_660x300_scrot](https://user-images.githubusercontent.com/86378/88067448-4bb23500-cb6f-11ea-8e96-35db40397f94.png)

Not super-happy about the hardcoded margin, but I don't see how else to do it nicely, save for maybe fooling it with an invisible button after it ;)