### PR TITLE
Side-nav menu styles fix: contacts and calendar

### DIFF
--- a/src/app/calendar-app/calendar-app.component.html
+++ b/src/app/calendar-app/calendar-app.component.html
@@ -111,44 +111,46 @@
         <mat-nav-list dense>
             <app-sidenav-menu (closeMenu)="sideMenu.close()"></app-sidenav-menu>
 
-            <mat-divider></mat-divider>
-
             <div class="sidenavSubMenu" *ngIf="mobileQuery.matches">
                 <ng-container *ngTemplateOutlet="viewModeButtons"></ng-container>
             </div>
 
-            <mat-list-item>
-                <button id="addEventButton" mat-button (click)="addEvent()">
-                    <mat-icon>add</mat-icon> Add event
-                </button>
+            <mat-list-item id="addEventButton" mat-button (click)="addEvent()" class="calendarMenuButton">
+                <mat-icon mat-list-icon>add</mat-icon>
+                <p mat-line>Add event</p>
             </mat-list-item>
-            <mat-list-item>
+
+            <mat-list-item (click)="importEventClicked()" class="calendarMenuButton">
                 <input #icsUploadInput type="file" [hidden]="true" multiple (change)="onIcsUploaded($event)" />
-                <button mat-button (click)="importEventClicked()">
-                    <mat-icon>import_export</mat-icon> Import event
-                </button>
+                <mat-icon mat-list-icon>import_export</mat-icon>
+                <p mat-line>Import event</p>
             </mat-list-item>
-            <mat-list-item>
-                <button mat-button (click)="openSettings()">
-                    <mat-icon>settings</mat-icon> Settings
-                </button>
+
+            <mat-list-item mat-button (click)="openSettings()" class="calendarMenuButton">
+                <mat-icon mat-list-icon>settings</mat-icon>
+                <p mat-line>Settings</p>
             </mat-list-item>
-            <mat-list-item>
-                <h4> Calendars </h4>
-                <button mat-icon-button (click)="showAddCalendarDialog()">
-                    <mat-icon> add </mat-icon>
+
+            <mat-divider></mat-divider>
+
+            <div class="calendarsSideHeader">
+                <span>Calendars</span>
+                <button mat-icon-button id="createCalendarButton" matTooltip="New calendar..." (click)="showAddCalendarDialog()">
+                    <mat-icon>add</mat-icon>
                 </button>
-            </mat-list-item>
+            </div>
+
             <mat-list-item *ngIf="calendars.length === 0">
                 Loading calendars...
             </mat-list-item>
+
             <mat-list-item class="calendarListItem" *ngFor="let calendar of calendars">
-                <mat-icon class="calendarColorLabel" [ngStyle]="{ 'color': calendar.color || '#1e90ff' }">
+                <mat-icon mat-list-icon class="calendarColorLabel" [ngStyle]="{ 'color': calendar.color || '#1e90ff' }">
                     label
                 </mat-icon>
-                <button mat-button>
+                <p mat-line>
                     {{ calendar.displayname || calendar.id }}
-                </button>
+                </p>
                 <button mat-icon-button class="calendarToggleButton"
                     matTooltip="Show/hide this calendar"
                     (click)="toggleCalendar(calendar.id)"
@@ -165,25 +167,23 @@
 
             <mat-divider></mat-divider>
 
-            <mat-list-item>
-                <button mat-button
-                    (click)="calendarservice.syncCaldav(true)"
-                >
-                    <mat-icon mat-list-icon> refresh </mat-icon> Synchronize calendars
-                </button>
+            <mat-list-item (click)="calendarservice.syncCaldav(true)" class="calendarMenuButton">
+                <mat-icon mat-list-icon>refresh</mat-icon> 
+                <p mat-line>Synchronize calendars</p>
             </mat-list-item>
 
-            <mat-list-item *ngIf="calendarservice.lastUpdate">
+            <mat-list-item *ngIf="calendarservice.lastUpdate" class="updateInfo">
                 Last update: {{ calendarservice.lastUpdate.fromNow() }}
             </mat-list-item>
 
             <mat-divider></mat-divider>
 
-            <mat-list-item *ngFor="let activity of activityList" style="display: flex;">
+            <mat-list-item *ngFor="let activity of activityList" style="display: flex;" class="updateInfo">
                 <mat-spinner diameter="15"></mat-spinner> {{ activity }}
             </mat-list-item>
         </mat-nav-list>
     </mat-sidenav>
+
     <mat-sidenav-content>
         <mat-toolbar>
             <button mat-icon-button (click)="sidemenu.toggle()">

--- a/src/app/calendar-app/calendar-app.component.scss
+++ b/src/app/calendar-app/calendar-app.component.scss
@@ -1,0 +1,33 @@
+.calendarsSideHeader {
+    font-weight: bold;
+    display: flex;
+    align-items: center;
+
+    span {
+        padding: 16px;
+        flex-grow: 1;
+    }
+}
+
+.calendarMenuButton {
+    mat-icon {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        font-size: 24px !important;
+    }
+}
+
+.updateInfo {
+    &:hover {
+        background-color: #fff;
+        cursor: default;
+    }
+}
+
+#addCalendarButton {
+    font-weight: bold !important;
+    p {
+        padding: 16px;
+    }
+}

--- a/src/app/calendar-app/calendar-app.component.ts
+++ b/src/app/calendar-app/calendar-app.component.ts
@@ -68,6 +68,7 @@ import '../sentry';
 @Component({
     selector: 'app-calendar-app-component',
     templateUrl: './calendar-app.component.html',
+    styleUrls: ['calendar-app.component.scss'],
     providers: [
         { provide: CalendarEventTitleFormatter, useClass: EventTitleFormatter }
     ],

--- a/src/app/contacts-app/contacts-app.component.css
+++ b/src/app/contacts-app/contacts-app.component.css
@@ -1,4 +1,0 @@
-.contactListControls {
-    height: 60px !important;
-    padding-top: 10px !important;
-}

--- a/src/app/contacts-app/contacts-app.component.html
+++ b/src/app/contacts-app/contacts-app.component.html
@@ -7,32 +7,35 @@
         id="sideMenu"
         style="width: 330px"
     >
-        <app-sidenav-menu (closeMenu)="sideMenu.close()"></app-sidenav-menu>
         <mat-nav-list dense>
-            <mat-list-item>
-                <button mat-button routerLink="/contacts/new">
-                    <mat-icon> person_add </mat-icon> New contact
-                </button>
-            </mat-list-item>
-            <mat-list-item>
-                <button mat-button routerLink="/contacts/new_group">
-                    <mat-icon> group_add </mat-icon> New group
-                </button>
-            </mat-list-item>
-            <mat-list-item>
-                <input #vcfUploadInput type="file" [hidden]="true" multiple (change)="onVcfUploaded($event)" />
-                <button mat-button (click)="importVcfClicked()">
-                    <mat-icon>import_export</mat-icon> Import contacts
-                </button>
-            </mat-list-item>
-            <mat-list-item>
-                <a mat-button routerLink="/contacts/settings">
-                    <mat-icon> settings </mat-icon> Settings
-                </a>
+            <app-sidenav-menu (closeMenu)="sideMenu.close()"></app-sidenav-menu>
+
+            <mat-list-item routerLink="/contacts/new" class="contactListButton">
+                <mat-icon mat-list-icon>person_add</mat-icon>
+                <p mat-line>New contact</p>
             </mat-list-item>
 
-            <mat-list-item  class="contactListControls">
-                <mat-form-field>
+            <mat-list-item routerLink="/contacts/new_group" class="contactListButton">
+                <mat-icon mat-list-icon>group_add</mat-icon>
+                <p mat-line>New group</p>
+            </mat-list-item>
+
+            <mat-list-item (click)="importVcfClicked()" class="contactListButton">
+                <input #vcfUploadInput type="file" [hidden]="true" multiple (change)="onVcfUploaded($event)" />
+                <mat-icon mat-list-icon>import_export</mat-icon>
+                <p mat-line>Import contacts</p>
+            </mat-list-item>
+
+            <mat-list-item routerLink="/contacts/settings" class="contactListButton">
+                <mat-icon mat-list-icon>settings</mat-icon>
+                <p mat-line>Settings</p>
+            </mat-list-item>
+
+            <mat-divider></mat-divider>
+
+            <mat-list>
+            <mat-list-item class="contactListControls">
+                <mat-form-field mat-line>
                     <mat-label> Show categories </mat-label>
                     <mat-select [(value)]="categoryFilter" (selectionChange)="filterContacts()">
                         <mat-option value="RUNBOX:ALL">
@@ -49,7 +52,7 @@
             </mat-list-item>
 
             <mat-list-item class="contactListControls">
-                <mat-form-field>
+                <mat-form-field mat-line>
                     <mat-label> Sort by </mat-label>
                     <mat-select [(value)]="sortMethod" (selectionChange)="sortContacts()">
                         <mat-option value="firstname+"> First name, ascending  </mat-option>
@@ -61,7 +64,7 @@
             </mat-list-item>
 
             <mat-list-item class="contactListControls">
-                <mat-form-field>
+                <mat-form-field mat-line>
                     <mat-label> Search </mat-label>
                     <input matInput [(ngModel)]="searchTerm" (input)="filterContacts()">
                     <button mat-button *ngIf="searchTerm" matSuffix mat-icon-button aria-label="Clear" (click)="searchTerm=''; filterContacts()">
@@ -77,18 +80,21 @@
             </mat-list-item>
             -->
 
-            <mat-list-item>
-                <mat-checkbox
-                    [(ngModel)]="selectingMultiple"
-                    (change)="onSelectMultipleChange()"
-                >
-                Select multiple
-                </mat-checkbox>
+                <mat-list-item>
+                    <mat-checkbox mat-line
+                        [(ngModel)]="selectingMultiple"
+                        (change)="onSelectMultipleChange()"
+                    >
+                    Select multiple
+                    </mat-checkbox>
+                </mat-list-item>
 
-                <button mat-button *ngIf="selectingMultiple" (click)="selectAll()">
-                    Select all visible
-                </button>
-            </mat-list-item>
+                <mat-list-item mat-line mat-button *ngIf="selectingMultiple" (click)="selectAll()">
+                    <mat-checkbox mat-line>
+                        Select all visible
+                    </mat-checkbox>
+                </mat-list-item>
+            </mat-list>
 
             <mat-list-item *ngFor="let contact of shownContacts" (dragstart)="dragStarted($event, contact)">
                 <mat-checkbox

--- a/src/app/contacts-app/contacts-app.component.scss
+++ b/src/app/contacts-app/contacts-app.component.scss
@@ -1,0 +1,22 @@
+.contactListControls {
+    height: 60px !important;
+    padding-top: 10px !important;
+
+    &:hover {
+        background-color: #fff;
+        cursor: default;
+    }
+
+    &:active {
+        background-color: #fff;
+    }
+}
+
+.contactListButton {
+    mat-icon {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        font-size: 24px !important;
+    }
+}

--- a/src/app/contacts-app/contacts-app.component.ts
+++ b/src/app/contacts-app/contacts-app.component.ts
@@ -36,7 +36,7 @@ import { v4 as uuidv4 } from 'uuid';
     moduleId: 'angular2/app/contacts-app/',
     // tslint:disable-next-line:component-selector
     selector: 'contacts-app-root',
-    styleUrls: ['./contacts-app.component.css'],
+    styleUrls: ['./contacts-app.component.scss'],
     templateUrl: './contacts-app.component.html'
 })
 export class ContactsAppComponent {


### PR DESCRIPTION
For more consistent look throughout the app Webmail, Contacts and Calendar now have the same styling of the side pane menu.

<img src="https://user-images.githubusercontent.com/24294620/88075016-81a7e700-cb78-11ea-8d48-6598f04bb7ea.png" width=300> <img src="https://user-images.githubusercontent.com/24294620/88075012-8076ba00-cb78-11ea-8754-28108f04d943.png" width=300>