### PR TITLE
Lint fixes

### DIFF
--- a/src/app/account-app/account-app.module.ts
+++ b/src/app/account-app/account-app.module.ts
@@ -17,7 +17,6 @@
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
 
-import { CommonModule } from '@angular/common';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { NgModule, ErrorHandler } from '@angular/core';
 import { MenuModule } from '../menu/menu.module';

--- a/src/app/account-app/account-upgrades.component.ts
+++ b/src/app/account-app/account-upgrades.component.ts
@@ -24,7 +24,6 @@ import { CartService } from './cart.service';
 import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
 import { PaymentsService } from './payments.service';
 import { Product } from './product';
-import { ProductOrder } from './product-order';
 import { AsyncSubject } from 'rxjs';
 
 @Component({

--- a/src/app/account-app/bitpay-payment-dialog.component.ts
+++ b/src/app/account-app/bitpay-payment-dialog.component.ts
@@ -18,12 +18,9 @@
 // ---------- END RUNBOX LICENSE ----------
 
 import { Component, Inject } from '@angular/core';
-import { Router } from '@angular/router';
-import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { HttpErrorResponse } from '@angular/common/http';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 
 import { CartService } from './cart.service';
-import { PaymentsService } from './payments.service';
 import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
 
 @Component({
@@ -41,10 +38,7 @@ export class BitpayPaymentDialogComponent {
 
     constructor(
         private cart: CartService,
-        private dialog: MatDialog,
         private rmmapi: RunboxWebmailAPI,
-        private paymentsservice: PaymentsService,
-        private router: Router,
         public dialogRef: MatDialogRef<BitpayPaymentDialogComponent>,
         @Inject(MAT_DIALOG_DATA) public data: any
     ) {

--- a/src/app/account-app/cart.service.spec.ts
+++ b/src/app/account-app/cart.service.spec.ts
@@ -20,7 +20,7 @@
 import { CartService } from './cart.service';
 import { ProductOrder } from './product-order';
 import { StorageService } from '../storage.service';
-import { RunboxWebmailAPI, RunboxMe } from '../rmmapi/rbwebmail';
+import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
 import { of } from 'rxjs';
 import { take } from 'rxjs/operators';
 

--- a/src/app/account-app/paypal-handler.component.ts
+++ b/src/app/account-app/paypal-handler.component.ts
@@ -21,7 +21,6 @@ import { Component } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
 import { CartService } from './cart.service';
-import { PaymentsService } from './payments.service';
 
 @Component({
     selector: 'app-paypal-handler',
@@ -35,7 +34,6 @@ import { PaymentsService } from './payments.service';
 export class PaypalHandlerComponent {
     constructor(
         private cart: CartService,
-        private paymentsservice: PaymentsService,
         private rmmapi: RunboxWebmailAPI,
         private route:  ActivatedRoute,
         private router: Router,

--- a/src/app/account-app/paypal-payment-dialog.component.ts
+++ b/src/app/account-app/paypal-payment-dialog.component.ts
@@ -18,9 +18,7 @@
 // ---------- END RUNBOX LICENSE ----------
 
 import { Component, Inject } from '@angular/core';
-import { Router } from '@angular/router';
-import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { HttpErrorResponse } from '@angular/common/http';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 
 import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
 
@@ -50,9 +48,7 @@ export class PaypalPaymentDialogComponent {
     redirect_url: string;
 
     constructor(
-        private dialog: MatDialog,
         private rmmapi: RunboxWebmailAPI,
-        private router: Router,
         public dialogRef: MatDialogRef<PaypalPaymentDialogComponent>,
         @Inject(MAT_DIALOG_DATA) public data: any
     ) {

--- a/src/app/account-app/stripe-payment-dialog.component.ts
+++ b/src/app/account-app/stripe-payment-dialog.component.ts
@@ -19,7 +19,7 @@
 
 import { AfterViewInit, Component, ElementRef, Inject, ViewChild } from '@angular/core';
 import { Router } from '@angular/router';
-import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { HttpErrorResponse } from '@angular/common/http';
 
 import { PaymentsService } from './payments.service';
@@ -54,7 +54,6 @@ export class StripePaymentDialogComponent implements AfterViewInit {
     @ViewChild('cardCvc') cardCvc:              ElementRef;
 
     constructor(
-        private dialog: MatDialog,
         private paymentsservice: PaymentsService,
         private router: Router,
         public dialogRef: MatDialogRef<StripePaymentDialogComponent>,

--- a/src/app/account-security/account.security.component.ts
+++ b/src/app/account-security/account.security.component.ts
@@ -16,40 +16,12 @@
 // You should have received a copy of the GNU General Public License
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
-import { timeout } from 'rxjs/operators';
-import { SecurityContext, Component, Input, Output, EventEmitter, NgZone, ViewChild, AfterViewInit, OnInit, Inject } from '@angular/core';
-import { DomSanitizer } from '@angular/platform-browser';
-import { Router } from '@angular/router';
-import { ProgressService } from '../http/progress.service';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { CommonModule } from '@angular/common';
-import { FormsModule } from '@angular/forms';
+import { Component, Output, EventEmitter, ViewChild, OnInit, Inject } from '@angular/core';
 
-import { MatCardModule } from '@angular/material/card';
-import { MatCheckboxModule } from '@angular/material/checkbox';
-import { MatChipsModule } from '@angular/material/chips';
-import { MatDialogModule } from '@angular/material/dialog';
-import { MatInputModule } from '@angular/material/input';
-import { MatListModule } from '@angular/material/list';
 import { MatPaginator } from '@angular/material/paginator';
-import { MatPaginatorModule } from '@angular/material/paginator';
-import { MatProgressBarModule } from '@angular/material/progress-bar';
-import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { MatSelectModule } from '@angular/material/select';
-import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { MatSnackBarModule } from '@angular/material/snack-bar';
-import { MatTableModule } from '@angular/material/table';
-import { MatTabsModule } from '@angular/material/tabs';
 import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 
-import { RunboxIntroComponent } from '../runbox-components/runbox-intro';
-import { RunboxListComponent } from '../runbox-components/runbox-list';
-import { RunboxContainerComponent } from '../runbox-components/runbox-container';
-import { RunboxSectionComponent } from '../runbox-components/runbox-section';
-import { RunboxSlideToggleComponent } from '../runbox-components/runbox-slide-toggle';
-import { RunboxTimerComponent } from '../runbox-components/runbox-timer';
-import { MatFormFieldModule } from '@angular/material/form-field';
 import { RMM } from '../rmm';
 
 @Component({
@@ -418,7 +390,7 @@ export class AccountSecurityComponent implements OnInit {
 
   ip_always_block(result) {
     if ( ! this.rmm.account_security.user_password ) { this.show_modal_password(); return; }
-    const req = this.rmm.account_security.acl.update({
+    this.rmm.account_security.acl.update({
       ip: result.ip,
       label: 'Always Block',
       rule: 'deny',

--- a/src/app/actions/movemessage.action.spec.ts
+++ b/src/app/actions/movemessage.action.spec.ts
@@ -18,8 +18,8 @@
 // ---------- END RUNBOX LICENSE ----------
 
 import { Component, OnInit, NO_ERRORS_SCHEMA } from '@angular/core';
-import { ComponentFixture, TestBed, fakeAsync, tick, flushMicrotasks } from '@angular/core/testing';
-import { HttpClient, HttpClientModule } from '@angular/common/http';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { HttpClientModule } from '@angular/common/http';
 import { MoveMessageDialogComponent } from './movemessage.action';
 import { MatDialogModule, MatDialog } from '@angular/material/dialog';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -68,7 +68,7 @@ describe('MoveMessageAction', () => {
     let fixture: ComponentFixture<TestComponent>;
 
     beforeEach(() => {
-        const testingmodule = TestBed.configureTestingModule({
+        TestBed.configureTestingModule({
             imports: [HttpClientModule, MatDialogModule, NoopAnimationsModule],
             declarations: [
                 MoveMessageDialogComponent, TestComponent

--- a/src/app/aliases/aliases.editor.modal.ts
+++ b/src/app/aliases/aliases.editor.modal.ts
@@ -18,35 +18,13 @@
 // ---------- END RUNBOX LICENSE ----------
 import { timeout } from 'rxjs/operators';
 import {
-  SecurityContext,
   Component,
   Input,
-  Output,
-  EventEmitter,
-  NgZone,
-  ViewChild,
   Inject,
-  AfterViewInit
 } from '@angular/core';
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { MatCardModule } from '@angular/material/card';
-import { MatCheckboxModule } from '@angular/material/checkbox';
-import { MatDialogModule } from '@angular/material/dialog';
-import { MatInputModule } from '@angular/material/input';
-import { MatListModule } from '@angular/material/list';
-import { MatPaginatorModule } from '@angular/material/paginator';
-import { MatProgressBarModule } from '@angular/material/progress-bar';
-import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { MatSnackBarModule } from '@angular/material/snack-bar';
-import { MatTableModule } from '@angular/material/table';
-import { MatTabsModule } from '@angular/material/tabs';
-import { MatChipsModule } from '@angular/material/chips';
-import { MatDialog } from '@angular/material/dialog';
-import { MatPaginator } from '@angular/material/paginator';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatSelectModule } from '@angular/material/select';
 import { RMM } from '../rmm';
 
 @Component({

--- a/src/app/aliases/aliases.lister.ts
+++ b/src/app/aliases/aliases.lister.ts
@@ -17,33 +17,13 @@
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
 import {
-  SecurityContext,
   Component,
   Input,
   Output,
   EventEmitter,
-  NgZone,
-  ViewChild,
-  AfterViewInit
 } from '@angular/core';
-import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { MatCardModule } from '@angular/material/card';
-import { MatCheckboxModule } from '@angular/material/checkbox';
-import { MatDialogModule } from '@angular/material/dialog';
-import { MatInputModule } from '@angular/material/input';
-import { MatListModule } from '@angular/material/list';
-import { MatPaginatorModule } from '@angular/material/paginator';
-import { MatProgressBarModule } from '@angular/material/progress-bar';
-import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { MatSelectModule } from '@angular/material/select';
-import { MatSnackBarModule } from '@angular/material/snack-bar';
-import { MatTableModule } from '@angular/material/table';
-import { MatTabsModule } from '@angular/material/tabs';
-import { MatChipsModule } from '@angular/material/chips';
-import { MatPaginator } from '@angular/material/paginator';
-import { MatFormFieldModule } from '@angular/material/form-field';
 import { AliasesEditorModalComponent } from '../aliases/aliases.editor.modal';
 import { RMM } from '../rmm';
 

--- a/src/app/calendar-app/calendar-app.component.spec.ts
+++ b/src/app/calendar-app/calendar-app.component.spec.ts
@@ -31,7 +31,7 @@ import { of, Observable } from 'rxjs';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { RunboxCalendar } from './runbox-calendar';
 import { RunboxCalendarEvent } from './runbox-calendar-event';
-import { MatIcon, MatIconModule } from '@angular/material/icon';
+import { MatIcon } from '@angular/material/icon';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import * as moment from 'moment';
 

--- a/src/app/calendar-app/calendar-editor-dialog.component.ts
+++ b/src/app/calendar-app/calendar-editor-dialog.component.ts
@@ -21,7 +21,6 @@ import { Component, Inject } from '@angular/core';
 import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 
 import { RunboxCalendar } from './runbox-calendar';
-import { RunboxCalendarEvent } from './runbox-calendar-event';
 import { ColorSelectorDialogComponent } from './color-selector-dialog.component';
 import { DeleteConfirmationDialogComponent } from './delete-confirmation-dialog.component';
 

--- a/src/app/calendar-app/calendar-event-card.component.ts
+++ b/src/app/calendar-app/calendar-event-card.component.ts
@@ -17,7 +17,7 @@
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
 
-import { Component, EventEmitter, Input, OnChanges, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { EventOverview } from './event-overview';
 
 @Component({

--- a/src/app/calendar-app/calendar-settings-dialog.component.ts
+++ b/src/app/calendar-app/calendar-settings-dialog.component.ts
@@ -18,7 +18,7 @@
 // ---------- END RUNBOX LICENSE ----------
 
 import { Component, Inject } from '@angular/core';
-import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 
 import { CalendarSettings } from './calendar-settings';
 import { CalendarService } from './calendar.service';

--- a/src/app/calendar-app/color-selector-dialog.component.ts
+++ b/src/app/calendar-app/color-selector-dialog.component.ts
@@ -18,11 +18,7 @@
 // ---------- END RUNBOX LICENSE ----------
 
 import { Component, Inject } from '@angular/core';
-import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
-
-import { RunboxCalendar } from './runbox-calendar';
-import { RunboxCalendarEvent } from './runbox-calendar-event';
-import { DeleteConfirmationDialogComponent } from './delete-confirmation-dialog.component';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 
 @Component({
     selector: 'app-calendar-colour-selector-dialog-component',
@@ -61,7 +57,6 @@ export class ColorSelectorDialogComponent {
     selected: string;
 
     constructor(
-        private dialog: MatDialog,
         public dialogRef: MatDialogRef<ColorSelectorDialogComponent>,
         @Inject(MAT_DIALOG_DATA) public data: string[]
     ) {

--- a/src/app/calendar-app/delete-confirmation-dialog.component.ts
+++ b/src/app/calendar-app/delete-confirmation-dialog.component.ts
@@ -18,7 +18,7 @@
 // ---------- END RUNBOX LICENSE ----------
 
 import { Component, Inject } from '@angular/core';
-import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 
 @Component({
     selector: 'app-calendar-delete-confirmation-dialog',
@@ -41,7 +41,6 @@ import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dial
 })
 export class DeleteConfirmationDialogComponent {
     constructor(
-        private dialog: MatDialog,
         public dialogRef: MatDialogRef<DeleteConfirmationDialogComponent>,
         @Inject(MAT_DIALOG_DATA) public data: any
     ) {

--- a/src/app/calendar-app/import-dialog.component.ts
+++ b/src/app/calendar-app/import-dialog.component.ts
@@ -19,7 +19,7 @@
 
 import { Component, Inject } from '@angular/core';
 import { FormControl, Validators } from '@angular/forms';
-import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 
 import * as moment from 'moment';
 import { RunboxCalendar } from './runbox-calendar';
@@ -40,7 +40,6 @@ export class ImportDialogComponent {
     extractedCalendar: RunboxCalendar;
 
     constructor(
-        private dialog: MatDialog,
         public dialogRef: MatDialogRef<ImportDialogComponent>,
         @Inject(MAT_DIALOG_DATA) public data: any
     ) {

--- a/src/app/canvastable/canvastable.spec.ts
+++ b/src/app/canvastable/canvastable.spec.ts
@@ -18,8 +18,7 @@
 // ---------- END RUNBOX LICENSE ----------
 
 import { TestBed } from '@angular/core/testing';
-import { CanvasTableModule, CanvasTableSelectListener, CanvasTableContainerComponent } from './canvastable';
-import { AsyncSubject } from 'rxjs';
+import { CanvasTableModule, CanvasTableContainerComponent } from './canvastable';
 
 describe('canvastable', () => {
     beforeEach(() => {

--- a/src/app/canvastable/canvastable.ts
+++ b/src/app/canvastable/canvastable.ts
@@ -23,7 +23,7 @@
 
 
 import {
-  NgModule, Component, QueryList, AfterViewInit,
+  NgModule, Component, AfterViewInit,
   Input, Output, Renderer2,
   ElementRef,
   DoCheck, NgZone, EventEmitter, OnInit, ViewChild
@@ -145,7 +145,6 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
   private fontheight = 16;
   private fontheightSmaller = 13;
   private fontheightSmall = 15;
-  private fontheightLarge = 18;
 
   private scrollbarwidth = 12;
 
@@ -157,7 +156,6 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
   private scrollBarRect: any;
 
   private isTouchZoom = false;
-  private touchdownxy: any;
   private scrollbarDragInProgress = false;
   columnResizeInProgress = false;
   private scrollbarArea = false;
@@ -314,7 +312,6 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
       }
 
       const canvrect = this.canv.getBoundingClientRect();
-      this.touchdownxy = { x: clientX - canvrect.left, y: clientY - canvrect.top };
       if (checkIfScrollbarArea(clientX, clientY)) {
         this.scrollbarDragInProgress = true;
         this.scrollbarArea = true;
@@ -532,7 +529,6 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
     };
 
     this.renderer.listen('window', 'mouseup', (event: MouseEvent) => {
-      this.touchdownxy = undefined;
       this.lastMouseDownEvent = undefined;
       if (this.scrollbarDragInProgress) {
         this.scrollbarDragInProgress = false;
@@ -603,8 +599,6 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
   }
 
   private updateDragImage(selectedRowIndex: number) {
-    const canvrect = this.canv.getBoundingClientRect();
-
     const dragImageYCoords: number[][] = [];
     let dragImageDestY = 0;
 
@@ -762,8 +756,6 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
     if (!this.canv) {
       return;
     }
-
-    const padding = this.colpaddingleft + this.colpaddingright;
 
     const canvasWidth = Math.floor(this.wantedCanvasWidth / window.devicePixelRatio) - this.scrollbarwidth - 2;
 

--- a/src/app/compose/recipients.service.spec.ts
+++ b/src/app/compose/recipients.service.spec.ts
@@ -20,7 +20,6 @@
 import { TestBed } from '@angular/core/testing';
 import { RecipientsService } from './recipients.service';
 import { ContactsService } from '../contacts-app/contacts.service';
-import { Injector } from '@angular/core';
 import { SearchService } from '../xapian/searchservice';
 import { StorageService } from '../storage.service';
 import { AsyncSubject, of, Subject } from 'rxjs';
@@ -131,8 +130,6 @@ export class RunboxWebMailAPIMock {
 }
 
 describe('RecipientsService', () => {
-    let injector: Injector;
-
     beforeEach(() => {
         const testingmodule = TestBed.configureTestingModule({
             imports: [],
@@ -143,13 +140,12 @@ describe('RecipientsService', () => {
                 {provide: ContactsService,  useClass: ContactsServiceMock  },
             ]
         });
-        injector = TestBed.get(Injector);
     });
 
     afterEach(() => FS.chdir('/'));
 
     it('Should get recipients from contacts', async () => {
-        const recipientsService = injector.get(RecipientsService);
+        const recipientsService = TestBed.inject(RecipientsService);
 
         // Take 2 as searchindex+contacts service are separate updates
         const recipients = await recipientsService.recipients.pipe(take(2)).toPromise();
@@ -169,7 +165,7 @@ describe('RecipientsService', () => {
     });
 
     it('Should suggest recent recipients', async () => {
-        const searchMock: MockSearchService = <MockSearchService><unknown>injector.get(SearchService);
+        const searchMock: MockSearchService = <MockSearchService><unknown>TestBed.inject(SearchService);
 
         searchMock.mockedRecentMessages = [101, 102];
         searchMock.mockedRecipients = {
@@ -178,7 +174,7 @@ describe('RecipientsService', () => {
             103: { recipients: ['testuser@runbox.com'] }, // own address should be skipped
         };
 
-        const recipientsService: RecipientsService = injector.get(RecipientsService);
+        const recipientsService: RecipientsService = TestBed.inject(RecipientsService);
         const suggested = await recipientsService.recentlyUsed.pipe(take(1)).toPromise();
 
         expect(suggested.length).toBe(2);

--- a/src/app/compose/recipients.service.spec.ts
+++ b/src/app/compose/recipients.service.spec.ts
@@ -131,7 +131,7 @@ export class RunboxWebMailAPIMock {
 
 describe('RecipientsService', () => {
     beforeEach(() => {
-        const testingmodule = TestBed.configureTestingModule({
+        TestBed.configureTestingModule({
             imports: [],
             declarations: [ ], // declare the test component
             providers: [RecipientsService, StorageService,

--- a/src/app/contacts-app/contact-details/formarray-editor.component.ts
+++ b/src/app/contacts-app/contact-details/formarray-editor.component.ts
@@ -18,7 +18,7 @@
 // ---------- END RUNBOX LICENSE ----------
 
 import { Component, EventEmitter, Input, OnInit, Output  } from '@angular/core';
-import { FormArray, FormBuilder, FormControl, FormGroup } from '@angular/forms';
+import { FormArray, FormGroup } from '@angular/forms';
 
 @Component({
     selector: 'app-contact-details-fa-viewer',

--- a/src/app/contacts-app/contacts-settings.component.ts
+++ b/src/app/contacts-app/contacts-settings.component.ts
@@ -22,7 +22,6 @@ import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
 import { AppSettings, AppSettingsService } from '../app-settings';
 import { ContactsService } from './contacts.service';
 import { Subject } from 'rxjs';
-import { filter } from 'rxjs/operators';
 
 @Component({
     selector: 'app-contacts-settings',

--- a/src/app/contacts-app/vcf-import-dialog.component.ts
+++ b/src/app/contacts-app/vcf-import-dialog.component.ts
@@ -19,7 +19,7 @@
 
 import { Component, Inject } from '@angular/core';
 import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { Contact, ContactKind } from './contact';
+import { Contact } from './contact';
 import { GroupPickerDialogComponent } from './group-picker-dialog-component';
 
 export interface VcfImportDialogResult {

--- a/src/app/dev/dev.module.ts
+++ b/src/app/dev/dev.module.ts
@@ -24,7 +24,6 @@ import { FormsModule } from '@angular/forms';
 import { MenuModule } from '../menu/menu.module';
 import { RouterModule } from '@angular/router';
 import { MatInputModule } from '@angular/material/input';
-import { MatDialogModule } from '@angular/material/dialog';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';

--- a/src/app/dialog/dialog.module.ts
+++ b/src/app/dialog/dialog.module.ts
@@ -17,9 +17,7 @@
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
 
-import { ApplicationRef, ComponentFactoryResolver, Injector,
-    NgModule,
-    NgZone } from '@angular/core';
+import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialogModule } from '@angular/material/dialog';
@@ -32,7 +30,7 @@ import { FormsModule } from '@angular/forms';
 
 import { HttpClientModule } from '@angular/common/http';
 import { ErrorDialog } from './error-dialog.component';
-import { InfoDialog, InfoParams } from './info.dialog';
+import { InfoDialog } from './info.dialog';
 import { ProgressDialog } from './progress.dialog';
 import { SimpleInputDialog } from './simpleinput.dialog';
 import { ConfirmDialog } from './confirmdialog.component';

--- a/src/app/dialog/progresssnackbarcomponent.spec.ts
+++ b/src/app/dialog/progresssnackbarcomponent.spec.ts
@@ -17,7 +17,7 @@
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
 
-import { TestBed, async, ComponentFixture, getTestBed, tick, fakeAsync } from '@angular/core/testing';
+import { TestBed, async, ComponentFixture, tick, fakeAsync } from '@angular/core/testing';
 import { DialogModule } from './dialog.module';
 import { ProgressSnackbarComponent } from './progresssnackbar.component';
 import { MatSnackBar } from '@angular/material/snack-bar';

--- a/src/app/dialog/progresssnackbarcomponent.spec.ts
+++ b/src/app/dialog/progresssnackbarcomponent.spec.ts
@@ -29,8 +29,6 @@ import { Component } from '@angular/core';
 }) export class TestAppComponent {}
 
 describe('ProgressService', () => {
-
-    let injector: TestBed;
     let fixture: ComponentFixture<TestAppComponent>;
 
     beforeEach(async(() => {
@@ -40,12 +38,11 @@ describe('ProgressService', () => {
                 DialogModule],
             declarations: [TestAppComponent]
         }).compileComponents();
-        injector = getTestBed();
-        fixture = injector.createComponent(TestAppComponent);
+        fixture = TestBed.createComponent(TestAppComponent);
     }));
 
     it('should see changes in the progress snackbar', fakeAsync(() => {
-        const snackbar: MatSnackBar = injector.get(MatSnackBar);
+        const snackbar: MatSnackBar = TestBed.inject(MatSnackBar);
 
         expect(snackbar.openFromComponent).toBeDefined();
 

--- a/src/app/directives/horizresizer.directive.ts
+++ b/src/app/directives/horizresizer.directive.ts
@@ -17,7 +17,7 @@
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
 
-import { Directive, ElementRef, OnInit, Input, OnDestroy, Renderer2, Output, EventEmitter } from '@angular/core';
+import { Directive, ElementRef, OnInit, Input, Renderer2, Output, EventEmitter } from '@angular/core';
 
 @Directive({
     selector: '[appHorizResizable]' // Attribute selector
@@ -42,8 +42,6 @@ export class HorizResizerDirective implements OnInit {
     ngOnInit(): void {
         if (!this.resizableDisabled) {
             this.el.nativeElement.style['border-top'] = `${this.resizableGrabHeight}px solid darkgrey`;
-
-            const self = this;
 
             const mouseDrag = (evt) => {
                 if (this.inDragRegion(evt) || this.dragging) {

--- a/src/app/directives/resizer.directive.ts
+++ b/src/app/directives/resizer.directive.ts
@@ -33,8 +33,6 @@ export class ResizerDirective implements OnInit {
         private el: ElementRef,
         private renderer: Renderer2) {
 
-        const self = this;
-
         const mouseDrag = (evt) => {
             if (!this.dragging) {
                 return;

--- a/src/app/dkim/dkim.component.ts
+++ b/src/app/dkim/dkim.component.ts
@@ -23,29 +23,12 @@ create initial keys: POST   /rest/v1/dkim/$domain/keys/create
         replace key: PUT    /rest/v1/dkim/$domain/key/update/$selector -- or selector2
          delete key: DELETE /rest/v1/dkim/$domain/key/remove/$selector -- or selector2
 */
-import { timeout } from 'rxjs/operators';
-import { SecurityContext, Component, Input, Output, EventEmitter, NgZone, ViewChild, AfterViewInit } from '@angular/core';
-import { DomSanitizer } from '@angular/platform-browser';
+import { Component, Output, EventEmitter, ViewChild, AfterViewInit } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Router } from '@angular/router';
-import { ProgressService } from '../http/progress.service';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { CommonModule } from '@angular/common';
-import { FormsModule } from '@angular/forms';
 import { ConfirmDialog } from '../dialog/dialog.module';
-import { MatCardModule } from '@angular/material/card';
-import { MatCheckboxModule } from '@angular/material/checkbox';
-import { MatChipsModule } from '@angular/material/chips';
-import { MatDialogModule, MatDialog } from '@angular/material/dialog';
-import { MatInputModule } from '@angular/material/input';
-import { MatListModule } from '@angular/material/list';
-import { MatPaginatorModule, MatPaginator } from '@angular/material/paginator';
-import { MatProgressBarModule } from '@angular/material/progress-bar';
-import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { MatSelectModule } from '@angular/material/select';
-import { MatSnackBarModule, MatSnackBar } from '@angular/material/snack-bar';
-import { MatTableModule, MatTableDataSource } from '@angular/material/table';
-import { MatTabsModule } from '@angular/material/tabs';
+import { MatDialog } from '@angular/material/dialog';
+import { MatPaginator } from '@angular/material/paginator';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 @Component({
   moduleId: 'angular2/app/dkim/',
@@ -234,9 +217,9 @@ export class DkimComponent implements AfterViewInit {
   }
 
   constructor(
+    private dialog: MatDialog,
     private http: HttpClient,
-    public snackBar: MatSnackBar,
-    public dialog: MatDialog
+    private snackBar: MatSnackBar,
   ) {
     const domain = window.location.href.match(/domain=([^&]+)/);
     if (domain && domain[1]) {

--- a/src/app/domainregister/domainregister.component.ts
+++ b/src/app/domainregister/domainregister.component.ts
@@ -117,7 +117,6 @@ export class DomainRegisterComponent implements AfterViewInit {
     tld_list: false,
   };
   private user_domains = [];
-  private tld;
   public is_agreement_checked = false;
   public is_specific_agreement_checked = false;
   public is_btn_purchase_disabled = false;
@@ -145,7 +144,6 @@ export class DomainRegisterComponent implements AfterViewInit {
   public displayedColumnsDNS = ['name', 'type', 'address', 'ttl', 'action'];
   public dataSourceDNS = new MatTableDataSource<ElementDnsSetting>(this.domain_dns_settings);
 
-  private tlds_available = [];
   public displayedColumnsTld = [
     'tld',
     'period',
@@ -187,16 +185,13 @@ export class DomainRegisterComponent implements AfterViewInit {
   };
 
   public is_data_validated = function () {
-    let is_valid = true;
     // check user accepted agreement
     if (this.agreement_generic && !this.is_agreement_checked) {
-      is_valid = false;
       this.show_error('Please check the agreement checkbox', 'Dismiss');
       return false;
     }
     // check user accepted specific agreement
     if (this.agreement_specific && !this.is_specific_agreement_checked) {
-      is_valid = false;
       this.show_error('Please check the specific agreement checkbox', 'Dismiss');
       return false;
     }
@@ -321,7 +316,6 @@ export class DomainRegisterComponent implements AfterViewInit {
 
   public get_generic_docs = function () {
     this.generic_docs = null;
-    const d = this.parse_domain_wanted();
     this.http.post('/rest/v1/domain_registration/enom/tld_docs_generic', {}).pipe(timeout(60000))
       .subscribe(
         (reply: any) => {
@@ -361,7 +355,6 @@ export class DomainRegisterComponent implements AfterViewInit {
     if (docs.type === 'select') {
       // check if the value will require an other field to be filled.
       // loop on each option and check which docs.options contains the value
-      let selected_option;
       const selected_value = docs.value;
       if (docs.field === 'RegistrantCountry') {
         const country = docs.value;
@@ -382,7 +375,6 @@ export class DomainRegisterComponent implements AfterViewInit {
       this.required_by[docs.name] = [];
       for (let i = 0, option; option = docs.options[i++];) {
         if (option.value === selected_value) {
-          selected_option = option;
           if (option.requires && option.requires.length) {
             for (let j = 0, req_field; req_field = option.requires[j++];) {
               this.required_fields[req_field.name] = 1;
@@ -735,7 +727,6 @@ export class DomainRegisterComponent implements AfterViewInit {
 
   public btn_renew() {
     this.is_btn_renew_disabled = true;
-    const self = this;
     const renew = {
       domain: this.renew_domain,
       products: [],
@@ -778,7 +769,6 @@ export class DomainRegisterComponent implements AfterViewInit {
 
   public btn_purchase_privacy () {
     this.is_btn_renew_disabled = true;
-    const self = this;
     const purchase = {
         domain : this.privacy_domain,
         products : [],

--- a/src/app/folder/folderlist.component.spec.ts
+++ b/src/app/folder/folderlist.component.spec.ts
@@ -39,7 +39,6 @@ class MatDialogMock {
   }
 
 describe('FolderListComponent', () => {
-    let injector: TestBed;
     let dialog: MatDialog;
     let hotkeyMock: HotkeysService;
 
@@ -54,8 +53,7 @@ describe('FolderListComponent', () => {
             ],
         providers: [RunboxWebmailAPI, { provide: MatDialog, useClass: MatDialogMock }]
         });
-        injector = getTestBed();
-        dialog = injector.get(MatDialog);
+        dialog = TestBed.inject(MatDialog);
         hotkeyMock = { add: _ => null } as HotkeysService;
     });
 

--- a/src/app/folder/folderlist.component.spec.ts
+++ b/src/app/folder/folderlist.component.spec.ts
@@ -21,7 +21,7 @@ import { FolderListComponent, DropPosition, CreateFolderEvent, MoveFolderEvent }
 import { FolderListEntry, RunboxWebmailAPI } from '../rmmapi/rbwebmail';
 import { BehaviorSubject, of } from 'rxjs';
 import { MatDialog } from '@angular/material/dialog';
-import { TestBed, getTestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { take } from 'rxjs/operators';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { MatDialogModule } from '@angular/material/dialog';

--- a/src/app/http/progress.service.spec.ts
+++ b/src/app/http/progress.service.spec.ts
@@ -32,7 +32,6 @@ import { RMMAuthGuardService } from '../rmmapi/rmmauthguard.service';
 import { RMMOfflineService } from '../rmmapi/rmmoffline.service';
 
 describe('ProgressService', () => {
-    let injector: TestBed;
     let rmmapiservice: RunboxWebmailAPI;
     let progressService: ProgressService;
     let httpMock: HttpTestingController;
@@ -54,10 +53,9 @@ describe('ProgressService', () => {
             { provide: HTTP_INTERCEPTORS, useClass: RMMHttpInterceptorService, multi: true}
         ]
         });
-        injector = getTestBed();
-        rmmapiservice = injector.get(RunboxWebmailAPI);
-        progressService = injector.get(ProgressService);
-        httpMock = injector.get(HttpTestingController);
+        rmmapiservice = TestBed.inject(RunboxWebmailAPI);
+        progressService = TestBed.inject(ProgressService);
+        httpMock = TestBed.inject(HttpTestingController);
     });
 
     it('should indicate http request activity', async( async() => {

--- a/src/app/http/progress.service.spec.ts
+++ b/src/app/http/progress.service.spec.ts
@@ -17,7 +17,7 @@
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
 
-import { TestBed, getTestBed, async } from '@angular/core/testing';
+import { TestBed, async } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatSnackBarModule } from '@angular/material/snack-bar';

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -22,7 +22,6 @@ import { Router } from '@angular/router';
 
 import { HttpClient } from '@angular/common/http';
 
-import { Subject, Observable } from 'rxjs';
 import { RMMAuthGuardService } from '../rmmapi/rmmauthguard.service';
 import { map, filter } from 'rxjs/operators';
 import { ProgressService } from '../http/progress.service';

--- a/src/app/mailviewer/mailviewer.module.ts
+++ b/src/app/mailviewer/mailviewer.module.ts
@@ -17,7 +17,7 @@
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
 
-import { NgModule, ApplicationRef, ComponentFactoryResolver, Injector, NgZone } from '@angular/core';
+import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';

--- a/src/app/mailviewer/singlemailviewer.component.ts
+++ b/src/app/mailviewer/singlemailviewer.component.ts
@@ -17,9 +17,9 @@
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
 
-import { filter, map } from 'rxjs/operators';
+import { map } from 'rxjs/operators';
 import {
-  SecurityContext, Component, Input, OnInit, Output, EventEmitter, NgZone, ViewChild,
+  SecurityContext, Component, Input, OnInit, Output, EventEmitter, ViewChild,
   ElementRef,
   AfterViewInit,
   DoCheck
@@ -29,11 +29,9 @@ import { HttpClient, HttpEvent, HttpEventType } from '@angular/common/http';
 
 import { MatButtonToggle } from '@angular/material/button-toggle';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
-import { MatExpansionModule } from '@angular/material/expansion';
 
 import { MessageActions } from './messageactions';
 import { ProgressDialog } from '../dialog/progress.dialog';
-import { ProgressService } from '../http/progress.service';
 import { MobileQueryService } from '../mobile-query.service';
 
 import { SafeUrl } from '@angular/platform-browser';
@@ -41,7 +39,6 @@ import { HorizResizerDirective } from '../directives/horizresizer.directive';
 import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
 import { of } from 'rxjs';
 import { Router } from '@angular/router';
-import { MediaMatcher } from '@angular/cdk/layout';
 import { MessageListService } from '../rmmapi/messagelist.service';
 import { loadLocalMailParser } from './mailparser';
 
@@ -124,12 +121,11 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
   folder: string;
 
 
-  constructor(private _ngZone: NgZone,
+  constructor(
     private domSanitizer: DomSanitizer,
     private http: HttpClient,
     public dialog: MatDialog,
     private rbwebmailapi: RunboxWebmailAPI,
-    private progressService: ProgressService,
     public messagelistservice: MessageListService,
     public mobileQuery: MobileQueryService,
     private router: Router,
@@ -275,8 +271,6 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
         // Remove style tag otherwise angular sanitazion will display style tag content as text
 
         if (res.text.html) {
-          const styles: string[] = [];
-          const MAILVIEWER_STYLE_PREFIX = 'MAILVIEWER_STYLE_';
           const styleFilterRegexp = new RegExp(/(<style[\S\s]*?>[\S\s]*?<\/style>)/ig);
           const rawhtml = '' + res.text.html;
           let filteredhtml = rawhtml;
@@ -284,18 +278,6 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
           filteredhtml = this.domSanitizer.sanitize(SecurityContext.HTML, filteredhtml);
 
           res.html = filteredhtml;
-
-
-          /*
-            // Object URL doesn't work in prod because of content security policy
-
-            this.htmlObjectURL = this.domSanitizer.bypassSecurityTrustResourceUrl(
-            URL.createObjectURL(
-              // If your browser supports sandbox we can show the raw unfiltered HTML
-              new Blob([SUPPORTS_IFRAME_SANDBOX ? rawhtml: filteredhtml],
-                  {type: 'text/html'})
-            )
-          );*/
 
           // Use HTML rest endpoint
           if (SUPPORTS_IFRAME_SANDBOX) {

--- a/src/app/mobile-query.service.ts
+++ b/src/app/mobile-query.service.ts
@@ -33,7 +33,7 @@ export class MobileQueryService {
     }
 
     constructor(
-        private media: MediaMatcher,
+        media: MediaMatcher,
     ) {
         this.mobileQuery = media.matchMedia('(max-width: 1024px)');
         // tslint:disable-next-line:deprecation

--- a/src/app/profiles/profile.ts
+++ b/src/app/profiles/profile.ts
@@ -16,7 +16,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
-import { TestBed, async } from '@angular/core/testing';
 export class Profile {
     id:         number;
     profile:    string;

--- a/src/app/profiles/profiles.component.ts
+++ b/src/app/profiles/profiles.component.ts
@@ -16,33 +16,10 @@
 // You should have received a copy of the GNU General Public License
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
-import { timeout } from 'rxjs/operators';
-import { SecurityContext, Component, Input, Output, EventEmitter, NgZone, ViewChild, AfterViewInit } from '@angular/core';
-import { DomSanitizer } from '@angular/platform-browser';
-import { Router } from '@angular/router';
-import { ProgressService } from '../http/progress.service';
+import { Component, Output, EventEmitter, ViewChild, AfterViewInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { CommonModule } from '@angular/common';
-import { FormsModule } from '@angular/forms';
-import { MatCardModule } from '@angular/material/card';
-import { MatCheckboxModule } from '@angular/material/checkbox';
-import { MatDialogModule } from '@angular/material/dialog';
-import { MatInputModule } from '@angular/material/input';
-import { MatListModule } from '@angular/material/list';
-import { MatPaginatorModule } from '@angular/material/paginator';
-import { MatProgressBarModule } from '@angular/material/progress-bar';
-import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { MatSelectModule } from '@angular/material/select';
-import { MatSnackBarModule } from '@angular/material/snack-bar';
-import { MatTableModule } from '@angular/material/table';
-import { MatTabsModule } from '@angular/material/tabs';
-import { MatChipsModule } from '@angular/material/chips';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { AliasesListerComponent } from '../aliases/aliases.lister';
-import { ProfilesListerComponent } from './profiles.lister';
 import { ProfilesEditorModalComponent } from './profiles.editor.modal';
 import { AliasesEditorModalComponent } from '../aliases/aliases.editor.modal';
 import { RMM } from '../rmm';

--- a/src/app/profiles/profiles.editor.modal.ts
+++ b/src/app/profiles/profiles.editor.modal.ts
@@ -16,43 +16,14 @@
 // You should have received a copy of the GNU General Public License
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
-import { timeout } from 'rxjs/operators';
-import {
-  SecurityContext,
-  Component,
-  Input,
-  Output,
-  EventEmitter,
-  NgZone,
-  ViewChild,
-  Inject,
-  AfterViewInit
-} from '@angular/core';
+import { Component, Input, Inject } from '@angular/core';
 
-import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { RMM } from '../rmm';
 import { Location } from '@angular/common';
-import { DraftDeskService, DraftFormModel } from '../compose/draftdesk.service';
+import { DraftDeskService } from '../compose/draftdesk.service';
 import { TinyMCEPlugin } from '../rmm/plugin/tinymce.plugin';
-import { MatCardModule } from '@angular/material/card';
-import { MatCheckboxModule } from '@angular/material/checkbox';
-import { MatDialogModule } from '@angular/material/dialog';
-import { MatInputModule } from '@angular/material/input';
-import { MatListModule } from '@angular/material/list';
-import { MatGridListModule } from '@angular/material/grid-list';
-import { MatPaginatorModule } from '@angular/material/paginator';
-import { MatProgressBarModule } from '@angular/material/progress-bar';
-import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { MatSnackBarModule } from '@angular/material/snack-bar';
-import { MatTableModule } from '@angular/material/table';
-import { MatTabsModule } from '@angular/material/tabs';
-import { MatChipsModule } from '@angular/material/chips';
-import { MatDialog } from '@angular/material/dialog';
-import { MatPaginator } from '@angular/material/paginator';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatSelectModule } from '@angular/material/select';
 
 @Component({
     selector: 'app-profiles-edit',
@@ -404,7 +375,6 @@ export class ProfilesEditorModalComponent {
     public tinymce_plugin: TinyMCEPlugin;
     constructor(
         public rmm: RMM,
-        private http: HttpClient,
         private location: Location,
         public snackBar: MatSnackBar,
         public dialog_ref: MatDialogRef<ProfilesEditorModalComponent>,

--- a/src/app/profiles/profiles.lister.ts
+++ b/src/app/profiles/profiles.lister.ts
@@ -17,39 +17,15 @@
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
 import {
-  SecurityContext,
   Component,
   Input,
   Output,
   EventEmitter,
-  NgZone,
-  ViewChild,
-  AfterViewInit
 } from '@angular/core';
 
 import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { CommonModule } from '@angular/common';
-import { FormsModule } from '@angular/forms';
-import { MatCardModule } from '@angular/material/card';
-import { MatCheckboxModule } from '@angular/material/checkbox';
-import { MatDialogModule } from '@angular/material/dialog';
-import { MatExpansionModule } from '@angular/material/expansion';
-import { MatInputModule } from '@angular/material/input';
-import { MatListModule } from '@angular/material/list';
-import { MatPaginatorModule } from '@angular/material/paginator';
-import { MatProgressBarModule } from '@angular/material/progress-bar';
-import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { MatSelectModule } from '@angular/material/select';
-import { MatSnackBarModule } from '@angular/material/snack-bar';
-import { MatTableModule } from '@angular/material/table';
-import { MatTabsModule } from '@angular/material/tabs';
-import { MatChipsModule } from '@angular/material/chips';
-import { MatPaginator } from '@angular/material/paginator';
-import { MatGridListModule } from '@angular/material/grid-list';
-import { MatFormFieldModule } from '@angular/material/form-field';
 import { ProfilesEditorModalComponent } from './profiles.editor.modal';
-import { AliasesEditorModalComponent } from '../aliases/aliases.editor.modal';
 import { RMM } from '../rmm';
 
 @Component({

--- a/src/app/rmm.ts
+++ b/src/app/rmm.ts
@@ -17,9 +17,8 @@
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
 import { Injectable } from '@angular/core';
-import { timeout } from 'rxjs/operators';
 import { UserAgent } from './rmm/useragent';
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Email } from './rmm/email';
 import { Profile } from './rmm/profile';
 import { Alias } from './rmm/alias';

--- a/src/app/rmm/account-security-2fa.ts
+++ b/src/app/rmm/account-security-2fa.ts
@@ -18,7 +18,6 @@
 // ---------- END RUNBOX LICENSE ----------
 import { timeout, share } from 'rxjs/operators';
 import { Observable } from 'rxjs';
-import { of } from 'rxjs';
 import { RMM } from '../rmm';
 
 export class AccountSecurity2fa {
@@ -141,7 +140,7 @@ export class AccountSecurity2fa {
         qr_code_url.searchParams.set('device', device);
         qr_code_url.searchParams.set('label', this.totp_label);
         qr_code_url.searchParams.set('secret', this.new_totp_code);
-        const qr_code_image = this.generate_qr_code(device, this.app.account_security.tfa.totp_label, this.new_totp_code);
+        this.generate_qr_code(device, this.app.account_security.tfa.totp_label, this.new_totp_code);
     }
 
     generate_totp_code() {

--- a/src/app/rmm/account-security-acl.ts
+++ b/src/app/rmm/account-security-acl.ts
@@ -18,7 +18,6 @@
 // ---------- END RUNBOX LICENSE ----------
 import { timeout, share } from 'rxjs/operators';
 import { Observable } from 'rxjs';
-import { of } from 'rxjs';
 import { RMM } from '../rmm';
 
 export class AccountSecurityACL {

--- a/src/app/rmm/account-security-app-pass.ts
+++ b/src/app/rmm/account-security-app-pass.ts
@@ -18,7 +18,6 @@
 // ---------- END RUNBOX LICENSE ----------
 import { timeout, share } from 'rxjs/operators';
 import { Observable } from 'rxjs';
-import { of } from 'rxjs';
 import { RMM } from '../rmm';
 
 export class AccountSecurityAppPass {

--- a/src/app/rmm/account-security-device.ts
+++ b/src/app/rmm/account-security-device.ts
@@ -18,7 +18,6 @@
 // ---------- END RUNBOX LICENSE ----------
 import { timeout, share } from 'rxjs/operators';
 import { Observable } from 'rxjs';
-import { of } from 'rxjs';
 import { RMM } from '../rmm';
 
 export class AccountSecurityDevice {

--- a/src/app/rmm/account-security-service.ts
+++ b/src/app/rmm/account-security-service.ts
@@ -18,7 +18,6 @@
 // ---------- END RUNBOX LICENSE ----------
 import { timeout, share } from 'rxjs/operators';
 import { Observable } from 'rxjs';
-import { of } from 'rxjs';
 import { RMM } from '../rmm';
 
 export class AccountSecurityService {

--- a/src/app/rmm/account-security-session.ts
+++ b/src/app/rmm/account-security-session.ts
@@ -18,7 +18,6 @@
 // ---------- END RUNBOX LICENSE ----------
 import { timeout, share } from 'rxjs/operators';
 import { Observable } from 'rxjs';
-import { of } from 'rxjs';
 import { RMM } from '../rmm';
 
 export class AccountSecuritySession {

--- a/src/app/rmm/account-security-unlock-code.ts
+++ b/src/app/rmm/account-security-unlock-code.ts
@@ -18,7 +18,6 @@
 // ---------- END RUNBOX LICENSE ----------
 import { timeout, share } from 'rxjs/operators';
 import { Observable } from 'rxjs';
-import { of } from 'rxjs';
 import { RMM } from '../rmm';
 
 export class AccountSecurityUnlockCode {

--- a/src/app/rmm/account-security.ts
+++ b/src/app/rmm/account-security.ts
@@ -18,7 +18,6 @@
 // ---------- END RUNBOX LICENSE ----------
 import { timeout, share } from 'rxjs/operators';
 import { Observable } from 'rxjs';
-import { of } from 'rxjs';
 import { RMM } from '../rmm';
 import { AccountSecuritySession } from './account-security-session';
 import { AccountSecurityACL } from './account-security-acl';

--- a/src/app/rmm/alias.ts
+++ b/src/app/rmm/alias.ts
@@ -95,8 +95,7 @@ export class Alias {
     validate(obj) {
         const req = this.app.ua.http.post('/rest/v1/alias/' + obj.id + '/validate_email/', obj).pipe(timeout(60000), share());
         req.subscribe(
-          data => {
-            const reply = data;
+          _data => {
           },
           error => {
             this.app.show_error('Could not validate aliases.', 'Dismiss');

--- a/src/app/rmm/plugin/tinymce.plugin.ts
+++ b/src/app/rmm/plugin/tinymce.plugin.ts
@@ -16,8 +16,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
-import { timeout, share } from 'rxjs/operators';
-import { Observable } from 'rxjs';
 
 declare const tinymce: any;
 

--- a/src/app/rmm/profile.ts
+++ b/src/app/rmm/profile.ts
@@ -18,7 +18,6 @@
 // ---------- END RUNBOX LICENSE ----------
 import { timeout, share } from 'rxjs/operators';
 import { Observable } from 'rxjs';
-import { of } from 'rxjs';
 import { RMM } from '../rmm';
 import { FromAddress } from '../rmmapi/from_address';
 

--- a/src/app/rmm/useragent.ts
+++ b/src/app/rmm/useragent.ts
@@ -16,9 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
-import { timeout } from 'rxjs/operators';
-import { Observable } from 'rxjs';
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { RMM } from '../rmm';
 export class UserAgent {
     constructor(

--- a/src/app/rmm6/rmm6.module.ts
+++ b/src/app/rmm6/rmm6.module.ts
@@ -23,7 +23,7 @@ import { MailViewerModule, SingleMailViewerComponent } from '../mailviewer/mailv
 import { DomainRegisterModule } from '../domainregister/domainregister.module';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { HttpClient, HttpClientModule, HttpClientJsonpModule } from '@angular/common/http';
+import { HttpClient, HttpClientModule } from '@angular/common/http';
 import { ProgressService } from '../http/progress.service';
 import { DialogModule } from '../dialog/dialog.module';
 import { RMM6MessageActions } from '../mailviewer/rmm6messageactions';

--- a/src/app/rmm6/rmm6angulargateway.ts
+++ b/src/app/rmm6/rmm6angulargateway.ts
@@ -24,7 +24,6 @@
 import { ComponentRef } from '@angular/core';
 import { RMM6Module } from './rmm6.module';
 import { SingleMailViewerComponent } from '../mailviewer/singlemailviewer.component';
-import { InfoDialog, InfoParams } from '../dialog/info.dialog';
 import { RMM6SearchComponent } from './rmm6search.component';
 import { DomainRegisterComponent } from '../domainregister/domainregister.component';
 
@@ -45,12 +44,6 @@ export class RMM6AngularGateway {
                 .create(this.appmod.injector, [], aelm);
             this.appmod.appref.attachView(component.hostView);
         });
-    }
-
-    private removeChildNodesFromElement(elm: Element) {
-        while (elm.hasChildNodes()) {
-            elm.removeChild(elm.lastChild);
-        }
     }
 
     public openSearch() {

--- a/src/app/rmmapi/messagelist.service.spec.ts
+++ b/src/app/rmmapi/messagelist.service.spec.ts
@@ -18,9 +18,9 @@
 // ---------- END RUNBOX LICENSE ----------
 
 import { MessageListService } from './messagelist.service';
-import { RunboxWebmailAPI, FolderListEntry } from './rbwebmail';
+import { FolderListEntry } from './rbwebmail';
 
-import { of, Subject, Observable } from 'rxjs';
+import { Subject, Observable } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
 describe('MessageListService', () => {

--- a/src/app/rmmapi/rbwebmail.spec.ts
+++ b/src/app/rmmapi/rbwebmail.spec.ts
@@ -36,11 +36,11 @@ describe('RBWebMail', () => {
     });
 
     it('should cache message contents', async () => {
-        const rmmapi = TestBed.get(RunboxWebmailAPI);
+        const rmmapi = TestBed.inject(RunboxWebmailAPI);
 
         let messageContentsObservable = rmmapi.getMessageContents(123);
 
-        const httpTestingController = TestBed.get(HttpTestingController);
+        const httpTestingController = TestBed.inject(HttpTestingController);
         let req = httpTestingController.expectOne('/rest/v1/email/123');
         req.flush({
             result: {
@@ -49,7 +49,7 @@ describe('RBWebMail', () => {
             }
         });
 
-        let messageContents = await messageContentsObservable.toPromise();
+        let messageContents = await <any>messageContentsObservable.toPromise();
         expect(messageContents.id).toBe(123);
         expect(messageContents.subject).toBe('test');
 
@@ -214,9 +214,9 @@ describe('RBWebMail', () => {
             }
         };
 
-        const rmmapi = TestBed.get(RunboxWebmailAPI);
+        const rmmapi = TestBed.inject(RunboxWebmailAPI);
         const folderListPromise = rmmapi.getFolderList().toPromise();
-        const httpTestingController = TestBed.get(HttpTestingController);
+        const httpTestingController = TestBed.inject(HttpTestingController);
         const req = httpTestingController.expectOne('/rest/v1/email_folder/list');
         req.flush(listEmailFoldersResponse);
 
@@ -603,9 +603,9 @@ describe('RBWebMail', () => {
             }
         };
 
-        const rmmapi = TestBed.get(RunboxWebmailAPI);
+        const rmmapi = TestBed.inject(RunboxWebmailAPI);
         const folderListPromise = rmmapi.getFolderList().toPromise();
-        const httpTestingController = TestBed.get(HttpTestingController);
+        const httpTestingController = TestBed.inject(HttpTestingController);
         const req = httpTestingController.expectOne('/rest/v1/email_folder/list');
         req.flush(listEmailFoldersResponse);
 

--- a/src/app/rmmapi/rbwebmail.ts
+++ b/src/app/rmmapi/rbwebmail.ts
@@ -28,7 +28,6 @@ import { RunboxCalendar } from '../calendar-app/runbox-calendar';
 import { RunboxCalendarEvent } from '../calendar-app/runbox-calendar-event';
 import { Product } from '../account-app/product';
 import { DraftFormModel } from '../compose/draftdesk.service';
-import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { map, mergeMap, tap } from 'rxjs/operators';
 
@@ -81,11 +80,6 @@ export class ContactSyncResult {
         public removed:      string[],
         public toMigrate:    number,
     ) { }
-}
-
-class FromAddressResponse {
-    public from_addresses: FromAddress[];
-    public status: string;
 }
 
 export class RunboxMe {
@@ -154,7 +148,6 @@ export class RunboxWebmailAPI {
     constructor(
         public snackBar: MatSnackBar,
         private http: HttpClient,
-        private dialog: MatDialog,
         public rmm: RMM,
         private ngZone: NgZone
     ) {

--- a/src/app/rmmapi/rmmauthguard.service.ts
+++ b/src/app/rmmapi/rmmauthguard.service.ts
@@ -20,8 +20,8 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { CanActivate, ActivatedRouteSnapshot, RouterStateSnapshot, Router, CanActivateChild } from '@angular/router';
-import { Observable, of } from 'rxjs';
-import { map, take, tap } from 'rxjs/operators';
+import { Observable } from 'rxjs';
+import { map, take } from 'rxjs/operators';
 
 @Injectable()
 export class RMMAuthGuardService implements CanActivate, CanActivateChild {

--- a/src/app/rmmapi/rmmhttpinterceptor.service.ts
+++ b/src/app/rmmapi/rmmhttpinterceptor.service.ts
@@ -20,7 +20,7 @@
 import { Injectable } from '@angular/core';
 import { HttpInterceptor, HttpRequest, HttpHandler, HttpEvent, HttpResponse, HttpClient } from '@angular/common/http';
 import { Observable,  throwError } from 'rxjs';
-import { catchError, filter, map, finalize } from 'rxjs/operators';
+import { catchError, map, finalize } from 'rxjs/operators';
 import { ProgressService } from '../http/progress.service';
 import { RMMAuthGuardService } from './rmmauthguard.service';
 import { RMMOfflineService } from './rmmoffline.service';

--- a/src/app/runbox-components/runbox-component.module.ts
+++ b/src/app/runbox-components/runbox-component.module.ts
@@ -21,7 +21,6 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MenuModule } from '../menu/menu.module';
-import { RouterModule } from '@angular/router';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';

--- a/src/app/runbox-components/runbox-container.ts
+++ b/src/app/runbox-components/runbox-container.ts
@@ -17,41 +17,10 @@
 // You should have received a copy of the GNU General Public License
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
-import {
-  SecurityContext,
-  Component,
-  Input,
-  Output,
-  EventEmitter,
-  NgZone,
-  ViewChild,
-  AfterViewInit,
-  ContentChild,
-  ElementRef,
-  TemplateRef,
-} from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { FormsModule } from '@angular/forms';
+import { Component, Input } from '@angular/core';
 
-import { MatCardModule } from '@angular/material/card';
-import { MatCheckboxModule } from '@angular/material/checkbox';
-import { MatDialogModule } from '@angular/material/dialog';
-import { MatExpansionModule } from '@angular/material/expansion';
-import { MatInputModule } from '@angular/material/input';
-import { MatListModule } from '@angular/material/list';
-import { MatPaginatorModule } from '@angular/material/paginator';
-import { MatProgressBarModule } from '@angular/material/progress-bar';
-import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { MatSelectModule } from '@angular/material/select';
-import { MatSnackBarModule } from '@angular/material/snack-bar';
-import { MatTableModule } from '@angular/material/table';
-import { MatTabsModule } from '@angular/material/tabs';
-import { MatChipsModule } from '@angular/material/chips';
 import { MatDialog } from '@angular/material/dialog';
-import { MatPaginator } from '@angular/material/paginator';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { MatGridListModule } from '@angular/material/grid-list';
-import { MatFormFieldModule } from '@angular/material/form-field';
 import { RMM } from '../rmm';
 
 @Component({
@@ -73,7 +42,6 @@ import { RMM } from '../rmm';
 
 export class RunboxContainerComponent {
   @Input() sidebar_opened = false;
-  private dialog_ref: any;
   constructor(public dialog: MatDialog,
     public rmm: RMM,
     public snackBar: MatSnackBar,

--- a/src/app/runbox-components/runbox-intro.ts
+++ b/src/app/runbox-components/runbox-intro.ts
@@ -16,38 +16,10 @@
 // You should have received a copy of the GNU General Public License
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
-import {
-  SecurityContext,
-  Component,
-  Input,
-  Output,
-  EventEmitter,
-  NgZone,
-  ViewChild,
-  AfterViewInit
-} from '@angular/core';
+import { Component } from '@angular/core';
 
 import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { CommonModule } from '@angular/common';
-import { FormsModule } from '@angular/forms';
-import { MatCardModule } from '@angular/material/card';
-import { MatCheckboxModule } from '@angular/material/checkbox';
-import { MatDialogModule } from '@angular/material/dialog';
-import { MatExpansionModule } from '@angular/material/expansion';
-import { MatInputModule } from '@angular/material/input';
-import { MatListModule } from '@angular/material/list';
-import { MatPaginatorModule } from '@angular/material/paginator';
-import { MatProgressBarModule } from '@angular/material/progress-bar';
-import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { MatSelectModule } from '@angular/material/select';
-import { MatSnackBarModule } from '@angular/material/snack-bar';
-import { MatTableModule } from '@angular/material/table';
-import { MatTabsModule } from '@angular/material/tabs';
-import { MatChipsModule } from '@angular/material/chips';
-import { MatPaginator } from '@angular/material/paginator';
-import { MatGridListModule } from '@angular/material/grid-list';
-import { MatFormFieldModule } from '@angular/material/form-field';
 import { RMM } from '../rmm';
 
 @Component({
@@ -76,7 +48,6 @@ import { RMM } from '../rmm';
 })
 
 export class RunboxIntroComponent {
-  private dialog_ref: any;
   constructor(public dialog: MatDialog,
     public rmm: RMM,
     public snackBar: MatSnackBar,

--- a/src/app/runbox-components/runbox-list.ts
+++ b/src/app/runbox-components/runbox-list.ts
@@ -17,14 +17,8 @@
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
 import {
-  SecurityContext,
   Component,
   Input,
-  Output,
-  EventEmitter,
-  NgZone,
-  ViewChild,
-  AfterViewInit,
   ContentChild,
   ElementRef,
   TemplateRef,
@@ -32,25 +26,6 @@ import {
 
 import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { CommonModule } from '@angular/common';
-import { FormsModule } from '@angular/forms';
-import { MatCardModule } from '@angular/material/card';
-import { MatCheckboxModule } from '@angular/material/checkbox';
-import { MatDialogModule } from '@angular/material/dialog';
-import { MatExpansionModule } from '@angular/material/expansion';
-import { MatInputModule } from '@angular/material/input';
-import { MatListModule } from '@angular/material/list';
-import { MatPaginatorModule } from '@angular/material/paginator';
-import { MatProgressBarModule } from '@angular/material/progress-bar';
-import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { MatSelectModule } from '@angular/material/select';
-import { MatSnackBarModule } from '@angular/material/snack-bar';
-import { MatTableModule } from '@angular/material/table';
-import { MatTabsModule } from '@angular/material/tabs';
-import { MatChipsModule } from '@angular/material/chips';
-import { MatPaginator } from '@angular/material/paginator';
-import { MatGridListModule } from '@angular/material/grid-list';
-import { MatFormFieldModule } from '@angular/material/form-field';
 import { RMM } from '../rmm';
 
 @Component({
@@ -92,7 +67,6 @@ import { RMM } from '../rmm';
 
 export class RunboxListComponent {
   @Input() values: any[];
-  private dialog_ref: any;
   view_mode: any;
   @ContentChild('runbox_list_row_small') runbox_list_row_small: TemplateRef<ElementRef>;
   @ContentChild('runbox_list_row_medium') runbox_list_row_medium: TemplateRef<ElementRef>;

--- a/src/app/runbox-components/runbox-section.ts
+++ b/src/app/runbox-components/runbox-section.ts
@@ -16,41 +16,10 @@
 // You should have received a copy of the GNU General Public License
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
-import {
-  SecurityContext,
-  Component,
-  Input,
-  Output,
-  EventEmitter,
-  NgZone,
-  ViewChild,
-  AfterViewInit,
-  ContentChild,
-  ElementRef,
-  TemplateRef,
-} from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { FormsModule } from '@angular/forms';
+import { Component, Input } from '@angular/core';
 
-import { MatCardModule } from '@angular/material/card';
-import { MatCheckboxModule } from '@angular/material/checkbox';
-import { MatDialogModule } from '@angular/material/dialog';
-import { MatExpansionModule } from '@angular/material/expansion';
-import { MatInputModule } from '@angular/material/input';
-import { MatListModule } from '@angular/material/list';
-import { MatPaginatorModule } from '@angular/material/paginator';
-import { MatProgressBarModule } from '@angular/material/progress-bar';
-import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { MatSelectModule } from '@angular/material/select';
-import { MatSnackBarModule } from '@angular/material/snack-bar';
-import { MatTableModule } from '@angular/material/table';
-import { MatTabsModule } from '@angular/material/tabs';
-import { MatChipsModule } from '@angular/material/chips';
 import { MatDialog } from '@angular/material/dialog';
-import { MatPaginator } from '@angular/material/paginator';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { MatGridListModule } from '@angular/material/grid-list';
-import { MatFormFieldModule } from '@angular/material/form-field';
 import { RMM } from '../rmm';
 
 @Component({
@@ -74,7 +43,6 @@ import { RMM } from '../rmm';
 export class RunboxSectionComponent {
   @Input() is_header_open = true;
   @Input() size = 'h1';
-  private dialog_ref: any;
   public section_sizes = {
     h1: {
     },

--- a/src/app/runbox-components/runbox-slide-toggle.ts
+++ b/src/app/runbox-components/runbox-slide-toggle.ts
@@ -16,19 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
-import {
-  SecurityContext,
-  Component,
-  Input,
-  Output,
-  EventEmitter,
-  NgZone,
-  ViewChild,
-  AfterViewInit,
-  ContentChild,
-  ElementRef,
-  TemplateRef,
-} from '@angular/core';
+import { Component, Input } from '@angular/core';
 
 @Component({
     selector: 'app-runbox-slide-toggle',

--- a/src/app/runbox-components/runbox-timer.ts
+++ b/src/app/runbox-components/runbox-timer.ts
@@ -17,40 +17,14 @@
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
 import {
-  SecurityContext,
   Component,
   Input,
-  Output,
-  EventEmitter,
-  NgZone,
-  ViewChild,
-  AfterViewInit,
   ContentChild,
   ElementRef,
-  TemplateRef,
   OnInit
 } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { FormsModule } from '@angular/forms';
-import { MatCardModule } from '@angular/material/card';
-import { MatCheckboxModule } from '@angular/material/checkbox';
-import { MatDialogModule } from '@angular/material/dialog';
-import { MatExpansionModule } from '@angular/material/expansion';
-import { MatInputModule } from '@angular/material/input';
-import { MatListModule } from '@angular/material/list';
-import { MatPaginatorModule } from '@angular/material/paginator';
-import { MatProgressBarModule } from '@angular/material/progress-bar';
-import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { MatSelectModule } from '@angular/material/select';
-import { MatSnackBarModule } from '@angular/material/snack-bar';
-import { MatTableModule } from '@angular/material/table';
-import { MatTabsModule } from '@angular/material/tabs';
-import { MatChipsModule } from '@angular/material/chips';
 import { MatDialog } from '@angular/material/dialog';
-import { MatPaginator } from '@angular/material/paginator';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { MatGridListModule } from '@angular/material/grid-list';
-import { MatFormFieldModule } from '@angular/material/form-field';
 import { RMM } from '../rmm';
 
 @Component({
@@ -80,7 +54,6 @@ export class RunboxTimerComponent implements OnInit {
   @Input() future_date: any; // yyyy/mm/dd hh:mm:ss
   @Input() css_class: any; // cool_timer_css
   @Input() child_timer: any = {years: 0, months: 0, days: 0, hours: 0, minutes: 0, seconds: 0};
-  private dialog_ref: any;
 
   years: any;
   months: any;

--- a/src/app/storage.service.spec.ts
+++ b/src/app/storage.service.spec.ts
@@ -18,9 +18,8 @@
 // ---------- END RUNBOX LICENSE ----------
 
 import { StorageService } from './storage.service';
-import { RunboxWebmailAPI, RunboxMe } from './rmmapi/rbwebmail';
+import { RunboxWebmailAPI } from './rmmapi/rbwebmail';
 import { of } from 'rxjs';
-import { filter } from 'rxjs/operators';
 
 describe('StorageService', () => {
     const me_1 = { me: of({ uid: 1 }) } as RunboxWebmailAPI;

--- a/src/app/storage.service.ts
+++ b/src/app/storage.service.ts
@@ -27,7 +27,7 @@ export class StorageService {
     keySubjects: { [key: string]: ReplaySubject<any> } = {};
 
     constructor(
-        private rmmapi: RunboxWebmailAPI,
+        rmmapi: RunboxWebmailAPI,
     ) {
         rmmapi.me.subscribe(me => {
             this.uid.next(me.uid);

--- a/src/app/websocketsearch/websocketsearch.module.ts
+++ b/src/app/websocketsearch/websocketsearch.module.ts
@@ -19,7 +19,6 @@
 
 import { NgModule } from '@angular/core';
 
-import { MatInputModule } from '@angular/material/input';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { WebSocketSearchService } from './websocketsearch.service';
 

--- a/src/app/welcome/welcomedesk.module.ts
+++ b/src/app/welcome/welcomedesk.module.ts
@@ -21,7 +21,7 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { WelcomeDeskComponent } from './welcomedesk.component';
 import { MatIconModule } from '@angular/material/icon';
-import { RouterModule, Routes } from '@angular/router';
+import { RouterModule } from '@angular/router';
 
 @NgModule({
   declarations: [WelcomeDeskComponent],

--- a/src/app/xapian/searchservice.spec.ts
+++ b/src/app/xapian/searchservice.spec.ts
@@ -18,8 +18,8 @@
 // ---------- END RUNBOX LICENSE ----------
 
 import { SearchService, XAPIAN_GLASS_WR } from './searchservice';
+import { Type } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { Injector, Type } from '@angular/core';
 import { RunboxWebmailAPI, RunboxMe } from '../rmmapi/rbwebmail';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { MatDialogModule } from '@angular/material/dialog';
@@ -34,7 +34,6 @@ declare var IDBFS;
 
 describe('SearchService', () => {
 
-    let injector: Injector;
     let httpMock: HttpTestingController;
 
     const listEmailFoldersResponse = {
@@ -106,12 +105,11 @@ describe('SearchService', () => {
           ]
         });
 
-        injector = TestBed.get(Injector);
-        httpMock = injector.get(HttpTestingController as Type<HttpTestingController>);
+        httpMock = TestBed.inject(HttpTestingController as Type<HttpTestingController>);
     }));
 
     it('should load searchservice, but no local index', async () => {
-        const searchService = injector.get(SearchService);
+        const searchService = TestBed.inject(SearchService);
         await xapianLoadedSubject.toPromise();
 
         let req = httpMock.expectOne(`/rest/v1/me`);
@@ -127,7 +125,7 @@ describe('SearchService', () => {
 
         await new Promise(resolve => setTimeout(resolve, 100));
 
-        const messageListService = injector.get(MessageListService);
+        const messageListService = TestBed.inject(MessageListService);
         expect(messageListService.trashFolderName).toEqual('Trash');
         expect(messageListService.spamFolderName).toEqual('Spam');
         expect(messageListService.folderListSubject.value.length).toBe(3);
@@ -203,7 +201,7 @@ describe('SearchService', () => {
         Object.keys(IDBFS.dbs).forEach(k => IDBFS.dbs[k].close());
         IDBFS.dbs = {};
 
-        const searchService = injector.get(SearchService);
+        const searchService = TestBed.inject(SearchService);
         let req = httpMock.expectOne(`/rest/v1/me`);
         req.flush( { result: {
                 uid: testuserid
@@ -222,7 +220,7 @@ describe('SearchService', () => {
 
         await new Promise(resolve => setTimeout(resolve, 100));
 
-        const messageListService = injector.get(MessageListService);
+        const messageListService = TestBed.inject(MessageListService);
         expect(messageListService.trashFolderName).toEqual('Trash');
         expect(messageListService.spamFolderName).toEqual('Spam');
         expect(messageListService.folderListSubject.value.length).toBe(3);

--- a/src/app/xapian/searchservice.ts
+++ b/src/app/xapian/searchservice.ts
@@ -17,7 +17,7 @@
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
 
-import { Injectable, NgZone } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { HttpClient, HttpRequest, HttpResponse, HttpEventType } from '@angular/common/http';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar, MatSnackBarRef } from '@angular/material/snack-bar';
@@ -146,7 +146,6 @@ export class SearchService {
 
   constructor(public rmmapi: RunboxWebmailAPI,
        private httpclient: HttpClient,
-       private ngZone: NgZone,
        private snackbar: MatSnackBar,
        private dialog: MatDialog,
        private messagelistservice: MessageListService) {
@@ -975,8 +974,8 @@ export class SearchService {
                   `${newmessages.length} new email messages` :
                   `New email message`;
               try {
-                // tslint:disable-next-line:no-unused-expression
-                  const notification = new Notification(newMessagesTitle, {
+                  // tslint:disable-next-line:no-unused-expression
+                  new Notification(newMessagesTitle, {
                     body: newmessages[0].from[0].name,
                     icon: 'assets/icons/icon-192x192.png',
                     tag: 'newmessages'
@@ -1021,7 +1020,6 @@ export class SearchService {
 
     downloadPartitions(): Observable<any> {
       let totalSize;
-      let totalCompressedSize;
       let partitions: DownloadablePartition[];
       let userHasAcceptedDownloadAllPartitions = false;
       return this.httpclient.get('/rest/v1/searchindex/partitions')
@@ -1033,8 +1031,6 @@ export class SearchService {
             partitions = searchindexmap.partitions.filter((p, ndx) => ndx > 0);
             totalSize = partitions.reduce((prev, curr) => prev +
               curr.files.reduce((p, c) => c.uncompressedsize + p, 0), 0);
-            totalCompressedSize  = partitions.reduce((prev, curr) => prev +
-              curr.files.reduce((p, c) => c.compressedsize + p, 0), 0);
             if (totalSize === 0) {
               console.log('No extra search index partitions');
               this.updateIndexWithNewChanges();

--- a/src/app/xapian/xapianwebloader.ts
+++ b/src/app/xapian/xapianwebloader.ts
@@ -303,7 +303,6 @@ function patchIDBFS() {
         },
         removeLocalEntry: function(path, callback) {
         try {
-            var lookup = FS.lookupPath(path);
             var stat = FS.stat(path);
 
             if (FS.isDir(stat.mode)) {
@@ -361,7 +360,6 @@ function patchIDBFS() {
 
             var remove = [];
             Object.keys(dst.entries).forEach(function (key) {
-                var e = dst.entries[key];
                 var e2 = src.entries[key];
                 if (!e2) {
                 remove.push(key);
@@ -373,7 +371,6 @@ function patchIDBFS() {
                 return callback(null);
             }
 
-            var errored = false;
             var completed = 0;
             var db = src.type === 'remote' ? src.db : dst.db;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
       "dom"
     ],
     "module": "esNext",
+    "noUnusedLocals": true,
     "baseUrl": "./"
   }
 }


### PR DESCRIPTION
Makes our linter a bit happier, and our code a bit cleaner.

`no-unused-variables` is deprecated as a tslint rule, in favour of the compiler option, which I introduced (and it seems to catch quite a few more errors than the tslint one). We can see if it proves to be annoying during development, and if so, we can figure out how to enable it for production builds only.