### PR TITLE
feat(webmail): Always show popular recipients component if enabled, even with no local index

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -73,7 +73,11 @@
     <app-popular-recipients
         [ngStyle]="{ 'display': settingsService.settings.showPopularRecipients ? 'block' : 'none' }"
         (recipientClicked)="searchFor($event)"
-    ></app-popular-recipients>
+    >
+        <mat-list-item *ngIf="!dataReady" (click)="downloadIndexFromServer()">
+            Synchronize index in order to use this feature
+        </mat-list-item>
+    </app-popular-recipients>
 
     <mat-divider></mat-divider>
 

--- a/src/app/popular-recipients/popular-recipients.component.html
+++ b/src/app/popular-recipients/popular-recipients.component.html
@@ -1,13 +1,12 @@
-<mat-expansion-panel
-    [expanded]="expanded"
-    [ngStyle]="{'display': recipients.length ? 'block' : 'none'}"
->
+<mat-expansion-panel [expanded]="expanded" >
     <mat-expansion-panel-header>
         <mat-icon> contact_mail </mat-icon>
         <span class="headerText"> Popular recipients </span>
     </mat-expansion-panel-header>
 
     <mat-nav-list dense>
+        <ng-content></ng-content>
+
         <mat-list-item *ngFor="let recipient of recipients"
             (click)="recipientClicked.emit(recipient.address)"
         >


### PR DESCRIPTION
It now shows a hint, in a form of a button, informing the user about how to make it work:

![image](https://user-images.githubusercontent.com/86378/90280412-2dd4a900-de6b-11ea-87c6-06cadd237047.png)

The button is clickable and does actually synchronize the index as expected.

Fixes GH-700