### PR TITLE
feat(login): Set inputmode to show email and numeric keyboards on mobile as appropriate

### DIFF
--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -23,7 +23,7 @@
           <img src="assets/runbox7_blue_dark.png" id="logoLogin" alt="Runbox 7" />
 	</div>
 	<mat-form-field>
-          <input matInput placeholder="Username" name="username" autofocus ngModel />
+          <input matInput placeholder="Username" name="username" type="email" inputmode="email" autofocus ngModel />
 	</mat-form-field>
 	<mat-form-field>
           <input matInput placeholder="Password" type="password" name="password" ngModel />
@@ -68,7 +68,7 @@
               <p>Please enter your TOTP code.</p>
               <br />
               <mat-form-field>
-		<input matInput placeholder="Timed one-time password" name="totp" id="totp"  ngModel />
+		<input matInput placeholder="Timed one-time password" name="totp" id="totp" inputmode="numeric" ngModel />
               </mat-form-field>
 	      <button mat-raised-button color="primary" type="submit">Log in</button>
 	      <br />
@@ -78,7 +78,7 @@
               <p>Please enter your OTP code.</p>
               <br />
               <mat-form-field>
-		<input matInput placeholder="One-time password" name="otp" id="otp" ngModel />
+		<input matInput placeholder="One-time password" name="otp" id="otp" inputmode="numeric" ngModel />
               </mat-form-field>
 	      <button mat-raised-button color="primary" type="submit">Log in</button>
 	      <br />


### PR DESCRIPTION
Closes https://github.com/runbox/runbox7/issues/705 & https://github.com/runbox/runbox7/issues/706.

I've opted to set just `inputmode` on the number inputs, rather than `type="number"` as well, as this has accessibility problems (among others). See https://technology.blog.gov.uk/2020/02/24/why-the-gov-uk-design-system-team-changed-the-input-type-for-numbers/.

Although I followed [CONTRIBUTING.md](https://github.com/runbox/runbox7/blob/master/CONTRIBUTING.md), I've not updated the changelog as it appears this hasn't been done in some time, so doing so would have included a lot of unrelated entries. Let me know if I should have still updated it.