### PR TITLE
fix(canvastable): Make sort icons show actual sorting direction

### DIFF
--- a/src/app/canvastable/canvastable.ts
+++ b/src/app/canvastable/canvastable.ts
@@ -1354,7 +1354,8 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
   // tslint:disable-next-line:component-selector
   selector: 'canvastablecontainer',
   templateUrl: 'canvastablecontainer.component.html',
-  moduleId: 'angular2/app/canvastable/'
+  moduleId: 'angular2/app/canvastable/',
+  styleUrls: ['canvastablecontainer.component.scss']
 })
 export class CanvasTableContainerComponent implements OnInit {
   colResizeInitialClientX: number;

--- a/src/app/canvastable/canvastablecontainer.component.html
+++ b/src/app/canvastable/canvastablecontainer.component.html
@@ -57,9 +57,9 @@
             [style.left]="sumWidthsBefore(colIndex)+'px'"
             [style.cursor]="col.sortColumn!==null ? 'pointer' : 'default'"
             >
-            <mat-icon *ngIf="sortColumn===col.sortColumn" style="font-size: 12px;" svgIcon="{{sortDescending ? 'chevron-up' : 'cheron-down'}}">
+            {{col.name}}
+            <mat-icon class="sortIcon" *ngIf="sortColumn===col.sortColumn" svgIcon="{{sortDescending ? 'chevron-up' : 'chevron-down'}}">
             </mat-icon>
-            {{col.name}}               
         </div>
       </ng-container>
     </ng-container>

--- a/src/app/canvastable/canvastablecontainer.component.scss
+++ b/src/app/canvastable/canvastablecontainer.component.scss
@@ -1,0 +1,4 @@
+.sortIcon {
+    position: relative;
+    bottom: 3px;
+}


### PR DESCRIPTION
Because of some typos, they weren't changing while sorting was changed, and only the "arrow up" icon was showing.

Additionally, moved the sorting icon to the right side of column name. This prevents the name from snapping to the side when the icon appears.