### PR TITLE
fix(webmail): Fix switching folders not working in some cases

### DIFF
--- a/e2e/cypress/integration/folder-switching.ts
+++ b/e2e/cypress/integration/folder-switching.ts
@@ -1,0 +1,36 @@
+/// <reference types="cypress" />
+
+describe('Switching between folders (and not-folders)', () => {
+
+    function goToInbox() {
+        cy.get('rmm-folderlist mat-tree-node:contains(Inbox)').click();
+        cy.url().should('be', '/#Inbox');
+        cy.get('rmm-folderlist mat-tree-node:contains(Inbox)').should('have.class', 'selectedFolder');
+    }
+
+    it('can switch from welcome to inbox', () => {
+        localStorage.setItem('localSearchPromptDisplayed221', 'true');
+
+        // start of on /welcome, like a fresh new user
+        cy.visit('/welcome');
+
+        // should be able to switch to inbox...
+        goToInbox();
+
+        // then to compose...
+        cy.get('#composeButton').click();
+        cy.url().should('be', '/compose?new=true');
+        cy.get('#composeButton').should('have.class', 'selectedFolder');
+
+        // then back to inbox...
+        goToInbox();
+
+        // then to drafts...
+        cy.get('#draftsButton').click();
+        cy.url().should('be', '/compose');
+        cy.get('#draftsButton').should('have.class', 'selectedFolder');
+
+        // and back to inbox...
+        goToInbox();
+    });
+})

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -22,12 +22,12 @@
           <mat-icon color="primary">drafts</mat-icon></a>
       </div>
 
-      <mat-list-item (click)="compose();" id="composeButton">
+      <mat-list-item (click)="compose();" id="composeButton" [ngClass]="{'selectedFolder' : composeSelected}">
         <mat-icon mat-list-icon class="folderIconStandard">edit</mat-icon>
         <p mat-line class="folderName">Compose</p>
       </mat-list-item>
 
-      <mat-list-item (click)="drafts()" id="draftsButton" [ngClass]="{'selectedFolder' : selectedFolder == 'Drafts'}">
+      <mat-list-item (click)="drafts()" id="draftsButton" [ngClass]="{'selectedFolder' : draftsSelected}">
         <mat-icon mat-list-icon class="folderIconStandard">drafts</mat-icon>
         <p mat-line class="folderName">Drafts</p>
         <span style="flex-grow: 1"></span>
@@ -46,6 +46,7 @@
     <rmm-folderlist #folderListComponent
         [folders]="displayedFolders"
         [folderMessageCounts]="messagelistservice.folderMessageCountSubject"
+        [selectedFolder]="selectedFolder"
         (folderSelected)="selectFolder($event)"
         (droppedToFolder)="dropToFolder($event)"
         (emptyTrash)="emptyTrash($event)"
@@ -262,7 +263,7 @@
           <mat-icon>report_off</mat-icon>
       </button>
     </div>
-  <router-outlet (activate)="hasChildRouterOutlet=true" (deactivate)="hasChildRouterOutlet=false"></router-outlet>
+  <router-outlet (activate)="childRouteActivated(true)" (deactivate)="childRouteActivated(false)"></router-outlet>
 </mat-sidenav-container>
 
 <div style="position: absolute; bottom: 2px; right: 2px; z-index: 10000;"

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -30,7 +30,7 @@ import { MatIconRegistry } from '@angular/material/icon';
 import { MatSidenav } from '@angular/material/sidenav';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MoveMessageDialogComponent } from './actions/movemessage.action';
-import { Router, RouterOutlet, ActivatedRoute } from '@angular/router';
+import { Router, RouterOutlet, ActivatedRoute, NavigationEnd } from '@angular/router';
 import { DomSanitizer } from '@angular/platform-browser';
 import { HttpClient } from '@angular/common/http';
 import { MessageTableRow, MessageTableRowTool } from './messagetable/messagetablerow';
@@ -94,6 +94,8 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
 
   displayedFolders = new Observable<FolderListEntry[]>();
   selectedFolder = 'Inbox';
+  composeSelected: boolean;
+  draftsSelected: boolean;
 
   timeOfDay: string;
 
@@ -356,6 +358,13 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
         }
       }
     );
+
+    this.router.events.pipe(
+      filter(e => e instanceof NavigationEnd)
+    ).subscribe((event: NavigationEnd) => {
+      this.composeSelected = this.router.url === '/compose?new=true';
+      this.draftsSelected = this.router.url === '/compose';
+    });
 
     // Download visible messages in the background
     this.canvastable.repaintDoneSubject.pipe(
@@ -784,6 +793,13 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
 
   }
 
+  public childRouteActivated(yes: boolean): void {
+    this.hasChildRouterOutlet = yes;
+    if (yes) {
+      this.selectedFolder = null;
+    }
+  }
+
   public downloadIndexFromServer() {
     this.searchService.downloadIndexFromServer().subscribe((res) => {
       if (res) {
@@ -894,7 +910,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     this.clearSelection();
 
     let doResetColumns = false;
-    if (folder.startsWith('Sent') || this.selectedFolder.startsWith('Sent')) {
+    if (folder.startsWith('Sent') || this.selectedFolder?.startsWith('Sent')) {
       doResetColumns = true;
     }
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -770,6 +770,10 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
   }
 
   searchFor(text) {
+    if (!this.selectedFolder) {
+        // resetSearch=false, to make sure selectFolder doesn't call us back
+        this.selectFolder('Inbox', false);
+    }
     if (text !== this.searchText) {
       this.searchText = text;
       if (this.usewebsocketsearch) {
@@ -892,12 +896,14 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     }
   }
 
-  selectFolder(folder: string): void {
+  selectFolder(folder: string, resetSearch = true): void {
     if (this.mobileQuery.matches && this.sidemenu.opened) {
       this.sidemenu.close();
     }
     this.singlemailviewer.close();
-    this.searchFor('');
+    if (resetSearch) {
+      this.searchFor('');
+    }
     this.switchToFolder(folder);
     this.updateUrlFragment();
   }

--- a/src/app/folder/folderlist.component.spec.ts
+++ b/src/app/folder/folderlist.component.spec.ts
@@ -61,6 +61,7 @@ describe('FolderListComponent', () => {
 
     it('folderReorderingDrop', async () => {
         const comp = new FolderListComponent(null, hotkeyMock);
+        comp.selectedFolder = 'Inbox';
         comp.folders = new BehaviorSubject([
             new FolderListEntry(1, 50, 40, 'inbox', 'folder1', 'folder2', 0),
             new FolderListEntry(2, 50, 40, 'user', 'folder2', 'folder2', 0),
@@ -232,6 +233,7 @@ describe('FolderListComponent', () => {
 
     it('should create new folder in root', async () => {
         const comp = new FolderListComponent(dialog, hotkeyMock);
+        comp.selectedFolder = 'Inbox';
         const folders = [
             new FolderListEntry(1, 50, 40, 'inbox', 'folder1', 'folder2', 0),
             new FolderListEntry(2, 50, 40, 'user', 'folder2', 'folder2', 0),

--- a/src/app/folder/folderlist.component.ts
+++ b/src/app/folder/folderlist.component.ts
@@ -66,8 +66,6 @@ export class RenameFolderEvent {
     styleUrls: ['folderlist.component.css']
 })
 export class FolderListComponent implements OnChanges {
-    selectedFolder = 'Inbox';
-
     dropFolderId: number;
     dropPosition = DropPosition;
     dropAboveOrBelowOrInside: DropPosition = DropPosition.NONE;
@@ -75,6 +73,7 @@ export class FolderListComponent implements OnChanges {
 
     @Input() folders: Observable<FolderListEntry[]>;
     @Input() folderMessageCounts: Observable<FolderMessageCountMap>;
+    @Input() selectedFolder: string;
 
     @Output() droppedToFolder = new EventEmitter<number>();
     @Output() folderSelected  = new EventEmitter<string>();
@@ -99,12 +98,10 @@ export class FolderListComponent implements OnChanges {
             new Hotkey(['g+i', 'g+t'],
             (event: KeyboardEvent, combo: string): ExtendedKeyboardEvent => {
                 if (combo === 'g+i') {
-                    this.clearSelection();
                     this.selectFolder('Inbox');
                     combo = null;
                 }
                 if (combo === 'g+t') {
-                    this.clearSelection();
                     this.selectFolder('Sent');
                     combo = null;
                 }
@@ -261,14 +258,7 @@ export class FolderListComponent implements OnChanges {
         this.dropAboveOrBelowOrInside = DropPosition.NONE;
     }
 
-    clearSelection() {
-        this.selectedFolder = null;
-    }
-
     selectFolder(folder: string): void {
-        if (folder !== this.selectedFolder) {
-            this.selectedFolder = folder;
-        }
         this.folderSelected.next(folder);
     }
 


### PR DESCRIPTION
This includes things like going Inbox->Drafts->Inbox, /welcome->Inbox
and probably a few others. Also makes the selected section actually
hilight correctly, even if it's not a proper folder.