### PR TITLE
feat(app): Speed up the way sidemenu appears on the webmail page

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,5 +1,7 @@
 <mat-sidenav-container autosize>
-  <mat-sidenav #sidemenu [mode]="mobileQuery.matches ? 'over' : 'side'"
+  <mat-sidenav #sidemenu
+      [opened]="sideMenuOpened"
+      [mode]="mobileQuery.matches ? 'over' : 'side'"
       [fixedInViewport]="mobileQuery.matches"
       fixedTopGap="0"
       id="sideMenu"


### PR DESCRIPTION
This brings its behaviour in sync with contacts and calendar – sidepane being visible instantly (if in desktop), and still responsive.

The price we way is the animation of the sidemenu sliding in – which may be seen as nice or unnecessary, depending on your point of view (and the performance of your computer). To be discussed, @gtandersen @davidbowdley.