### PR TITLE
fix(compose): Set focus in textarea for replies

### DIFF
--- a/src/app/compose/compose.component.ts
+++ b/src/app/compose/compose.component.ts
@@ -138,6 +138,12 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
             if (this.model.bcc.length > 0) {
                 this.hasBCC = true;
             }
+            if (this.model.replying) {
+                setTimeout(() => {
+                    this.messageTextArea.nativeElement.setSelectionRange(0, 0);
+                    this.messageTextArea.nativeElement.focus();
+                });
+            }
         } else {
             this.rmmapi.getMessageContents(this.model.mid).subscribe(msgObj =>
                 this.model.preview = msgObj.text.text ? DraftFormModel.trimmedPreview(msgObj.text.text) : ''

--- a/src/app/compose/draftdesk.service.ts
+++ b/src/app/compose/draftdesk.service.ts
@@ -50,6 +50,7 @@ export class DraftFormModel {
     preview: string;
     in_reply_to: string;
     reply_to_id: string = null;
+    replying = false;
     tags: string;
     useHTML = false;
     save = 'Save';
@@ -75,6 +76,7 @@ export class DraftFormModel {
         const ret = new DraftFormModel();
         ret.reply_to_id = mailObj.mid;
         ret.in_reply_to = mailObj.headers['message-id'];
+        ret.replying = true;
 
         // list of MailAddressInfo objects:
         // sender always used for body string


### PR DESCRIPTION
Cursor is put at the beginning of the textarea when replying to an email.

Issue: #731 