### PR TITLE
fix(calendar): Refactor ical event handling to treat each uid as one item

### DIFF
--- a/backend-proxy-remote.conf.js
+++ b/backend-proxy-remote.conf.js
@@ -21,7 +21,7 @@ const PROXY_CONFIG = [
     },
     {
         context: [
-            "/rest", "/LOGOUT", "/mail", "/ajax", "/_js", "/_img", "/_css", "/app", "/angular2"    
+            "/rest", "/LOGOUT", "/mail", "/ajax", "/_js", "/_img", "/_css", "/app", "/angular2", "/locale"     
         ],
         onProxyRes: (proxyRes, req, res) => {            
             if (proxyRes.headers['set-cookie']) {

--- a/backend-proxy-remote.conf.js
+++ b/backend-proxy-remote.conf.js
@@ -21,7 +21,7 @@ const PROXY_CONFIG = [
     },
     {
         context: [
-            "/rest", "/LOGOUT", "/mail", "/ajax", "/_js", "/_img", "/_css", "/app", "/angular2", "/locale"     
+            "/rest", "/LOGOUT", "/mail", "/ajax", "/_js", "/_img", "/_css", "/_ics", "/app", "/angular2", "/locale", "/signup", "pw_reset"
         ],
         onProxyRes: (proxyRes, req, res) => {            
             if (proxyRes.headers['set-cookie']) {

--- a/e2e/cypress/integration/calendar.ts
+++ b/e2e/cypress/integration/calendar.ts
@@ -8,8 +8,6 @@ describe('Create calendar event', () => {
 
         cy.get('#addEventButton').should('contain', 'Add event').click();
         cy.get('input[data-placeholder=Title]').type('my test event');
-        cy.get('mat-select').contains('Calendar').click();
-        cy.get('mat-option').contains('Mock Calendar').click();
         cy.get('#eventSubmitButton').click();
 
         cy.get('.calendarMonthDayEvent').contains('my test event');

--- a/src/app/calendar-app/calendar-app.component.spec.ts
+++ b/src/app/calendar-app/calendar-app.component.spec.ts
@@ -37,47 +37,48 @@ import { RunboxCalendarEvent } from './runbox-calendar-event';
 import { MatIcon } from '@angular/material/icon';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import * as moment from 'moment';
+import * as ICAL from 'ical.js';
 
 describe('CalendarAppComponent', () => {
     let component: CalendarAppComponent;
     let fixture: ComponentFixture<CalendarAppComponent>;
 
     const simpleEvents = [
-        new RunboxCalendarEvent('test-calendar/event0', ['vcalendar', [], [ [ 'vevent', [
+      new RunboxCalendarEvent('test-calendar/event0', new ICAL.Event(new ICAL.Component(['vcalendar', [], [ [ 'vevent', [
             [ 'dtstart', {}, 'date-time', moment().toISOString() ],
             [ 'summary', {}, 'text',      'Test Event #0'        ],
-        ]]]]),
-        new RunboxCalendarEvent('test-calendar/event1', ['vcalendar', [], [ [ 'vevent', [
+      ]]]])), ICAL.Time.fromJSDate(new Date()), undefined),
+        new RunboxCalendarEvent('test-calendar/event1', new ICAL.Event(new ICAL.Component(['vcalendar', [], [ [ 'vevent', [
             [ 'dtstart', {}, 'date-time', moment().add(1, 'month').add(14, 'day').toISOString() ],
             [ 'summary', {}, 'text',      'Event #1, next month' ],
-        ]]]]),
+        ]]]])), ICAL.Time.fromJSDate(moment().add(1, 'month').add(14, 'day').toDate()), undefined),
     ];
 
     const recurringEvents = [
-        new RunboxCalendarEvent('test-calendar/recurring', ['vcalendar', [], [ [ 'vevent', [
+        new RunboxCalendarEvent('test-calendar/recurring', new ICAL.Event(new ICAL.Component(['vcalendar', [], [ [ 'vevent', [
             [ 'dtstart', {}, 'date-time', moment().date(1).toISOString() ],
             [ 'summary', {}, 'text',      'Weekly Event #0' ],
             [ 'rrule',   {}, 'text',      'FREQ=WEEKLY'     ],
-        ]]]]),
+        ]]]])), ICAL.Time.fromJSDate(moment().date(1).toDate()), undefined),
     ];
 
     const GH_179_recurring_yearly = [
-        new RunboxCalendarEvent('test-calendar/recurring-yearly', ['vcalendar', [], [ [ 'vevent', [
+        new RunboxCalendarEvent('test-calendar/recurring-yearly', new ICAL.Event(new ICAL.Component(['vcalendar', [], [ [ 'vevent', [
             [ 'dtstart', {}, 'date',  moment().date(5).toISOString().split('T')[0] ],
             [ 'dtend',   {}, 'date',  moment().date(6).toISOString().split('T')[0] ],
             [ 'summary', {}, 'text',  'Yearly event' ],
             [ 'rrule',   {}, 'text',  'FREQ=YEARLY'  ],
-        ]]]]),
+        ]]]])), ICAL.Time.fromJSDate(moment().date(5).toDate()), ICAL.Time.fromJSDate(moment().date(6).toDate())),
     ];
 
     // the test below only makes sense when the event start date is not now()
     const not_today = moment().date() === 2 ? 3 : 2;
 
     const GH_181_setting_recurrence = [
-        new RunboxCalendarEvent('test-calendar/not-recurring-yet', ['vcalendar', [], [ [ 'vevent', [
+        new RunboxCalendarEvent('test-calendar/not-recurring-yet', new ICAL.Event(new ICAL.Component(['vcalendar', [], [ [ 'vevent', [
             [ 'dtstart', {}, 'date-time', moment.utc().date(not_today).hour(12).minute(34).toISOString() ],
             [ 'summary', {}, 'text',      'One-shot event' ],
-        ]]]]),
+        ]]]])), ICAL.Time.fromJSDate(moment().utc().date(not_today).hour(12).minute(34).toDate()), undefined),
     ];
 
     const mockData = {

--- a/src/app/calendar-app/calendar-app.component.spec.ts
+++ b/src/app/calendar-app/calendar-app.component.spec.ts
@@ -1,5 +1,5 @@
 // --------- BEGIN RUNBOX LICENSE ---------
-// Copyright (C) 2016-2018 Runbox Solutions AS (runbox.com).
+// Copyright (C) 2016-2021 Runbox Solutions AS (runbox.com).
 //
 // This file is part of Runbox 7.
 //
@@ -161,7 +161,6 @@ describe('CalendarAppComponent', () => {
     it('should display events', () => {
         mockData['events'] = simpleEvents;
         component.calendarservice.syncCaldav(true);
-        // component.calendarservice.eventSubject.next(simpleEvents);
         fixture.detectChanges();
 
         // if we run this at the end of the month, it might be 1, else
@@ -200,13 +199,6 @@ describe('CalendarAppComponent', () => {
         mockData['events'] = recurringEvents;
         component.calendarservice.syncCaldav(true);
 
-        // component.calendarservice.icalevents = [
-        //     { id: 'recurring',
-        //       event: recurringEvents[0].event
-        //     },
-        // ];
-        // component.calendarservice.eventSubject.next(recurringEvents);
-        // component.calendarservice.updateEventList();
         fixture.detectChanges();
 
         const shownEventsCount = component.shown_events.length;

--- a/src/app/calendar-app/calendar-app.component.spec.ts
+++ b/src/app/calendar-app/calendar-app.component.spec.ts
@@ -97,8 +97,65 @@ describe('CalendarAppComponent', () => {
 
     const mockData = {
         calendars: [ new RunboxCalendar({ id: 'test-calendar', displayname: 'Test Calendar', color: 'pink', syncToken: 'testsync' }) ],
-        events:    [] // set in test cases
-    };
+        events:    [], // set in test cases
+        timezone:
+`BEGIN:VCALENDAR
+PRODID:-//citadel.org//NONSGML Citadel calendar//EN
+VERSION:2.0
+BEGIN:VTIMEZONE
+TZID:/citadel.org/20210210_1/Europe/Stockholm
+LAST-MODIFIED:20210210T123706Z
+X-LIC-LOCATION:Europe/Stockholm
+X-PROLEPTIC-TZNAME:LMT
+BEGIN:STANDARD
+TZNAME:SET
+TZOFFSETFROM:+011212
+TZOFFSETTO:+010014
+DTSTART:18790101T000000
+END:STANDARD
+BEGIN:STANDARD
+TZNAME:CET
+TZOFFSETFROM:+010014
+TZOFFSETTO:+0100
+DTSTART:19000101T000000
+END:STANDARD
+BEGIN:DAYLIGHT
+TZNAME:CEST
+TZOFFSETFROM:+0100
+TZOFFSETTO:+0200
+DTSTART:19160514T230000
+RDATE:19800406T020000
+END:DAYLIGHT
+BEGIN:STANDARD
+TZNAME:CET
+TZOFFSETFROM:+0200
+TZOFFSETTO:+0100
+DTSTART:19161001T010000
+END:STANDARD
+BEGIN:STANDARD
+TZNAME:CET
+TZOFFSETFROM:+0200
+TZOFFSETTO:+0100
+DTSTART:19800928T030000
+RRULE:FREQ=YEARLY;BYMONTH=9;BYDAY=-1SU;UNTIL=19950924T010000Z
+END:STANDARD
+BEGIN:DAYLIGHT
+TZNAME:CEST
+TZOFFSETFROM:+0100
+TZOFFSETTO:+0200
+DTSTART:19810329T020000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU
+END:DAYLIGHT
+BEGIN:STANDARD
+TZNAME:CET
+TZOFFSETFROM:+0200
+TZOFFSETTO:+0100
+DTSTART:19961027T030000
+RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU
+END:STANDARD
+END:VTIMEZONE
+END:VCALENDAR
+`    };
 
     beforeEach(async(() => {
         TestBed.configureTestingModule({
@@ -119,6 +176,7 @@ describe('CalendarAppComponent', () => {
                     { provide: RunboxWebmailAPI, useValue: {
                         getCalendars:      (): Observable<RunboxCalendar[]> => of(mockData['calendars']),
                         getCalendarEvents: (): Observable<RunboxCalendarEvent[]> => of(mockData['events']),
+                        getVTimezone:      (tzname: string): Observable<string> => of(mockData['timezone']),
                         me:                    of({ uid: 1 }),
                     } },
                     { provide: HttpClient, useValue: {

--- a/src/app/calendar-app/calendar-app.component.spec.ts
+++ b/src/app/calendar-app/calendar-app.component.spec.ts
@@ -164,7 +164,9 @@ describe('CalendarAppComponent', () => {
         // component.calendarservice.eventSubject.next(simpleEvents);
         fixture.detectChanges();
 
-        expect(component.events.length).toBe(2);
+        // if we run this at the end of the month, it might be 1, else
+        // generally 2!
+        expect(component.events.length).toBeGreaterThan(0);
 
         fixture.detectChanges();
 

--- a/src/app/calendar-app/calendar-app.component.ts
+++ b/src/app/calendar-app/calendar-app.component.ts
@@ -237,10 +237,8 @@ export class CalendarAppComponent implements OnDestroy {
                     this.shown_events.push(e);
                 }
             }
-            // this.calendarservice.updateRecurringEvents(this.viewPeriod);
         }
 
-        // this.cdr.detectChanges();
         this.refresh.next();
     }
 
@@ -395,7 +393,6 @@ export class CalendarAppComponent implements OnDestroy {
     toggleCalendar(calendar_id: string): void {
         this.calendarVisibility[calendar_id] = !this.calendarVisibility[calendar_id];
         this.calendarservice.updateEventList(this.viewPeriod);
-//        this.filterEvents();
         this.cdr.markForCheck();
     }
 

--- a/src/app/calendar-app/calendar-app.component.ts
+++ b/src/app/calendar-app/calendar-app.component.ts
@@ -1,5 +1,5 @@
 // --------- BEGIN RUNBOX LICENSE ---------
-// Copyright (C) 2016-2019 Runbox Solutions AS (runbox.com).
+// Copyright (C) 2016-2021 Runbox Solutions AS (runbox.com).
 //
 // This file is part of Runbox 7.
 //
@@ -275,8 +275,6 @@ export class CalendarAppComponent implements OnDestroy {
         const target = event as RunboxCalendarEvent;
         console.log('Opening event', target);
         const dialogRef = this.dialog.open(EventEditorDialogComponent, {
-        // FIXME: why are we cloning?
-//            data: { event: target.clone(), calendars: this.calendars, settings: this.settings }
             data: { event: target, calendars: this.calendars, settings: this.settings }
         });
         dialogRef.afterClosed().subscribe(result => {

--- a/src/app/calendar-app/calendar-app.component.ts
+++ b/src/app/calendar-app/calendar-app.component.ts
@@ -163,8 +163,11 @@ export class CalendarAppComponent implements OnDestroy {
     }
 
     addEvent(on?: Date): void {
+        // setup new event
+        const new_event = RunboxCalendarEvent.newEmpty(this.calendarservice.me.timezone);
+        new_event.timezone = this.calendarservice.me.timezone;
         const dialogRef = this.dialog.open(EventEditorDialogComponent, {
-            data: { calendars: this.calendars, settings: this.settings, start: on } }
+            data: { event: new_event, calendars: this.calendars, settings: this.settings, start: on, is_new: true } }
         );
         dialogRef.afterClosed().subscribe(event => {
             console.log('Dialog result:', event);
@@ -275,7 +278,7 @@ export class CalendarAppComponent implements OnDestroy {
         const target = event as RunboxCalendarEvent;
         console.log('Opening event', target);
         const dialogRef = this.dialog.open(EventEditorDialogComponent, {
-            data: { event: target, calendars: this.calendars, settings: this.settings }
+            data: { event: target, calendars: this.calendars, settings: this.settings, is_new: false }
         });
         dialogRef.afterClosed().subscribe(result => {
             if (result === 'DELETE') {

--- a/src/app/calendar-app/calendar-app.component.ts
+++ b/src/app/calendar-app/calendar-app.component.ts
@@ -187,7 +187,6 @@ export class CalendarAppComponent implements OnDestroy {
         }
         this.viewPeriod = viewRender.period;
         this.calendarservice.updateEventList(this.viewPeriod);
-        // this.filterEvents();
     }
 
     dayClicked({ date, events }: { date: Date; events: CalendarEvent[] }): void {
@@ -239,6 +238,8 @@ export class CalendarAppComponent implements OnDestroy {
             }
         }
 
+        // else nothing actually visually changes until the next sync!
+        this.cdr.detectChanges();
         this.refresh.next();
     }
 

--- a/src/app/calendar-app/calendar-app.component.ts
+++ b/src/app/calendar-app/calendar-app.component.ts
@@ -220,7 +220,6 @@ export class CalendarAppComponent implements OnDestroy {
         });
     }
 
-    // drag&drop?
     eventTimesChanged({ event, newStart, newEnd }: CalendarEventTimesChangedEvent): void {
         event.start = newStart;
         event.end = newEnd;

--- a/src/app/calendar-app/calendar-app.module.ts
+++ b/src/app/calendar-app/calendar-app.module.ts
@@ -45,6 +45,7 @@ import { MatCardModule } from '@angular/material/card';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MatDialogModule } from '@angular/material/dialog';
+import { MatTabsModule } from '@angular/material/tabs';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
@@ -78,6 +79,7 @@ import { CalendarEventCardComponent } from './calendar-event-card.component';
     MatCheckboxModule,
     MatDatepickerModule,
     MatDialogModule,
+    MatTabsModule,
     MatFormFieldModule,
     MatIconModule,
     MatInputModule,

--- a/src/app/calendar-app/calendar.service.spec.ts
+++ b/src/app/calendar-app/calendar.service.spec.ts
@@ -106,9 +106,10 @@ describe('CalendarService', () => {
     it('should be able to move events between calendars', async () => {
         await new Promise(r => sut.eventSubject.pipe(take(1)).subscribe(events => {
             expect(events.length).toBe(1, '1 event loaded');
-            const event = events[0].clone();
-            event.calendar = 'test2';
-            sut.modifyEvent(event);
+            // FIXME?
+            // const event = events[0].clone();
+            events[0].calendar = 'test2';
+            sut.modifyEvent(events[0]);
             r();
         }));
 

--- a/src/app/calendar-app/calendar.service.spec.ts
+++ b/src/app/calendar-app/calendar.service.spec.ts
@@ -1,5 +1,5 @@
 // --------- BEGIN RUNBOX LICENSE ---------
-// Copyright (C) 2016-2018 Runbox Solutions AS (runbox.com).
+// Copyright (C) 2016-2021 Runbox Solutions AS (runbox.com).
 //
 // This file is part of Runbox 7.
 //
@@ -116,8 +116,6 @@ describe('CalendarService', () => {
     it('should be able to move events between calendars', async () => {
         await new Promise(r => sut.eventSubject.pipe(take(1)).subscribe(events => {
             expect(events.length).toBe(1, '1 event loaded');
-            // FIXME?
-            // const event = events[0].clone();
             events[0].calendar = 'test2';
             sut.modifyEvent(events[0]);
             r();

--- a/src/app/calendar-app/calendar.service.spec.ts
+++ b/src/app/calendar-app/calendar.service.spec.ts
@@ -380,7 +380,7 @@ END:VCALENDAR
         // The above generates by default all events from the
         // startdate of the recurring event, to 2 months in the
         // current future - generate a known set for tests.
-        rbevents = sut.generateEvents(new Date(2020,12,1,0,0,0), new Date(2021,1,1,0,0,0));
+        rbevents = sut.generateEvents(new Date(2020, 12, 1, 0, 0, 0), new Date(2021, 1, 1, 0, 0, 0));
         // These should generate on Mondays, using the dtstart as a pattern
         expect(rbevents.length).toBe(4, 'Got 4 weekly events');
         expect(rbevents[0].start.getDay()).toEqual(1, 'Generates dates on a Monday');

--- a/src/app/calendar-app/calendar.service.spec.ts
+++ b/src/app/calendar-app/calendar.service.spec.ts
@@ -291,6 +291,8 @@ END:VCALENDAR
     });
 
     it('should be possible to import/generate an infinitely repeating event', () => {
+        // This just says "WEEKLY", internals will figure out which
+        // day the startdate is and use that for the repeats.
         const rbevents = sut.fromIcal(undefined,
 `BEGIN:VCALENDAR
 VERSION:2.0
@@ -331,12 +333,13 @@ END:VCALENDAR
 `, true);
         // defaults to 2 months worth of events
         expect(rbevents.length).toBeGreaterThan(7, 'Got more than 7 weekly events');
-        expect(rbevents.length).toBeLessThan(13, 'Got less than 13 weekly events');
         expect(rbevents[0].start.getDay()).toEqual(1, 'Generates dates on a Monday');
     });
 
     it('should be possible to determine the day/time from the dtstart value', () => {
-        const rbevents = sut.fromIcal(undefined,
+        // This just says "WEEKLY", internals will figure out which
+        // day the startdate is and use that for the repeats.
+        let rbevents = sut.fromIcal(undefined,
 `BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:-//www.contactoffice.com//NONSGML Calendar//EN
@@ -374,9 +377,12 @@ TRANSP:OPAQUE
 END:VEVENT
 END:VCALENDAR
 `, true);
-        // defaults to 2 months worth of events
-        expect(rbevents.length).toBeGreaterThan(7, 'Got more than 7 weekly events');
-        expect(rbevents.length).toBeLessThan(13, 'Got less than 13 weekly events');
+        // The above generates by default all events from the
+        // startdate of the recurring event, to 2 months in the
+        // current future - generate a known set for tests.
+        rbevents = sut.generateEvents(new Date(2020,12,1,0,0,0), new Date(2021,1,1,0,0,0));
+        // These should generate on Mondays, using the dtstart as a pattern
+        expect(rbevents.length).toBe(4, 'Got 4 weekly events');
         expect(rbevents[0].start.getDay()).toEqual(1, 'Generates dates on a Monday');
     });
 });

--- a/src/app/calendar-app/calendar.service.spec.ts
+++ b/src/app/calendar-app/calendar.service.spec.ts
@@ -337,8 +337,8 @@ END:VCALENDAR
         // Produces multiple CalendarEvents which refer to the same ICal.Event
         expect(rbevents.length).toEqual(5, 'Recurring event contains 5 instances');
         expect(rbevents[0].recurringFrequency).toEqual('DAILY', 'recurrence is DAILY');
-        expect(rbevents[0].start).toEqual(new Date(2021, 3, 25, 13, 0, 0), 'event 1 start date is 9am');
-        expect(rbevents[1].start).toEqual(new Date(2021, 3, 26, 14, 0, 0), 'event 1 start date is 10am');
+        expect(rbevents[0].start).toEqual(new Date(2021, 3, 25, 9, 0, 0), 'event 1 start date is 9am');
+        expect(rbevents[1].start).toEqual(new Date(2021, 3, 26, 10, 0, 0), 'event 1 start date is 10am');
     });
 
     it('should be possible to import a static (non recurring) event', () => {

--- a/src/app/calendar-app/calendar.service.ts
+++ b/src/app/calendar-app/calendar.service.ts
@@ -519,8 +519,6 @@ export class CalendarService implements OnDestroy {
             // multiple months
             if (this.icalevents.length > 0) {
                 this.events = this.generateEvents(start.toDate(), next_month.toDate(), this.icalevents);
-//                this.events = this.generateEvents(viewPeriod.start, viewPeriod.end, this.icalevents);
-                // calendar-app calls filterEvents, will this recurse infinitely!?
                 this.eventSubject.next(this.events);
             }
 

--- a/src/app/calendar-app/calendar.service.ts
+++ b/src/app/calendar-app/calendar.service.ts
@@ -71,7 +71,7 @@ export class CalendarService implements OnDestroy {
             }
             console.log('Cache version:', cache['version']);
             // tslint:disable-next-line:triple-equals
-            if (cache['version'] != 3) {
+            if (cache['version'] != 4) {
                 console.log('Old cache format found, removing');
                 storage.set('caldavCache', undefined);
                 return;
@@ -87,7 +87,9 @@ export class CalendarService implements OnDestroy {
             this.calendarSubject.next(this.calendars);
             this.eventSubject.next(this.events);
             this.activities.end(Activity.LoadingCache);
-        }).then((_) => this.syncCaldav());
+        }).then(
+            () => this.syncCaldav(),
+        );
 
         this.calendarSubject.subscribe(cals => {
             const updatedCals = [];
@@ -202,7 +204,7 @@ export class CalendarService implements OnDestroy {
         // fixup underspecified rules
         // (or else figure out the nearest one to our start date but ick)
         // clone the recur object to update it:
-        let new_rule = rule_iterator.rule.clone();
+        const new_rule = rule_iterator.rule.clone();
         const event_start = icalevent.startDate;
         if (rule_iterator.rule.freq === 'WEEKLY'
             && !rule_iterator.has_by_data('BYDAY')) {
@@ -249,8 +251,6 @@ export class CalendarService implements OnDestroy {
         }
         // update if changed:
         if (new_rule.toString() !== rule_iterator.rule.toString()) {
-            console.log('new RRULE');
-            console.log(new_rule.toString());
             icalevent.component.updatePropertyWithValue('rrule', new_rule);
         }
 
@@ -360,7 +360,6 @@ export class CalendarService implements OnDestroy {
 
             // improve RRULEs if underspecified (then save!?)
             icalevent = this.fixICALEvent(icalevent);
-            // FIXME: splice changed item back into .icalevents? (in fixICALevent func)
 
             // Now recheck the start_date_ICAL against the known
             // start/end/until dates
@@ -372,7 +371,7 @@ export class CalendarService implements OnDestroy {
                 const calc_end_date = ICAL.Time.fromString(icalevent.component.parent
                     .getFirstPropertyValue('X-RUNBOX-CALCULATED-DTEND')).toJSDate();
                 if (startDate && moment(startDate).isAfter(calc_end_date)) {
-                    console.log('Skipping generation as already ended');
+                    // console.log('Skipping generation as already ended');
                     return;
                 }
                 // on COUNT, generate all

--- a/src/app/calendar-app/calendar.service.ts
+++ b/src/app/calendar-app/calendar.service.ts
@@ -22,12 +22,14 @@ import { RunboxCalendarEvent } from './runbox-calendar-event';
 import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
 import { StorageService } from '../storage.service';
 import { BackgroundActivityService } from '../common/background-activity.service';
+import { ViewPeriod } from 'calendar-utils';
 
 import { Injectable, OnDestroy } from '@angular/core';
 import { HttpErrorResponse } from '@angular/common/http';
 import { Observable, Subject, ReplaySubject } from 'rxjs';
 
 import * as moment from 'moment';
+import * as ICAL from 'ical.js';
 
 enum Activity {
     LoadingCache        = 'Loading local cache',
@@ -45,6 +47,8 @@ enum Activity {
 export class CalendarService implements OnDestroy {
     calendars:    RunboxCalendar[]      = [];
     events:       RunboxCalendarEvent[] = [];
+    // Stores ICAL.Events, one per single/recurring item, with .exceptions set
+    icalevents:   { id: string, event: ICAL.Event}[] = [];
 
     syncTokens = {};
     syncInterval: any;
@@ -78,11 +82,12 @@ export class CalendarService implements OnDestroy {
             for (const cal of this.calendars) {
                 this.syncTokens[cal.id] = cal.syncToken;
             }
+            const runboxevents = cache['events'].map((e: any) => this.fromIcal(e.id, e.ical));
+            runboxevents.forEach((events) => this.events = this.events.concat(events));
             this.calendarSubject.next(this.calendars);
-            this.events = cache['events'].map((e: any) => new RunboxCalendarEvent(e.id, e.jcal));
             this.eventSubject.next(this.events);
             this.activities.end(Activity.LoadingCache);
-        });
+        }).then((_) => this.syncCaldav());
 
         this.calendarSubject.subscribe(cals => {
             const updatedCals = [];
@@ -110,7 +115,6 @@ export class CalendarService implements OnDestroy {
         this.syncInterval = setInterval(() => {
             this.syncCaldav();
         }, this.syncIntervalSeconds * 1000);
-        this.syncCaldav();
     }
 
     ngOnDestroy() {
@@ -189,6 +193,205 @@ export class CalendarService implements OnDestroy {
         });
     }
 
+    fixICALEvent(icalevent: ICAL.Event): ICAL.Event {
+        // check if the rrule is specific enough:
+        const test_iterator = icalevent.iterator();
+        // V2+ does not allow multiple RRULES (so sabre will reject em?)
+        const rule_iterator = test_iterator.ruleIterators[0];
+
+        // fixup underspecified rules
+        // (or else figure out the nearest one to our start date but ick)
+        // clone the recur object to update it:
+        let new_rule = rule_iterator.rule.clone();
+        const event_start = icalevent.startDate;
+        if (rule_iterator.rule.freq === 'WEEKLY'
+            && !rule_iterator.has_by_data('BYDAY')) {
+            // set BYDAY to the day of the DTSTART
+            new_rule.addComponent(
+                'BYDAY',
+                ICAL.Recur.numericDayToIcalDay(event_start.dayOfWeek())
+            );
+        } else if (rule_iterator.rule.freq === 'MONTHLY'
+            && !rule_iterator.has_by_data('BYMONTHDAY')
+            && !rule_iterator.has_by_data('BYDAY') ) {
+            // set BYMONTHDAY
+            new_rule.addComponent(
+                'BYMONTHDAY',
+                event_start.day
+            );
+        } else if (rule_iterator.rule.freq === 'YEARLY'
+            && !rule_iterator.has_by_data('BYDAY')
+            && !rule_iterator.has_by_data('BYMONTHDAY')) {
+            // set BYMONTH && BYMONTHDAY from DTSTART
+            new_rule.addComponent(
+                'BYMONTH',
+                event_start.month
+            );
+            new_rule.addComponent(
+                'BYMONTHDAY',
+                event_start.day
+            );
+        }
+
+        // set hour/min/sec if not set:
+        if (!event_start.isDate) {
+            if (!rule_iterator.has_by_data('BYHOUR')) {
+                new_rule.addComponent('BYHOUR', event_start.hour);
+            }
+            // set min if not set:
+            if (!rule_iterator.has_by_data('BYMINUTE')) {
+                new_rule.addComponent('BYMINUTE', event_start.minute);
+            }
+            // set sec if not set:
+            if (!rule_iterator.has_by_data('BYSECOND')) {
+                new_rule.addComponent('BYSECOND', event_start.second);
+            }
+        }
+        // update if changed:
+        if (new_rule.toString() !== rule_iterator.rule.toString()) {
+            console.log('new RRULE');
+            console.log(new_rule.toString());
+            icalevent.component.updatePropertyWithValue('rrule', new_rule);
+        }
+
+        // this is based on the updated RRULE, I hope:
+        // UNTIL is already coped with, infinite is fine
+        // COUNT is the only one based on the DTSTART date.
+        if (rule_iterator.rule.isByCount()) {
+            // ends on a counted number of occurrences, bah humbug
+            // did we calculate this already?
+            if (!icalevent.component.parent.hasProperty('X-RUNBOX-CALCULATED-DTEND')) {
+                // calculate enddate + store it (loop until end)
+                const updated_iterator = icalevent.iterator();
+                let next_time = updated_iterator.next();
+                let last_time;
+                while ( next_time ) {
+                    last_time = next_time;
+                    next_time = updated_iterator.next();
+                }
+                // next_time is the end time!
+                icalevent.component.parent.addPropertyWithValue('X-RUNBOX-CALCULATED-DTEND', last_time.toString());
+            }
+        }
+        // this or the ical string and reparse it?
+        return icalevent;
+    }
+
+    // each ical "event" represents one or more items on the actual calendar
+    // eg for recurrening events. create N RunboxCalendarEvents, one per visible
+    // item, set their specific dtstart date, store the same ICAL.Event.
+    // an exception ICAL.Event gets both the exception, and the main one!?
+    // set an "isException" flag!?
+    fromIcal(id: string, ical: string, keep = true): RunboxCalendarEvent[] {
+        let component = new ICAL.Component(ICAL.parse(ical));
+        // https://github.com/mozilla-comm/ical.js/issues/455
+        if (component.getFirstSubcomponent('vtimezone')) {
+            for (const tzComponent of component.getAllSubcomponents('vtimezone')) {
+                const tz = new ICAL.Timezone({
+                    tzid:      tzComponent.getFirstPropertyValue('tzid'),
+                    component: tzComponent,
+                });
+
+                if (!ICAL.TimezoneService.has(tz.tzid)) {
+                    ICAL.TimezoneService.register(tz.tzid, tz);
+                }
+            }
+        }
+        component = ICAL.helpers.updateTimezones(component);
+        // Skip exceptions, ICAL.Event will add them as related items.
+        // Assuming this is one event, this should return one item
+        // with all the related ones attached to it(!)
+        // NB: Some ics has recurrence-id on *every* VEVENT, how prevalent
+        // is that? - this code will fail on those..
+        // keep = strict checking (not just for overview) and store
+        const vevents = component.getAllSubcomponents('vevent')
+            .filter((c) => !c.hasProperty('recurrence-id'))
+            .map((c) => new ICAL.Event(c, {'strictExceptions': keep}));
+        if (keep) {
+            this.icalevents.push({ 'id': id, 'event': vevents[0] });
+        }
+        // generate RBE events for just this set, for current month+1:
+        // FIXME: what if user runs import while not looking at "today"?
+        return this.generateEvents(undefined,
+                                   undefined,
+                                   [{ 'id': id, 'event': vevents[0] }]);
+    }
+
+    // generate RBE events from ICAL.Events (inc exceptions)
+    // default to "now", plus 1mo, and "events stored by fromIcal previously
+    // iterator will quite happily generate events before the ICAL startdate
+    // if you ask it to!
+
+    generateEvents(startDate?: Date, endDate?: Date, ical_events?: { id: string, event: ICAL.Event}[]): RunboxCalendarEvent[] {
+
+        // end does not default! recurs forever unless stopped
+        // set below if not a COUNT item
+        let end_date_Moment = endDate
+            ? moment(endDate)
+            : undefined;
+
+        const event_list = ical_events ? ical_events : this.icalevents;
+
+        // Get the instances (one per date):
+        // ICAL.RecurExpansion iterator
+        const events: RunboxCalendarEvent[] = [];
+        event_list.forEach((ievent) => {
+            const id = ievent['id'];
+            let icalevent = ievent['event'];
+
+            if (!icalevent.isRecurring()) {
+                if (!startDate ||
+                    (moment(startDate).isSameOrBefore(icalevent.endDate.toJSDate())
+                        && moment(endDate).isSameOrAfter(icalevent.startDate.toJSDate()) )) {
+                    events.push(new RunboxCalendarEvent(id, icalevent, icalevent.startDate, icalevent.endDate));
+                }
+                return;
+            }
+            // start defaults to event dtstart if undefined
+            // don't start before the event itself starts
+            // (after end is checked below)
+            const start_date_ICAL = startDate && moment(startDate).isSameOrAfter(icalevent.startDate.toJSDate())
+                ? ICAL.Time.fromJSDate(startDate) : undefined;
+
+            // in case we just got passed a generic date:
+            if (start_date_ICAL) {
+                start_date_ICAL.isDate = icalevent.startDate.isDate;
+            }
+
+            // improve RRULEs if underspecified (then save!?)
+            icalevent = this.fixICALEvent(icalevent);
+            // FIXME: splice changed item back into .icalevents? (in fixICALevent func)
+
+            // Now recheck the start_date_ICAL against the known
+            // start/end/until dates
+            // And actually generate some events!
+            let next_time;
+            let iterator = icalevent.iterator(start_date_ICAL);
+            if (iterator.ruleIterators[0].rule.isByCount()
+                && icalevent.component.parent.hasProperty('X-RUNBOX-CALCULATED-DTEND')) {
+                const calc_end_date = ICAL.Time.fromString(icalevent.component.parent
+                    .getFirstPropertyValue('X-RUNBOX-CALCULATED-DTEND')).toJSDate();
+                if (startDate && moment(startDate).isAfter(calc_end_date)) {
+                    console.log('Skipping generation as already ended');
+                    return;
+                }
+                // on COUNT, generate all
+                iterator = icalevent.iterator();
+            } else if (!end_date_Moment) {
+                end_date_Moment =  moment().startOf('month').add(2, 'month');
+            }
+
+            // keep going until we pass the end date:
+            while ( ( next_time = iterator.next() )
+                && (end_date_Moment ? end_date_Moment.isAfter(next_time.toJSDate()) : true) ) {
+                const details = icalevent.getOccurrenceDetails(next_time);
+                events.push(
+                    new RunboxCalendarEvent(id, details.item, details.startDate, details.endDate));
+            }
+        });
+        return events;
+    }
+
     modifyCalendar(calendar: RunboxCalendar) {
         this.activities.begin(Activity.EditingCalendar);
         this.rmmapi.modifyCalendar(calendar).subscribe(() => {
@@ -204,19 +407,19 @@ export class CalendarService implements OnDestroy {
     }
 
     modifyEvent(event: RunboxCalendarEvent) {
-        const existing = this.events.find(c => c.id === event.id);
-        if (existing.calendar !== event.calendar) {
+        if (event._old_id) {
+            console.log('old id found');
             // special case: if event.calendar is being modified we can't simply update the event:
             // we need to copy it to a new calendar, and remove it from the old one.
-            event.id = null; // this will make it a "new" event
             this.addEvent(event).then(id => {
                 console.log('Event recreated as', id);
-                this.deleteEvent(existing.id);
+                this.deleteEvent(event._old_id);
             });
         } else {
             // simple case: just modify the event in place
             this.activities.begin(Activity.EditingEvent);
             this.rmmapi.modifyCalendarEvent(event as RunboxCalendarEvent).subscribe(_ => {
+                // FIXME: ids are no longer unique!? add start time to the mix?
                 const idx = this.events.findIndex(c => c.id === event.id);
                 this.events.splice(idx, 1, event);
                 this.eventSubject.next(this.events);
@@ -241,7 +444,13 @@ export class CalendarService implements OnDestroy {
         console.log('Fetching events');
         this.activities.begin(Activity.RefreshingEvents);
         this.rmmapi.getCalendarEvents().subscribe(events => {
-            this.events = events.map((e: any) => RunboxCalendarEvent.fromIcal(e.id, e.ical));
+            // Returns an array of RunboxCalendarEvent objects
+            this.events = [];
+            this.icalevents = [];
+            events.forEach((e: any) => {
+                const runboxevents = this.fromIcal(e.id, e.ical);
+                this.events = this.events.concat(runboxevents);
+            });
             this.eventSubject.next(this.events);
             this.activities.end(Activity.RefreshingEvents);
         }, e => {
@@ -260,7 +469,8 @@ export class CalendarService implements OnDestroy {
         const cache = {
             version:   3,
             calendars: this.calendars,
-            events:    this.events,
+            events:    this.icalevents.map((event) =>
+                ({'id': event['id'], 'ical': event['event'].component.parent.toString() } ))
         };
         this.storage.set('caldavCache', cache);
     }
@@ -282,4 +492,33 @@ export class CalendarService implements OnDestroy {
             this.activities.end(Activity.RefreshingCalendars);
         });
     }
+
+    // check if we have enough events to show another month worth
+    // (forward and back), generate if not
+    updateEventList(viewPeriod?: ViewPeriod): void {
+        let this_month, start, end_month, next_month: moment.Moment;
+        // Too much is better than not enough!
+        if (viewPeriod) {
+            this_month = moment(viewPeriod.start).startOf('month');
+        } else {
+            this_month  = moment().startOf('month');
+        }
+        // generate now(viewdate) +/- 1 month (max display size)
+        start       = this_month.clone(); start.subtract(1, 'month');
+        end_month   = this_month.clone(); end_month.add(1, 'month');
+        next_month  = this_month.clone(); next_month.add(3, 'month');
+
+        // Could try and be clever and generate only last month / next month
+        // assuming some previous code did current one, but.. how to only insert
+        // those new ones into this.events?
+        // lets just try/do all for now
+        // we wont interrupt the page redraw process though.
+
+        if (this.icalevents.length > 0) {
+            this.events = this.generateEvents(start.toDate(), next_month.toDate(), this.icalevents);
+            // calendar-app calls filterEvents, will this recurse infinitely!?
+            this.eventSubject.next(this.events);
+        }
+    }
+
 }

--- a/src/app/calendar-app/calendar.service.ts
+++ b/src/app/calendar-app/calendar.service.ts
@@ -380,7 +380,6 @@ export class CalendarService implements OnDestroy {
             } else if (!end_date_Moment) {
                 end_date_Moment =  moment().startOf('month').add(2, 'month');
             }
-
             // keep going until we pass the end date:
             while ( ( next_time = iterator.next() )
                 && (end_date_Moment ? end_date_Moment.isAfter(next_time.toJSDate()) : true) ) {

--- a/src/app/calendar-app/event-editor-dialog.component.html
+++ b/src/app/calendar-app/event-editor-dialog.component.html
@@ -1,5 +1,7 @@
-<h1 mat-dialog-title>{{ event.title || "New event" }}</h1>
-<div mat-dialog-content>
+<h1 mat-dialog-title>{{ event_title || "New event" }}</h1>
+<section mat-dialog-content>
+  <mat-tab-group>
+    <mat-tab label="Details">
     <style>
         .mat-form-field {
             width: 100%;
@@ -7,15 +9,15 @@
     </style>
     <p>
         <mat-form-field>
-            <input matInput type="text" placeholder="Title" [(ngModel)]="event.title">
+            <input matInput type="text" placeholder="Title" [(ngModel)]="event_title">
         </mat-form-field>
     </p><p>
         <mat-form-field>
-            <input matInput type="text" placeholder="Location" [(ngModel)]="event.location">
+            <input matInput type="text" placeholder="Location" [(ngModel)]="event_location">
         </mat-form-field>
     </p><p>
         <mat-form-field>
-            <textarea matInput placeholder="Description" [(ngModel)]="event.description"></textarea>
+            <textarea matInput placeholder="Description" [(ngModel)]="event_description"></textarea>
         </mat-form-field>
     </p><p>
         <mat-form-field>
@@ -29,11 +31,12 @@
         </mat-form-field>
     </p><p>
         <label class="calendarEventPeriodLabel">Start: </label>
-        <input [(ngModel)]="event_start"
+        <input (ngModelChange)="updateStart($event)"
+               [(ngModel)]="event_start"
                [owlDateTimeTrigger]="start_dt" [owlDateTime]="start_dt">
         <owl-date-time
             #start_dt
-            [pickerType]="event.allDay ? 'calendar' : 'both'"
+            [pickerType]="event_allDay ? 'calendar' : 'both'"
             pickerMode="dialog"
             [firstDayOfWeek]="settings.weekStartsOnSunday ? 0 : 1"
         ></owl-date-time>
@@ -43,21 +46,62 @@
                [owlDateTimeTrigger]="end_dt" [owlDateTime]="end_dt">
         <owl-date-time
             #end_dt
-            [pickerType]="event.allDay ? 'calendar' : 'both'"
+            [pickerType]="event_allDay ? 'calendar' : 'both'"
             pickerMode="dialog"
             [firstDayOfWeek]="settings.weekStartsOnSunday ? 0 : 1"
         ></owl-date-time>
     </p><p>
-        <mat-checkbox [(ngModel)]="event.allDay">All-day event</mat-checkbox>
-    </p><p>
+        <mat-checkbox [(ngModel)]="event_allDay">All-day event</mat-checkbox>
+    </p>
+    </mat-tab>
+    <mat-tab label="Recurrence">
+      <ng-container *ngIf="edit_recurrence" class="display: flex;">
+        <p>
+          <mat-checkbox [(ngModel)]="event_recurs"> Event repeats </mat-checkbox>
+        </p><p>
+          <mat-form-field style="margin-top: 10px;">
+            <mat-label> Repeat every </mat-label>
+            <input matInput type="number" placeholder="1" (input)="updateInterval()" [(ngModel)]="recur_interval" [disabled]="!event_recurs">
+          </mat-form-field>
+        </p><p>
         <mat-form-field style="margin-top: 10px;">
-            <mat-label> Recurring </mat-label>
-            <mat-select placeholder="Recurring" [(ngModel)]="recurring_frequency">
+            <mat-label>  </mat-label>
+            <mat-select placeholder="day(s)" (selectionChange)="updateFrequency()" [(ngModel)]="recurring_frequency" [disabled]="!event_recurs">
                 <mat-option *ngFor="let freq of recurrence_frequencies" [value]="freq.val">
                     {{ freq.name }}
                 </mat-option>
             </mat-select>
         </mat-form-field>
+        </p><p>
+          <ng-container *ngIf="recurring_frequency == 'WEEKLY'" style="margin-top: 10px;display: flex;">
+            <mat-label> on day(s) </mat-label>
+            <mat-checkbox *ngFor="let wday of weekdays" (selectionChange)="updateWeekdays()" [(ngModel)]="wday.recurs_on" [value]="wday.val" [disabled]="!event_recurs">{{ wday.name }}</mat-checkbox>
+          </ng-container>
+        </p>
+        <ng-container *ngIf="recurring_frequency == 'MONTHLY' || recurring_frequency == 'YEARLY'" style="margin-top: 10px;display: flex;">
+          <p>
+            <mat-label> on the </mat-label>
+            <mat-select (selectionChange)="updateMonthlyNth($event)" [(value)]="recur_by_monthyeardays" multiple [disabled]="!event_recurs">
+              <mat-option *ngFor="let mnthday of month_year_days" [value]="mnthday.val" ngDefaultControl>{{ mnthday.name }}</mat-option>
+            </mat-select>
+            <mat-select (selectionChange)="updateWeekday($event)" [(value)]="recur_by_weekdays" multiple [disabled]="!event_recurs">
+              <mat-option value="day">day</mat-option>
+              <mat-option *ngFor="let wday of weekdays"[value]="wday.val" ngDefaultControl>{{ wday.name }}</mat-option>
+            </mat-select>
+          </p>
+          <p *ngIf="recurring_frequency == 'MONTHLY'">
+            of the month
+          </p>
+          <p *ngIf="recurring_frequency == 'YEARLY'">
+            <mat-label> of </mat-label>
+            <mat-select (selectionChange)="updateMonths($event)" [(value)]="recur_by_months" multiple [disabled]="!event_recurs">
+              <mat-option *ngFor="let month of year_months" [value]="month.val" ngDefaultControl>{{ month.name }}</mat-option>
+            </mat-select>
+          </p>
+        </ng-container>
+    </ng-container>
+    <p *ngIf="!edit_recurrence">
+      This event is an exception to a recurring one, to change the recurrence edit the main event.
     </p><p>
         <a *ngIf="export_url"
             [href]="export_url"
@@ -65,8 +109,21 @@
             <mat-icon svgIcon="swap-vertical"></mat-icon> Export this event
         </a>
     </p>
-</div>
-<div mat-dialog-actions style="justify-content: flex-end;">
+    </mat-tab>
+  </mat-tab-group>
+</section>
+<section mat-dialog-actions style="justify-content: flex-end;">
+    <ng-container>
+        <mat-form-field style="margin-top: 10px;">
+            <mat-label> modify which events? </mat-label>
+            <mat-select placeholder="All ocurrences" [(ngModel)]="recur_save_type" [disabled]="!change_save_type">
+                <mat-option *ngFor="let type of save_types" [value]="type.val" [disabled]="type.disabled">
+                    {{ type.name }}
+                </mat-option>
+            </mat-select>
+        </mat-form-field>
+    </ng-container>
+
     <button *ngIf="event.id"
             mat-raised-button color="warn"
             (click)="onDeleteClick()">Delete this event</button>
@@ -80,4 +137,4 @@
         <span *ngIf="!event.id"> Create </span>
     </button>
 
-</div>
+</section>

--- a/src/app/calendar-app/event-editor-dialog.component.html
+++ b/src/app/calendar-app/event-editor-dialog.component.html
@@ -1,5 +1,5 @@
 <h1 mat-dialog-title>{{ event_title || "New event" }}</h1>
-<section mat-dialog-content>
+<section mat-dialog-content style="max-width: 500px; box-sizing: border-box;">
   <mat-tab-group>
     <mat-tab label="Details">
     <style>
@@ -55,9 +55,9 @@
     </p>
     </mat-tab>
     <mat-tab label="Recurrence">
-      <ng-container *ngIf="edit_recurrence" class="display: flex;">
+      <ng-container *ngIf="edit_recurrence" style="display: flex;">
         <p>
-          <mat-checkbox [(ngModel)]="event_recurs"> Event repeats </mat-checkbox>
+          <mat-checkbox style="padding: 0 5px;" [(ngModel)]="event_recurs"> Event repeats </mat-checkbox>
         </p><p>
           <mat-form-field style="margin-top: 10px;">
             <mat-label> Repeat every </mat-label>
@@ -79,42 +79,40 @@
           </ng-container>
         </p>
         <ng-container *ngIf="recurring_frequency == 'MONTHLY' || recurring_frequency == 'YEARLY'" style="margin-top: 10px;display: flex;">
-          <p>
-            <mat-label> on the </mat-label>
-            <mat-select (selectionChange)="updateMonthlyNth($event)" [(value)]="recur_by_monthyeardays" multiple [disabled]="!event_recurs">
+          <p style="display: flex; justify-content: space-between; align-items: center;">
+            on the
+            <mat-select style="width:auto;" (selectionChange)="updateMonthlyNth($event)" [(value)]="recur_by_monthyeardays" multiple [disabled]="!event_recurs">
               <mat-option *ngFor="let mnthday of month_year_days" [value]="mnthday.val" ngDefaultControl>{{ mnthday.name }}</mat-option>
             </mat-select>
-            <mat-select (selectionChange)="updateWeekday($event)" [(value)]="recur_by_weekdays" multiple [disabled]="!event_recurs">
+            <mat-select style="width:auto;" (selectionChange)="updateWeekday($event)" [(value)]="recur_by_weekdays" multiple [disabled]="!event_recurs">
               <mat-option value="day">day</mat-option>
               <mat-option *ngFor="let wday of weekdays"[value]="wday.val" ngDefaultControl>{{ wday.name }}</mat-option>
             </mat-select>
-          </p>
-          <p *ngIf="recurring_frequency == 'MONTHLY'">
-            of the month
-          </p>
-          <p *ngIf="recurring_frequency == 'YEARLY'">
-            <mat-label> of </mat-label>
-            <mat-select (selectionChange)="updateMonths($event)" [(value)]="recur_by_months" multiple [disabled]="!event_recurs">
-              <mat-option *ngFor="let month of year_months" [value]="month.val" ngDefaultControl>{{ month.name }}</mat-option>
-            </mat-select>
-          </p>
+            <span *ngIf="recurring_frequency == 'MONTHLY'">
+              of the month
+            </span>
+            <span *ngIf="recurring_frequency == 'YEARLY'">
+              of
+              <mat-select style="width:auto;" (selectionChange)="updateMonths($event)" [(value)]="recur_by_months" multiple [disabled]="!event_recurs">
+                <mat-option *ngFor="let month of year_months" [value]="month.val" ngDefaultControl>{{ month.name }}</mat-option>
+              </mat-select>
+          </span>
         </ng-container>
-    </ng-container>
-    <p *ngIf="!edit_recurrence">
+      </ng-container>
+      <p *ngIf="!edit_recurrence">
       This event is an exception to a recurring one, to change the recurrence edit the main event.
-    </p><p>
-        <a *ngIf="export_url"
-            [href]="export_url"
-            mat-button>
-            <mat-icon svgIcon="swap-vertical"></mat-icon> Export this event
-        </a>
     </p>
     </mat-tab>
   </mat-tab-group>
-</section>
-<section mat-dialog-actions style="justify-content: flex-end;">
     <ng-container>
-        <mat-form-field style="margin-top: 10px;">
+      <p>
+        <a *ngIf="export_url"
+           [href]="export_url"
+           mat-button>
+          <mat-icon svgIcon="swap-vertical"></mat-icon> Export this event
+        </a>
+      </p>
+      <mat-form-field style="margin-top: 10px;">
             <mat-label> modify which events? </mat-label>
             <mat-select placeholder="All ocurrences" [(ngModel)]="recur_save_type" [disabled]="!change_save_type">
                 <mat-option *ngFor="let type of save_types" [value]="type.val" [disabled]="type.disabled">
@@ -123,12 +121,15 @@
             </mat-select>
         </mat-form-field>
     </ng-container>
-
+</section>
+<section mat-dialog-actions style="display: flex; justify-content: space-between;">
+  <span>
     <button *ngIf="event.id"
             mat-raised-button color="warn"
             (click)="onDeleteClick()">Delete this event</button>
-
-    <button mat-button
+  </span>
+  <span>
+    <button mat-raised-button color="accent"
             (click)="onCancelClick()">Cancel</button>
 
     <button id="eventSubmitButton" mat-raised-button color="primary"
@@ -136,5 +137,6 @@
         <span *ngIf="event.id">  Update </span>
         <span *ngIf="!event.id"> Create </span>
     </button>
+  </span>
 
 </section>

--- a/src/app/calendar-app/event-editor-dialog.component.ts
+++ b/src/app/calendar-app/event-editor-dialog.component.ts
@@ -107,13 +107,13 @@ export class EventEditorDialogComponent {
         this.event = data['event'];
         if (!data['is_new']) {
             this.calendarFC.setValue(this.event.calendar);
+            // TODO: Abstract url in rmmapi?
             this.export_url = '/rest/v1/calendar/ics/' + this.event.id;
             this.event_title = this.event.title;
             this.event_location = this.event.location;
             this.event_description = this.event.description;
             this.event_allDay = this.event.allDay;
 
-            // this.event_start = this.event.dtstart.toDate();
             this.event_start = this.event.start;
             this.event_end = this.event.end;
             this.event_recurs = this.event.recurs;
@@ -373,9 +373,6 @@ export class EventEditorDialogComponent {
             this.calendarFC.markAsTouched();
             return;
         }
-        // else if (this.event.calendar !== this.calendarFC.value) {
-        //     this.event.calendar = this.calendarFC.value;
-        // }
 
         const dtstart = moment(this.event_start).seconds(0).milliseconds(0);
         let dtend = moment(this.event_end).seconds(0).milliseconds(0);

--- a/src/app/calendar-app/event-editor-dialog.component.ts
+++ b/src/app/calendar-app/event-editor-dialog.component.ts
@@ -35,7 +35,7 @@ import * as ICAL from 'ical.js';
     templateUrl: 'event-editor-dialog.component.html',
 })
 export class EventEditorDialogComponent {
-    event = RunboxCalendarEvent.newEmpty();
+    event: RunboxCalendarEvent;
     calendars: RunboxCalendar[];
     calendarFC = new FormControl('', Validators.required);
     event_start: Date;
@@ -104,8 +104,8 @@ export class EventEditorDialogComponent {
         this.calendars = data['calendars'];
         this.calendarFC.setValue(this.calendars[0].id);
 
-        if (data['event']) {
-            this.event = data['event'];
+        this.event = data['event'];
+        if (!data['is_new']) {
             this.calendarFC.setValue(this.event.calendar);
             this.export_url = '/rest/v1/calendar/ics/' + this.event.id;
             this.event_title = this.event.title;
@@ -113,14 +113,11 @@ export class EventEditorDialogComponent {
             this.event_description = this.event.description;
             this.event_allDay = this.event.allDay;
 
-            this.event_start = this.event.dtstart.toDate();
-            if (this.event.allDay) {
-                // inclusive vs exclusive, see the comment in onSubmitClick()
-                this.event_end = this.event.dtend.subtract(1, 'day').toDate();
-            } else {
-                this.event_end = this.event.dtend.toDate();
-            }
+            // this.event_start = this.event.dtstart.toDate();
+            this.event_start = this.event.start;
+            this.event_end = this.event.end;
             this.event_recurs = this.event.recurs;
+
             // default:
             this.change_save_type = this.event_recurs;
             if (this.event_recurs
@@ -190,8 +187,9 @@ export class EventEditorDialogComponent {
                 this.event_start = moment(data['start']).hours(12).minutes(0).seconds(0).toDate();
                 this.event_end   = moment(data['start']).hours(14).minutes(0).seconds(0).toDate();
             } else {
-                this.event_start = moment().toDate();
-                this.event_end   = moment().toDate();
+                const now = moment();
+                this.event_start = now.toDate();
+                this.event_end   = now.add(1, 'hours').toDate();
             }
 
             // Default things for "new" events

--- a/src/app/calendar-app/event-editor-dialog.component.ts
+++ b/src/app/calendar-app/event-editor-dialog.component.ts
@@ -131,8 +131,8 @@ export class EventEditorDialogComponent {
             // Already an exception, may not save as "all occurences"
             // or "this and future"?
             if (this.event.isException) {
-                this.save_types[0]['disabled'] = false;
-                this.save_types[2]['disabled'] = false;
+                this.save_types[0]['disabled'] = true;
+                this.save_types[2]['disabled'] = true;
                 this.recur_save_type = '1';
                 this.edit_recurrence = false;
             }
@@ -171,9 +171,19 @@ export class EventEditorDialogComponent {
                 this.recur_by_monthyeardays = this.event.recursByYearDay;
                 this.recur_by_weekdays = ['day'];
             }
+            if (this.recur_by_monthyeardays.length === 0) {
+                // neither, set defaults in case its changed to either of these
+                this.recur_by_monthyeardays = [this.event_start.getDate().toString()];
+            }
+            if (this.recur_by_weekdays.length === 0) {
+                this.recur_by_weekdays = ['day'];
+            }
             // month event occurs if yearly:
-            if (this.recurring_frequency === 'YEARLY' && this.event.recursByMonth.length > 0) {
+            if (this.recurring_frequency === 'YEARLY'
+                && this.event.recursByMonth.length > 0) {
                 this.recur_by_months = this.event.recursByMonth;
+            } else {
+                this.recur_by_months = [String(this.event_start.getMonth() + 1)];
             }
         } else {
             if (data['start']) {

--- a/src/app/calendar-app/event-editor-dialog.component.ts
+++ b/src/app/calendar-app/event-editor-dialog.component.ts
@@ -20,6 +20,7 @@
 import { Component, Inject } from '@angular/core';
 import { FormControl, Validators } from '@angular/forms';
 import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatTab } from '@angular/material/tabs';
 
 import { CalendarSettings } from './calendar-settings';
 import { RunboxCalendar } from './runbox-calendar';
@@ -27,6 +28,7 @@ import { RunboxCalendarEvent } from './runbox-calendar-event';
 import { DeleteConfirmationDialogComponent } from './delete-confirmation-dialog.component';
 
 import * as moment from 'moment';
+import * as ICAL from 'ical.js';
 
 @Component({
     selector: 'app-calendar-event-editor-dialog',
@@ -38,16 +40,58 @@ export class EventEditorDialogComponent {
     calendarFC = new FormControl('', Validators.required);
     event_start: Date;
     event_end: Date;
+    event_title: string;
+    event_location: string;
+    event_description: string;
+    event_allDay = false;
     settings: CalendarSettings;
 
+    event_recurs = false;
+    event_is_recur_start = false;
+    edit_recurrence = true;
+    change_save_type = false;
     recurring_frequency: string;
+    recur_interval: number;
+    recur_by_months: string[] = [];
+    recur_by_monthyeardays: string[] = [];
+    recur_by_weekdays: string[] = [];
+    recur_save_type = '0';
     recurrence_frequencies = [
-        { name: 'No',      val: ''        },
-        { name: 'Hourly',  val: 'HOURLY'  },
-        { name: 'Daily',   val: 'DAILY'   },
-        { name: 'Weekly',  val: 'WEEKLY'  },
-        { name: 'Monthly', val: 'MONTHLY' },
-        { name: 'Yearly',  val: 'YEARLY'  },
+        { name: 'Hour(s)',    val: 'HOURLY'  },
+        { name: 'Day(s)',     val: 'DAILY'   },
+        { name: 'Week(s)',    val: 'WEEKLY'  },
+        { name: 'Month(s)',   val: 'MONTHLY' },
+        { name: 'Year(s)',    val: 'YEARLY'  },
+    ];
+    weekdays = [
+        { name: 'Sunday',     val: 'SU',  recurs_on: false  },
+        { name: 'Monday',     val: 'MO',  recurs_on: false  },
+        { name: 'Tuesday',    val: 'TU',  recurs_on: false  },
+        { name: 'Wednesday',  val: 'WE',  recurs_on: false  },
+        { name: 'Thursday',   val: 'TH',  recurs_on: false  },
+        { name: 'Friday',     val: 'FR',  recurs_on: false  },
+        { name: 'Saturday',   val: 'SA',  recurs_on: false  },
+    ];
+    month_year_days = [];
+    year_months = [
+        { name: 'the year' ,  val: 'year',  selected: false },
+        { name: 'January',    val: '1',     selected: false },
+        { name: 'February',   val: '2',     selected: false },
+        { name: 'March',      val: '3',     selected: false },
+        { name: 'April',      val: '4',     selected: false },
+        { name: 'May',        val: '5',     selected: false },
+        { name: 'June',       val: '6',     selected: false },
+        { name: 'July',       val: '7',     selected: false },
+        { name: 'August',     val: '8',     selected: false },
+        { name: 'September',  val: '9',     selected: false },
+        { name: 'October',    val: '10',    selected: false },
+        { name: 'November',   val: '11',    selected: false },
+        { name: 'December',   val: '12',    selected: false },
+    ];
+    save_types = [
+        { name: 'All ocurrences',         val: '0', disabled: false },
+        { name: 'This event only',        val: '1', disabled: false },
+        { name: 'This and future events', val: '2', disabled: false },
     ];
 
     export_url: string;
@@ -64,6 +108,10 @@ export class EventEditorDialogComponent {
             this.event = data['event'];
             this.calendarFC.setValue(this.event.calendar);
             this.export_url = '/rest/v1/calendar/ics/' + this.event.id;
+            this.event_title = this.event.title;
+            this.event_location = this.event.location;
+            this.event_description = this.event.description;
+            this.event_allDay = this.event.allDay;
 
             this.event_start = this.event.dtstart.toDate();
             if (this.event.allDay) {
@@ -71,6 +119,61 @@ export class EventEditorDialogComponent {
                 this.event_end = this.event.dtend.subtract(1, 'day').toDate();
             } else {
                 this.event_end = this.event.dtend.toDate();
+            }
+            this.event_recurs = this.event.recurs;
+            // default:
+            this.change_save_type = this.event_recurs;
+            if (this.event_recurs
+                && this.event_start.toString() === this.event.recurStart.toString()) {
+                this.event_is_recur_start = true;
+            }
+
+            // Already an exception, may not save as "all occurences"
+            // or "this and future"?
+            if (this.event.isException) {
+                this.save_types[0]['disabled'] = false;
+                this.save_types[2]['disabled'] = false;
+                this.recur_save_type = '1';
+                this.edit_recurrence = false;
+            }
+            this.recurring_frequency = this.event.recurringFrequency;
+            this.recur_interval = this.event.recurInterval;
+            // default, maybe overridden below:
+            this.recur_by_months = ['year'];
+            // This is a list of objects with 'day' + 'numth' keys
+            // numth is only set for monthly recurrences
+            // for weekly, just list the day values
+            const setDays = this.event.recursByDay;
+            const recurs_on_weekdays = [];
+            this.weekdays.forEach((day) => {
+                const hasDay = setDays.find((entry) => entry['day'] === day.val);
+                if (hasDay) {
+                    day['recurs_on'] = true;
+                    const monthrepeat = this.month_year_days.findIndex((nth) => nth.val ===  hasDay['numth']);
+                    if (hasDay['numth'] > 0) {
+                        this.recur_by_monthyeardays.push(hasDay['numth']);
+                    }
+                    recurs_on_weekdays.push(day.val);
+                }
+            });
+            if (this.recur_by_monthyeardays.length === 0) {
+                this.recur_by_monthyeardays = ['0'];
+            }
+            this.recur_by_weekdays = recurs_on_weekdays;
+            // day(s) of the month a monthly recurs:
+            if ((this.recurring_frequency === 'MONTHLY' || this.recurring_frequency === 'YEARLY')
+                && this.event.recursByMonthDay.length > 0) {
+                this.recur_by_monthyeardays = this.event.recursByMonthDay;
+                this.recur_by_weekdays = ['day'];
+            }
+            if (this.recurring_frequency === 'YEARLY'
+                && this.event.recursByYearDay.length > 0) {
+                this.recur_by_monthyeardays = this.event.recursByYearDay;
+                this.recur_by_weekdays = ['day'];
+            }
+            // month event occurs if yearly:
+            if (this.recurring_frequency === 'YEARLY' && this.event.recursByMonth.length > 0) {
+                this.recur_by_months = this.event.recursByMonth;
             }
         } else {
             if (data['start']) {
@@ -80,16 +183,157 @@ export class EventEditorDialogComponent {
                 this.event_start = moment().toDate();
                 this.event_end   = moment().toDate();
             }
+
+            // Default things for "new" events
+            // We should probably do these when user clicks the "event repeats" checkbox?
+            this.recurring_frequency = 'DAILY';
+            this.recur_interval = 1;
+            // for fresh events, default to start date chosen
+            this.recur_by_monthyeardays = [this.event_start.getDate().toString()];
+            this.recur_by_weekdays = ['day'];
+            this.recur_by_months = [String(this.event_start.getMonth() + 1)];
         }
 
         this.settings = data['settings'];
 
-        this.recurring_frequency = this.event.recurringFrequency;
+
+        // number of max days to display for monthly:
+        this.generateMonthYearDays('MONTHLY', this.event_start);
+    }
+
+    private generateMonthYearDays(repeat_type: string, when: Date) {
+        const m_repeats = [{ name: 'All', val: '0', selected: false }];
+        let days_to_generate = 0;
+        if (repeat_type === 'MONTHLY') {
+            days_to_generate = ICAL.Time.daysInMonth(when.getMonth() + 1);
+        } else {
+            // YEARLY
+            days_to_generate = 366;
+        }
+        // including 0 for "no number"
+        for (let i = 1; i <= days_to_generate; i++) {
+            const val = i.toString();
+            const th = val.endsWith('1')
+                ? 'st'
+                : val.endsWith('2')
+                ? 'nd'
+                : val.endsWith('3')
+                ? 'rd'
+                : 'th';
+            m_repeats.push({ name: val + th, val: val, selected: false });
+        }
+        this.month_year_days = m_repeats;
+    }
+
+    // exception recurrences (different start time or description etc)
+    // can't have RRULEs, so once we change the RRULE data, disallow
+    // different saving
+    public updateInterval(): void {
+        this.change_save_type = false;
+    }
+
+    public updateFrequency(): void {
+        this.change_save_type = false;
+    }
+
+    public updateWeekdays(): void {
+        this.change_save_type = false;
+    }
+
+    // capture Nth field changes
+    // could be Nth of month or Nth Xday of month!
+    // event: MatSelectChange? (not found!)
+    public updateMonthlyNth(event): void {
+        // If we're picking a weekday, can only be 1st-5th repeating
+        // (no 6ths Mondays in the month!)
+        if (this.recur_by_weekdays[0] !== 'day'
+            && (event.value.length > 1
+                || event.value.find((entry) => parseInt(entry, 10) > 5)) ) {
+            this.recur_by_weekdays = ['day'];
+        }
+        this.change_save_type = false;
+    }
+
+    public updateWeekday(event): void {
+        // Can't combine "day" and weekday
+        // we could "disable" the weekdays when picking day
+        // and the day when picking a weekday? Need a ViewChild?
+        if (event.value.length > 1
+            && event.value.find((entry) => entry === 'day')) {
+            console.log("Event editor - can't pick 'day' plus anything else");
+            const filtered_values = event.value.filter((entry) => entry !== 'day');
+            this.recur_by_weekdays = filtered_values;
+        }
+
+        // If we're picking a weekday, can only be 1st-5th repeating
+        // (no 6ths Mondays in the month!)
+        if (event.value[0] !== 'day'
+            && (this.recur_by_monthyeardays.length > 1
+                || parseInt(this.recur_by_monthyeardays[0], 10) > 5)) {
+            this.recur_by_monthyeardays = ['1'];
+        }
+        this.change_save_type = false;
+    }
+
+    public updateMonths(event): void {
+        // month, year, actual month name
+        if (event.value.length > 1
+            && event.value.find((entry) => entry === 'month')) {
+            this.recur_by_months = ['month'];
+        }
+        if (event.value.length > 1
+            && event.value.find((entry) => entry === 'year')) {
+            this.recur_by_months = ['year'];
+        }
+        if (this.recur_by_months.length === 1) {
+            if (this.recur_by_months[0] === 'year') {
+                // We can pick any/all days of year
+                this.generateMonthYearDays('YEARLY', this.event_start);
+            } else if (this.recur_by_months[0] === 'month') {
+                // based on initial event start month
+                this.generateMonthYearDays('MONTHLY', this.event_start);
+            } else {
+                // Days of chosen month:
+                this.generateMonthYearDays('MONTHLY', new Date(this.event_start.getFullYear(), event.value - 1, 1));
+            }
+        }
+        // remove any days previously picked that are no longer in the list:
+        const maxValue = this.month_year_days.reduce(
+            (current, entry) => parseInt(current['val'], 10) > parseInt(entry['val'], 10) ? current : entry);
+        const new_monthyeardays = this.recur_by_monthyeardays.filter((entry) => parseInt(entry, 10) <= parseInt(maxValue['val'], 10));
+        this.recur_by_monthyeardays = new_monthyeardays;
+        this.change_save_type = false;
+    }
+
+    // we assume they don't jump back and forth between startdate+recurrence?
+    // NB: ngModelChange has to be before ngModel (in template) to read
+    // the old value
+    public updateStart(value: Date) {
+        // Do this always, in case we fiddle with dates, then
+        // set event_recurs:
+        this.generateMonthYearDays('MONTHLY', value);
+        this.recur_by_monthyeardays = [value.getDate().toString()];
+        this.recur_by_months = [String(value.getMonth() + 1)];
+
+        // Logic for recurring event date/time updates:
+        if (this.event_recurs && !this.event_is_recur_start) {
+            if (value.getFullYear() !== this.event_start.getFullYear()
+                || value.getMonth() !== this.event_start.getMonth()
+                || value.getDate() !== this.event_start.getDate()
+               ) {
+                // If date changes, and not first event in recurring
+                // can't set on all occurences.
+                this.save_types[0]['disabled'] = true;
+                if (this.recur_save_type === '0') {
+                    this.recur_save_type = '1';
+                }
+            }
+        }
     }
 
     onDeleteClick(): void {
         const dialogData = { name: 'event' };
-      if (this.event.event.isRecurring()) {
+        if (this.event.recurs || this.event.isException) {
             dialogData['details'] = 'Note that this is a reccuring event – deleting it will delete ALL instances';
         }
         const confirmRef = this.dialog.open(DeleteConfirmationDialogComponent, { data: dialogData });
@@ -115,8 +359,8 @@ export class EventEditorDialogComponent {
             this.event.calendar = this.calendarFC.value;
         }
 
-        this.event.dtstart = moment(this.event_start).seconds(0).milliseconds(0);
-        this.event.dtend   = moment(this.event_end).seconds(0).milliseconds(0);
+        const dtstart = moment(this.event_start).seconds(0).milliseconds(0);
+        let dtend = moment(this.event_end).seconds(0).milliseconds(0);
 
         // For a user it makes sense that a 2-day-long event starts on 1st and ends on 2nd.
         // For iCalendar however, that's a 1-day event since end dates are non-inclusive.
@@ -125,10 +369,87 @@ export class EventEditorDialogComponent {
         // longer behind the scenes (that's how nextcloud does it too, for example).
         if (this.event.allDay) {
             // make sure we're going through the setter
-            this.event.dtend = this.event.dtend.add(1, 'day');
+            dtend = dtend.add(1, 'day');
         }
 
-        this.event.recurringFrequency = this.recurring_frequency;
+        if (this.event.recurs && this.recur_save_type !== '0') {
+            // Adding an exception to an already recurring event
+            this.event.addExceptionEvent(
+                this.event.dtstart,
+                dtstart,
+                dtend,
+                this.recur_save_type === '2' ? true : false,
+                this.event_title,
+                this.event_description,
+                this.event_location);
+        } else {
+            this.event.dtstart     = dtstart;
+            this.event.dtend       = dtend;
+            if (this.event_title) {
+                this.event.title       = this.event_title;
+            }
+            if (this.event_location) {
+                this.event.location    = this.event_location;
+            }
+            if (this.event_description) {
+                this.event.description = this.event_description;
+            }
+
+            if (this.event_recurs) {
+                // New recurring event, didn't recur before, or updating
+                // whole recurring event
+                this.event.recurs = true;
+                this.event.recurringFrequency = this.recurring_frequency;
+                this.event.recurInterval = this.recur_interval;
+                if (this.recurring_frequency === 'WEEKLY') {
+                    // Repeats on one or more days every week
+                    this.event.recursByDay = this.weekdays.filter((entry) => entry.recurs_on).map((entry) => entry.val);
+                } else if (this.recurring_frequency === 'MONTHLY'
+                    || this.recurring_frequency === 'YEARLY') {
+                    // Repeats on either: eg: 1st,(2nd, 3rd) Tuesday, or 17th, (18th, 19th) day
+                    if (this.recur_by_weekdays.length === 1
+                        && this.recur_by_weekdays[0] === 'day') {
+                        if (this.recurring_frequency === 'YEARLY'
+                            && this.recur_by_months.length === 1
+                            && this.recur_by_months[0] === 'year') {
+                            // Nth day of the year
+                            this.event.recursByYearDay = this.recur_by_monthyeardays;
+                        } else {
+                            // Nth day of the month
+                            this.event.recursByMonthDay = this.recur_by_monthyeardays;
+                            if (this.recurring_frequency === 'YEARLY') {
+                                this.event.recursByMonth = this.recur_by_months;
+                            }
+                        }
+                    } else {
+                        // Nth <?>day:
+                        // If Nth is 0, then skip adding a number
+                        // (means eg "all tuesdays in the month")
+                        const weekdays = [];
+                        if (this.recur_by_weekdays.length === this.recur_by_monthyeardays.length) {
+                            for (let i = 0; i < this.recur_by_weekdays.length; i++) {
+                                const recur_monthday = this.recur_by_monthyeardays[i] !== '0' ? this.recur_by_monthyeardays[i] : '';
+                                weekdays.push(recur_monthday + this.recur_by_weekdays[i]);
+                            }
+                        } else {
+                            // picked one Nth and multiple days?
+                            for (let i = 0; i < this.recur_by_weekdays.length; i++) {
+                                const recur_monthday = this.recur_by_monthyeardays[i] !== '0' ? this.recur_by_monthyeardays[i] : '';
+                                weekdays.push(recur_monthday + this.recur_by_weekdays[i]);
+                            }
+                        }
+                        // list of 1TU,2WE etc
+                        this.event.recursByDay = weekdays;
+
+                        if (this.recurring_frequency === 'YEARLY'
+                            && this.recur_by_months[0] !== 'year') {
+                            // occurs on Nth <X>day in particular months:
+                            this.event.recursByMonth = this.recur_by_months;
+                        }
+                    }
+                }
+            }
+        }
 
         this.dialogRef.close(this.event);
     }

--- a/src/app/calendar-app/event-editor-dialog.component.ts
+++ b/src/app/calendar-app/event-editor-dialog.component.ts
@@ -24,7 +24,7 @@ import { MatTab } from '@angular/material/tabs';
 
 import { CalendarSettings } from './calendar-settings';
 import { RunboxCalendar } from './runbox-calendar';
-import { RunboxCalendarEvent } from './runbox-calendar-event';
+import { RunboxCalendarEvent, RecurSaveType } from './runbox-calendar-event';
 import { DeleteConfirmationDialogComponent } from './delete-confirmation-dialog.component';
 
 import * as moment from 'moment';
@@ -55,7 +55,7 @@ export class EventEditorDialogComponent {
     recur_by_months: string[] = [];
     recur_by_monthyeardays: string[] = [];
     recur_by_weekdays: string[] = [];
-    recur_save_type = '0';
+    recur_save_type = RecurSaveType.ALL_OCCURENCES;
     recurrence_frequencies = [
         { name: 'Hour(s)',    val: 'HOURLY'  },
         { name: 'Day(s)',     val: 'DAILY'   },
@@ -89,9 +89,9 @@ export class EventEditorDialogComponent {
         { name: 'December',   val: '12',    selected: false },
     ];
     save_types = [
-        { name: 'All ocurrences',         val: '0', disabled: false },
-        { name: 'This event only',        val: '1', disabled: false },
-        { name: 'This and future events', val: '2', disabled: false },
+        { name: 'All ocurrences',         val: RecurSaveType.ALL_OCCURENCES,  disabled: false },
+        { name: 'This event only',        val: RecurSaveType.THIS_ONLY,       disabled: false },
+        { name: 'This and future events', val: RecurSaveType.THIS_AND_FUTURE, disabled: false },
     ];
 
     export_url: string;
@@ -133,7 +133,7 @@ export class EventEditorDialogComponent {
             if (this.event.isException) {
                 this.save_types[0]['disabled'] = true;
                 this.save_types[2]['disabled'] = true;
-                this.recur_save_type = '1';
+                this.recur_save_type = RecurSaveType.THIS_ONLY;
                 this.edit_recurrence = false;
             }
             this.recurring_frequency = this.event.recurringFrequency;
@@ -343,8 +343,8 @@ export class EventEditorDialogComponent {
                 // If date changes, and not first event in recurring
                 // can't set on all occurences.
                 this.save_types[0]['disabled'] = true;
-                if (this.recur_save_type === '0') {
-                    this.recur_save_type = '1';
+                if (this.recur_save_type === RecurSaveType.ALL_OCCURENCES) {
+                    this.recur_save_type = RecurSaveType.THIS_ONLY;
                 }
             }
         }

--- a/src/app/calendar-app/event-editor-dialog.component.ts
+++ b/src/app/calendar-app/event-editor-dialog.component.ts
@@ -89,7 +89,7 @@ export class EventEditorDialogComponent {
 
     onDeleteClick(): void {
         const dialogData = { name: 'event' };
-        if (this.event.rrule) {
+      if (this.event.event.isRecurring()) {
             dialogData['details'] = 'Note that this is a reccuring event – deleting it will delete ALL instances';
         }
         const confirmRef = this.dialog.open(DeleteConfirmationDialogComponent, { data: dialogData });

--- a/src/app/calendar-app/event-editor-dialog.component.ts
+++ b/src/app/calendar-app/event-editor-dialog.component.ts
@@ -111,7 +111,7 @@ export class EventEditorDialogComponent {
             // so let's help it a little
             this.calendarFC.markAsTouched();
             return;
-        } else {
+        } else if (this.event.calendar !== this.calendarFC.value) {
             this.event.calendar = this.calendarFC.value;
         }
 

--- a/src/app/calendar-app/import-dialog.component.ts
+++ b/src/app/calendar-app/import-dialog.component.ts
@@ -25,6 +25,7 @@ import * as moment from 'moment';
 import { RunboxCalendar } from './runbox-calendar';
 import { RunboxCalendarEvent } from './runbox-calendar-event';
 import { EventOverview } from './event-overview';
+import { CalendarService } from './calendar.service';
 
 @Component({
     selector: 'app-import-dialog-component',
@@ -40,6 +41,7 @@ export class ImportDialogComponent {
     extractedCalendar: RunboxCalendar;
 
     constructor(
+        public  calendarservice: CalendarService,
         public dialogRef: MatDialogRef<ImportDialogComponent>,
         @Inject(MAT_DIALOG_DATA) public data: any
     ) {
@@ -63,7 +65,9 @@ export class ImportDialogComponent {
             this.calendars.push(this.extractedCalendar);
         }
 
-        const event = RunboxCalendarEvent.fromIcal(undefined, data['ical']);
+        // returns an array of RunboxCalendarEvent, we can figure out
+        // the overview from any of them
+        const event = calendarservice.fromIcal(undefined, data['ical'], false)[0];
         this.events = event.get_overview();
     }
 

--- a/src/app/calendar-app/import-dialog.component.ts
+++ b/src/app/calendar-app/import-dialog.component.ts
@@ -67,8 +67,9 @@ export class ImportDialogComponent {
 
         // returns an array of RunboxCalendarEvent, we can figure out
         // the overview from any of them
-        const event = calendarservice.fromIcal(undefined, data['ical'], false)[0];
-        this.events = event.get_overview();
+        const ievent = calendarservice.importFromIcal(undefined, data['ical'], false);
+        const events = calendarservice.generateEvents(undefined, undefined, [ievent]);
+        this.events = events[0].get_overview();
     }
 
     onCancelClick(): void {

--- a/src/app/calendar-app/runbox-calendar-event.spec.ts
+++ b/src/app/calendar-app/runbox-calendar-event.spec.ts
@@ -51,7 +51,7 @@ describe('RunboxCalendarEvent', () => {
         expect(sut.toIcal()).toContain('RRULE:FREQ=MONTHLY', 'recurrence seems to be set');
         expect(sut.toIcal()).not.toContain('RRULE:FREQ=WEEKLY', 'old recurrence seems to be gone');
 
-        sut.recurringFrequency = '';
+        sut.recurs = false;
         expect(sut.recurringFrequency).toBe('', 'recurrence seems to be unset');
         expect(sut.toIcal()).not.toContain('RRULE', 'recurrence seems to be unset');
     });

--- a/src/app/calendar-app/runbox-calendar-event.spec.ts
+++ b/src/app/calendar-app/runbox-calendar-event.spec.ts
@@ -32,7 +32,7 @@ describe('RunboxCalendarEvent', () => {
         // test things addEvent calls:
       expect(newEvent.toIcal()).toMatch(/BEGIN:VEVENT/);
     });
-    it('should be possible to add/remove a recurrence rule', () => {
+    it('should be possible to add/edit/remove a WEEKLY recurrence rule', () => {
         const sut = new RunboxCalendarEvent(
           'testcal/testev', new ICAL.Event(new ICAL.Component(['vcalendar', [], [
                 [ 'vevent', [
@@ -54,6 +54,91 @@ describe('RunboxCalendarEvent', () => {
         sut.recurs = false;
         expect(sut.recurringFrequency).toBe('', 'recurrence seems to be unset');
         expect(sut.toIcal()).not.toContain('RRULE', 'recurrence seems to be unset');
+    });
+
+    it('should be possible to recur every other week on multiple days of the week', () => {
+        const sut = new RunboxCalendarEvent(
+          'testcal/testev', new ICAL.Event(new ICAL.Component(['vcalendar', [], [
+                [ 'vevent', [
+                    [ 'dtstart', {}, 'date',  moment().toISOString().split('T')[0] ],
+                    [ 'dtend',   {}, 'date',  moment().toISOString().split('T')[0] ],
+                    [ 'summary', {}, 'text',  'One-time event' ],
+                ] ]
+          ]])), ICAL.Time.fromJSDate(new Date()), ICAL.Time.fromJSDate(new Date()),
+        );
+        sut.recurringFrequency = 'WEEKLY';
+        sut.recurInterval = 2;
+        sut.recursByDay = ['SA', 'SU'];
+        expect(sut.recurringFrequency).toBe('WEEKLY', 'recurrence can be retrieved');
+        expect(sut.toIcal()).toContain('RRULE:FREQ=WEEKLY', 'recurrence seems to be stringified properly');
+        expect(sut.toIcal()).toContain('INTERVAL=2', 'ical has interval set');
+        expect(sut.toIcal()).toContain('BYDAY=SA,SU', 'ical has BYDAY params');
+    });
+
+    it('should be possible to recur monthly on one or more Xth of the month', () => {
+        const sut = new RunboxCalendarEvent(
+          'testcal/testev', new ICAL.Event(new ICAL.Component(['vcalendar', [], [
+                [ 'vevent', [
+                    [ 'dtstart', {}, 'date',  moment().toISOString().split('T')[0] ],
+                    [ 'dtend',   {}, 'date',  moment().toISOString().split('T')[0] ],
+                    [ 'summary', {}, 'text',  'One-time event' ],
+                ] ]
+          ]])), ICAL.Time.fromJSDate(new Date()), ICAL.Time.fromJSDate(new Date()),
+        );
+        sut.recurringFrequency = 'MONTHLY';
+        sut.recurInterval = 1; // the default
+        sut.recursByMonthDay = ['5'];
+        expect(sut.recurringFrequency).toBe('MONTHLY', 'recurrence can be retrieved');
+        expect(sut.toIcal()).toContain('RRULE:FREQ=MONTHLY', 'recurrence seems to be stringified properly');
+        expect(sut.toIcal()).not.toContain('INTERVAL', 'ical interval not set if default value (1)');
+        expect(sut.toIcal()).toContain('BYMONTHDAY=5', 'ical has BYMONTHDAY params');
+        sut.recursByMonthDay = ['5', '6'];
+        expect(sut.toIcal()).toContain('BYMONTHDAY=5,6', 'ical has updated BYMONTHDAY params');
+
+    });
+
+    it('should be possible to recur monthly on Xth day of the month', () => {
+        const sut = new RunboxCalendarEvent(
+          'testcal/testev', new ICAL.Event(new ICAL.Component(['vcalendar', [], [
+                [ 'vevent', [
+                    [ 'dtstart', {}, 'date',  moment().toISOString().split('T')[0] ],
+                    [ 'dtend',   {}, 'date',  moment().toISOString().split('T')[0] ],
+                    [ 'summary', {}, 'text',  'One-time event' ],
+                ] ]
+          ]])), ICAL.Time.fromJSDate(new Date()), ICAL.Time.fromJSDate(new Date()),
+        );
+        // Every 2nd Monday of every month
+        sut.recurringFrequency = 'MONTHLY';
+        sut.recurInterval = 1; // the default
+        sut.recursByMonthDay = ['2'];
+        sut.recursByDay = ['MO'];
+        expect(sut.recurringFrequency).toBe('MONTHLY', 'recurrence can be retrieved');
+        expect(sut.toIcal()).toContain('RRULE:FREQ=MONTHLY', 'recurrence seems to be stringified properly');
+        expect(sut.toIcal()).not.toContain('INTERVAL', 'ical interval not set if default value (1)');
+        expect(sut.toIcal()).toContain('BYMONTHDAY=2', 'ical has BYMONTHDAY params');
+        expect(sut.toIcal()).toContain('BYDAY=MO', 'ical has BYDAY params');
+    });
+
+    it('should be possible to recur yearly on Xth day of the month', () => {
+        const sut = new RunboxCalendarEvent(
+          'testcal/testev', new ICAL.Event(new ICAL.Component(['vcalendar', [], [
+                [ 'vevent', [
+                    [ 'dtstart', {}, 'date',  moment().toISOString().split('T')[0] ],
+                    [ 'dtend',   {}, 'date',  moment().toISOString().split('T')[0] ],
+                    [ 'summary', {}, 'text',  'One-time event' ],
+                ] ]
+          ]])), ICAL.Time.fromJSDate(new Date()), ICAL.Time.fromJSDate(new Date()),
+        );
+        // Every 2nd of February of every year
+        sut.recurringFrequency = 'YEARLY';
+        sut.recurInterval = 1; // the default
+        sut.recursByMonth = ['2'];
+        sut.recursByMonthDay = ['2'];
+        expect(sut.recurringFrequency).toBe('YEARLY', 'recurrence can be retrieved');
+        expect(sut.toIcal()).toContain('RRULE:FREQ=YEARLY', 'recurrence seems to be stringified properly');
+        expect(sut.toIcal()).not.toContain('INTERVAL', 'ical interval not set if default value (1)');
+        expect(sut.toIcal()).toContain('BYMONTHDAY=2', 'ical has BYMONTHDAY params');
+        expect(sut.toIcal()).toContain('BYMONTH=2', 'ical has BYMONTH params');
     });
 
     it('should be possible to add a special case to a recurring event', () => {
@@ -134,17 +219,6 @@ describe('RunboxCalendarEvent', () => {
      it('should be possible to add a special case to a recurring event (with timezone)', () => {
          // mostly taken straight out of the jCal spec: https://tools.ietf.org/html/rfc7265#page-30
         const jcal = ICAL.parse(
-// `BEGIN:VCALENDAR
-// CALSCALE:GREGORIAN
-// PRODID:-//Example Inc.//Example Calendar//EN
-// VERSION:2.0
-// BEGIN:VEVENT
-// DTSTAMP:20080205T191224Z
-// DTSTART:20081006
-// SUMMARY:Planning meeting
-// UID:4088E990AD89CB3DBB484909
-// END:VEVENT
-// END:VCALENDAR`);
 `BEGIN:VCALENDAR
 VERSION:2.0
 BEGIN:VTIMEZONE
@@ -175,6 +249,19 @@ END:VEVENT
 END:VCALENDAR`
         );
          const ical = new ICAL.Component(jcal);
+         // Need to setup timezones (usually calendar.service does this)
+         if (ical.getFirstSubcomponent('vtimezone')) {
+             for (const tzComponent of ical.getAllSubcomponents('vtimezone')) {
+                 const tz = new ICAL.Timezone({
+                     tzid:      tzComponent.getFirstPropertyValue('tzid'),
+                     component: tzComponent,
+                 });
+
+                 if (!ICAL.TimezoneService.has(tz.tzid)) {
+                     ICAL.TimezoneService.register(tz.tzid, tz);
+                 }
+             }
+         }
          const vevent = ical.getFirstSubcomponent('vevent');
          // pass in prop to apply the correct timezone to the ICAL.Time object
          const dtstartProp = vevent.getFirstProperty('dtstart');

--- a/src/app/calendar-app/runbox-calendar-event.spec.ts
+++ b/src/app/calendar-app/runbox-calendar-event.spec.ts
@@ -171,18 +171,6 @@ describe('RunboxCalendarEvent', () => {
         expect(sut.toIcal()).toContain('SUMMARY:Moved weekly event');
         expect(sut.toIcal()).toContain('RECURRENCE-ID;VALUE=DATE:20210201');
         expect(sut.toIcal()).toContain('DTSTART;VALUE=DATE:20210204');
-        // expect(events.length).toBe(2);
-        // expect(events[0].dtstart.isSame(events[1].dtstart)).toBe(false);
-
-        // alter the one happening next week
-        // const copy = events[1].clone();
-        // copy.title = 'Next weekly occurrence';
-        // sut.addRecurrenceSpecialCase(copy);
-        // console.log("Sut after setting specialcase:", sut.toIcal(), "\n");
-
-        // events = sut.recurrences(yesterday.toDate(), future.toDate());
-        // expect(events[0].title).toBe('Weekly event');
-        // expect(events[1].title).toBe('Next weekly event');
     });
 
     it('should be possible to add a special case to a recurring event (with time)', () => {

--- a/src/app/calendar-app/runbox-calendar-event.spec.ts
+++ b/src/app/calendar-app/runbox-calendar-event.spec.ts
@@ -19,17 +19,18 @@
 
 import { RunboxCalendarEvent } from './runbox-calendar-event';
 import * as moment from 'moment';
+import * as ICAL from 'ical.js';
 
 describe('RunboxCalendarEvent', () => {
-    it('should be possible to add/remove a recurrence rule', async () => {
+    it('should be possible to add/remove a recurrence rule', () => {
         const sut = new RunboxCalendarEvent(
-            'testcal/testev', ['vcalendar', [], [
+          'testcal/testev', new ICAL.Event(new ICAL.Component(['vcalendar', [], [
                 [ 'vevent', [
                     [ 'dtstart', {}, 'date',  moment().toISOString().split('T')[0] ],
                     [ 'dtend',   {}, 'date',  moment().toISOString().split('T')[0] ],
                     [ 'summary', {}, 'text',  'One-time event' ],
                 ] ]
-            ]]
+          ]])), ICAL.Time.fromJSDate(new Date()), ICAL.Time.fromJSDate(new Date()),
         );
         sut.recurringFrequency = 'WEEKLY';
         expect(sut.recurringFrequency).toBe('WEEKLY', 'recurrence seems to be set');
@@ -43,5 +44,38 @@ describe('RunboxCalendarEvent', () => {
         sut.recurringFrequency = '';
         expect(sut.recurringFrequency).toBe('', 'recurrence seems to be unset');
         expect(sut.toIcal()).not.toContain('RRULE', 'recurrence seems to be unset');
+    });
+
+    it('should be possible to add a special case to a recurring event', () => {
+        const todayStr = moment().toISOString().split('T')[0];
+        const yesterday = moment().subtract(1, 'day');
+        const sut = new RunboxCalendarEvent(
+            'testcal/testev', new ICAL.Event(new ICAL.Component(['vcalendar', [], [
+                [ 'vevent', [
+                    [ 'dtstart', {}, 'date',  todayStr ],
+                    [ 'dtend',   {}, 'date',  todayStr ],
+                    [ 'summary', {}, 'text',  'Weekly event' ],
+                    [ 'uid',     {}, 'text',  'unittestcase1' ],
+                    [ 'rrule',   {}, 'recur', { 'freq': 'WEEKLY' } ],
+                ] ]
+            ]])), ICAL.Time.fromJSDate(new Date()), ICAL.Time.fromJSDate(new Date()),
+        );
+
+      const future = moment().add(1, 'week').add(3, 'day');
+      // FIXME
+        // const events = sut.recurrences(yesterday.toDate(), future.toDate());
+
+        // expect(events.length).toBe(2);
+        // expect(events[0].dtstart.isSame(events[1].dtstart)).toBe(false);
+
+        // alter the one happening next week
+        // const copy = events[1].clone();
+        // copy.title = 'Next weekly occurrence';
+        // sut.addRecurrenceSpecialCase(copy);
+        // console.log("Sut after setting specialcase:", sut.toIcal(), "\n");
+
+        // events = sut.recurrences(yesterday.toDate(), future.toDate());
+        // expect(events[0].title).toBe('Weekly event');
+        // expect(events[1].title).toBe('Next weekly event');
     });
 });

--- a/src/app/calendar-app/runbox-calendar-event.spec.ts
+++ b/src/app/calendar-app/runbox-calendar-event.spec.ts
@@ -17,7 +17,7 @@
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
 
-import { RunboxCalendarEvent } from './runbox-calendar-event';
+import { RunboxCalendarEvent, RecurSaveType } from './runbox-calendar-event';
 import * as moment from 'moment';
 import * as ICAL from 'ical.js';
 
@@ -160,7 +160,7 @@ describe('RunboxCalendarEvent', () => {
             future,
             future,
             sut.calendar,
-            '1', // 'This event only', should probably be an enum
+            RecurSaveType.THIS_ONLY,
             'Moved weekly event', undefined, undefined,
             true,
             sut.recurringFrequency,
@@ -203,7 +203,7 @@ describe('RunboxCalendarEvent', () => {
             future,
             future,
             sut.calendar,
-            '1', // 'This event only', should probably be an enum
+            RecurSaveType.THIS_ONLY,
             'Moved weekly event one hour', undefined, undefined,
             true,
             sut.recurringFrequency,
@@ -279,7 +279,7 @@ END:VCALENDAR`
              future,
              undefined,
              sut.calendar,
-             '1', // 'This event only', should probably be an enum
+             RecurSaveType.THIS_ONLY,
              'Moved daily event one hour', undefined, undefined,
              true,
              sut.recurringFrequency,

--- a/src/app/calendar-app/runbox-calendar-event.spec.ts
+++ b/src/app/calendar-app/runbox-calendar-event.spec.ts
@@ -178,7 +178,7 @@ END:VCALENDAR`
          const vevent = ical.getFirstSubcomponent('vevent');
          // pass in prop to apply the correct timezone to the ICAL.Time object
          const dtstartProp = vevent.getFirstProperty('dtstart');
-         
+
          // This is the RCE instance for the 2nd day:
          const sut = new RunboxCalendarEvent(
              'testcal/unittestcase3',

--- a/src/app/calendar-app/runbox-calendar-event.spec.ts
+++ b/src/app/calendar-app/runbox-calendar-event.spec.ts
@@ -22,6 +22,16 @@ import * as moment from 'moment';
 import * as ICAL from 'ical.js';
 
 describe('RunboxCalendarEvent', () => {
+    it('should be possible to create a new event', () => {
+        const newEvent = RunboxCalendarEvent.newEmpty();
+        newEvent.dtstart = moment().date(1).hours(13).seconds(0).milliseconds(0);
+        newEvent.dtend = moment().date(1).hours(14).seconds(0).milliseconds(0);
+        newEvent.title = 'New Event';
+        newEvent.location = 'Somewhere';
+
+        // test things addEvent calls:
+      expect(newEvent.toIcal()).toMatch(/BEGIN:VEVENT/);
+    });
     it('should be possible to add/remove a recurrence rule', () => {
         const sut = new RunboxCalendarEvent(
           'testcal/testev', new ICAL.Event(new ICAL.Component(['vcalendar', [], [

--- a/src/app/calendar-app/runbox-calendar-event.ts
+++ b/src/app/calendar-app/runbox-calendar-event.ts
@@ -393,8 +393,6 @@ export class RunboxCalendarEvent implements CalendarEvent {
         if (enddate) {
             new_end = this.momentToIcalTime(enddate, this.event.startDate.zone);
         }
-        console.log('isDate? ' + this._dtstart.isDate);
-        console.log('Start: ' + this._dtstart.toString()); 
         if (this._dtstart.isDate) {
             recurrence_id.isDate = true;
             new_start.isDate = true;

--- a/src/app/calendar-app/runbox-calendar-event.ts
+++ b/src/app/calendar-app/runbox-calendar-event.ts
@@ -27,6 +27,12 @@ import * as ICAL from 'ical.js';
 
 import { EventOverview } from './event-overview';
 
+export enum RecurSaveType {
+    ALL_OCCURENCES,
+    THIS_ONLY,
+    THIS_AND_FUTURE,
+}
+
 export class RunboxCalendarEvent implements CalendarEvent {
     id?:       string;
 
@@ -421,7 +427,7 @@ export class RunboxCalendarEvent implements CalendarEvent {
         dtstart:        moment.Moment,
         dtend:          moment.Moment,
         calendar:       string,
-        recur_save_type: string,
+        recur_save_type: RecurSaveType,
         title:          string,
         location:       string,
         description:    string,
@@ -432,13 +438,13 @@ export class RunboxCalendarEvent implements CalendarEvent {
         recur_months:   string[],
         recur_nth:      string[],
     ) {
-        if (this.recurs && recur_save_type !== '0') {
+        if (this.recurs && recur_save_type !== RecurSaveType.ALL_OCCURENCES) {
             // Adding an exception to an already recurring event
             this.addExceptionEvent(
                 this.dtstart,
                 dtstart,
                 dtend,
-                recur_save_type === '2' ? true : false,
+                recur_save_type === RecurSaveType.THIS_AND_FUTURE ? true : false,
                 title,
                 description,
                 location);

--- a/src/app/calendar-app/runbox-calendar-event.ts
+++ b/src/app/calendar-app/runbox-calendar-event.ts
@@ -299,6 +299,7 @@ export class RunboxCalendarEvent implements CalendarEvent {
         this.event.component.updatePropertyWithValue('rrule', recur);
     }
 
+    // Jan-Dec numbered 1-12
     get recursByMonth(): string[] {
         const recur = this.event.component.getFirstPropertyValue('rrule');
         if (!recur) {

--- a/src/app/calendar-app/runbox-calendar-event.ts
+++ b/src/app/calendar-app/runbox-calendar-event.ts
@@ -143,8 +143,6 @@ export class RunboxCalendarEvent implements CalendarEvent {
     get start(): Date {
         // _dtstart as-is for display (its already got tz set.. )
         return new Date(this._dtstart.toString());
-        // this one converts to utc which is not helpful.
-        // return this._dtstart.toJSDate();
     }
 
     get end(): Date {
@@ -160,7 +158,6 @@ export class RunboxCalendarEvent implements CalendarEvent {
             shownEnd.addDuration(new ICAL.Duration({'isNegative': true, 'seconds': 1}));
         }
         return new Date(shownEnd.toString());
-        // return shownEnd.toJSDate();
     }
 
     get allDay(): boolean {
@@ -188,10 +185,6 @@ export class RunboxCalendarEvent implements CalendarEvent {
     // be different from dtstart above. Matches if its an exception.
     get recurStart(): Date {
         return this.event.startDate.toJSDate();
-    }
-
-    set recurStart(start: Date) {
-        // Nope can't do that Dave
     }
 
     // DAILY, WEEKLY, MONTHLY etc
@@ -394,7 +387,7 @@ export class RunboxCalendarEvent implements CalendarEvent {
         if (this.isException) {
             // This shouldnt be possible
             console.log('Refusing to create an exception of an exception');
-            return false;
+            return;
         }
         // clone existing one
         const new_exception = new ICAL.Event(ICAL.Component.fromString(this.event.toString()));

--- a/src/app/calendar-app/runbox-calendar-event.ts
+++ b/src/app/calendar-app/runbox-calendar-event.ts
@@ -88,21 +88,20 @@ export class RunboxCalendarEvent implements CalendarEvent {
         this.event.description = value;
     }
 
+    // This is the start time of an event instance (if recurring)
+    // See also: calendar.service.ts generateEvents
     get dtstart(): moment.Moment {
         return this.icalTimeToLocalMoment(this._dtstart);
     }
 
     // If set on an event with RRULE, updates entire repeated event
     // to now *start* from this new date
-    // FIXME: Should we prompt for "only this instance" /
-    // "this and future instances" and generate exceptions?
     // If set on an exception, only changes that exception
     set dtstart(value: moment.Moment) {
         const allDay = this.allDay;
-        this._dtstart = ICAL.Time.fromJSDate(value.toDate());
-        this.event.startDate = ICAL.Time.fromJSDate(value.toDate());
-        // FIXME: Now we need to update _dtstart (display time)
-        this._dtstart = this.event.startDate;
+        this._dtstart = this.momentToIcalTime(value, this.event.startDate ? this.event.startDate.zone : null);
+        // FIXME: Do this only if its the first one?
+        this.event.startDate = this._dtstart;
         // FIXME: regenerate all following events!?
         // Do we just let the save-to-dav / reloadEvents cycle do this for us?
         this.allDay = allDay;
@@ -122,9 +121,11 @@ export class RunboxCalendarEvent implements CalendarEvent {
     // See also set dtstart comments!
     set dtend(value: moment.Moment) {
         const allDay = this.allDay;
-        this._dtend = ICAL.Time.fromJSDate(value.toDate());
-        this.event.endDate = value ? ICAL.Time.fromJSDate(value.toDate()) : undefined;
-        this._dtstart = this.event.endDate;
+        if (value) {
+            this._dtend = this.momentToIcalTime(value, this.event.endDate ? this.event.endDate.zone : undefined);
+            // FIXME: (see above)
+            this.event.endDate = this._dtend;
+        }
         this.allDay = allDay;
     }
 
@@ -139,7 +140,7 @@ export class RunboxCalendarEvent implements CalendarEvent {
             return undefined;
         }
 
-        const shownEnd = this._dtend;
+        const shownEnd = this._dtend.clone();
         // ICAL event DTEND is exclusive, angular-calendar is inclusive
         if (this.allDay) {
             shownEnd.addDuration(new ICAL.Duration({'isNegative': true, 'days': 1}));
@@ -154,21 +155,163 @@ export class RunboxCalendarEvent implements CalendarEvent {
         return this._dtstart.isDate;
     }
 
+    get recurs(): boolean {
+        const recur = this.event.component.getFirstPropertyValue('rrule');
+        return recur ? true : false;
+    }
+
+    set recurs(flag: boolean) {
+        if (flag) {
+            const recur = this.event.component.getFirstPropertyValue('rrule');
+            if (!recur) {
+                this.event.component.addPropertyWithValue('rrule', new ICAL.Recur({ freq: 'DAILY' }));
+            }
+        } else {
+            this.event.component.removeProperty('rrule');
+        }
+    }
+
+    // This is the original DTSTART of the event - if recurring, will different
+    // from dtstart above.
+    get recurStart(): Date {
+        return this.event.startDate.toJSDate();
+    }
+
+    set recurStart(start: Date) {
+        // Nope can't do that Dave
+    }
+
     // DAILY, WEEKLY, MONTHLY etc
     get recurringFrequency(): string {
         const recur = this.event.component.getFirstPropertyValue('rrule');
         return recur ? recur.freq : '';
     }
 
-    // FIXME: This will delete any rrule parts from imported events
-    // that rb7's ui doesnt cope with
-    // FIXME: rrule only wants updating on the "main" event, not here if this is an exception event!?
+    // Only set if the new value is different from the old one
+    // Prevents us accidentally overwriting imported RRULE details
     // -> dont display the "recurring" select box on exception events?
     set recurringFrequency(frequency: string) {
-        this.event.component.removeProperty('rrule');
-        if (frequency !== '') {
+        const recur = this.event.component.getFirstPropertyValue('rrule');
+        if (recur) {
+            recur.freq = frequency;
+            this.event.component.updatePropertyWithValue('rrule', recur);
+        } else {
             this.event.component.addPropertyWithValue('rrule', new ICAL.Recur({ freq: frequency }));
         }
+    }
+
+    // How often does this repeat (every X freqs)
+    get recurInterval(): number {
+        const recur = this.event.component.getFirstPropertyValue('rrule');
+        return recur ? recur.interval : 1;
+    }
+
+    set recurInterval(interval: number) {
+        const recur = this.event.component.getFirstPropertyValue('rrule');
+        recur.interval = interval;
+        this.event.component.updatePropertyWithValue('rrule', recur);
+    }
+
+    // An UNTIL date, a COUNT or null = unset/repeats forever
+    get recurEnds(): Date | number {
+        const recur = this.event.component.getFirstPropertyValue('rrule');
+        if (recur && recur.until) {
+            return recur.until.toJSDate();
+        }
+        if (recur && recur.count) {
+            return recur.count;
+        }
+        return null;
+    }
+
+    set recurEnds(end: Date | number) {
+        const recur = this.event.component.getFirstPropertyValue('rrule');
+        recur.until = null;
+        recur.count = null;
+        if (typeof end === 'number' && end != null) {
+            recur.count = end;
+        }
+        if (end instanceof Date &&  end != null) {
+            // Must be a date (cant do typeof === 'Date' !?
+            const zone = this.event.startDate.zone;
+            const icaltime = ICAL.Time.fromJSDate(end);
+            icaltime.zone = zone;
+            recur.until = icaltime;
+        }
+        // else, everything null, repeats forever.
+        this.event.component.updatePropertyWithValue('rrule', recur);
+    }
+
+    // get "part"s, eg byday, bymonthday, bymonth, byyearday, byweekno
+
+    // One or more days of the week this rule could run on (or none)
+    // SU, MO etc (or can convert to days of week using .icalDayToNumericDay
+    // if a monthly BYDAY, could be "\+?1SU" or "-2TU" etc
+    get recursByDay(): string[] {
+        const recur = this.event.component.getFirstPropertyValue('rrule');
+        if (!recur) {
+            return [];
+        }
+        const bydays = recur.getComponent('byday');
+        const rgx = /^([+-]?\d+)?(\w{2})$/;
+        const bydays_mapped = bydays.map((day) => {
+            const match = day.match(rgx);
+            const numth = match[1] ? match[1] : '0';
+            return { 'day': match[2], 'numth': numth };
+        });
+        return bydays_mapped;
+    }
+
+    // replace entire list of day(s)
+    set recursByDay(value: string[]) {
+        const recur = this.event.component.getFirstPropertyValue('rrule');
+        recur.setComponent('byday', value);
+        this.event.component.updatePropertyWithValue('rrule', recur);
+    }
+
+    get recursByMonthDay(): string[] {
+        const recur = this.event.component.getFirstPropertyValue('rrule');
+        if (!recur) {
+            return [];
+        }
+        const bymonthdays = recur.getComponent('bymonthday');
+        return bymonthdays.map((day) => day.toString());
+    }
+
+    set recursByMonthDay(value: string[]) {
+        const recur = this.event.component.getFirstPropertyValue('rrule');
+        recur.setComponent('bymonthday', value);
+        this.event.component.updatePropertyWithValue('rrule', recur);
+    }
+
+    get recursByYearDay(): string[] {
+        const recur = this.event.component.getFirstPropertyValue('rrule');
+        if (!recur) {
+            return [];
+        }
+        const byyeardays = recur.getComponent('byyearday');
+        return byyeardays.map((day) => day.toString());
+    }
+
+    set recursByYearDay(value: string[]) {
+        const recur = this.event.component.getFirstPropertyValue('rrule');
+        recur.setComponent('byyearday', value);
+        this.event.component.updatePropertyWithValue('rrule', recur);
+    }
+
+    get recursByMonth(): string[] {
+        const recur = this.event.component.getFirstPropertyValue('rrule');
+        if (!recur) {
+            return [];
+        }
+        const bymonth = recur.getComponent('bymonth');
+        return bymonth.map((month) => month.toString());
+    }
+
+    set recursByMonth(value: string[]) {
+        const recur = this.event.component.getFirstPropertyValue('rrule');
+        recur.setComponent('bymonth', value);
+        this.event.component.updatePropertyWithValue('rrule', recur);
     }
 
     set allDay(value) {
@@ -182,6 +325,10 @@ export class RunboxCalendarEvent implements CalendarEvent {
         // FIXME: where is this set/used?
         // this.event.startDate = this._dtstart;
         // this.event.endDate   = this._dtend;
+    }
+
+    get isException(): boolean {
+        return this.event.component.hasProperty('recurrence-id');
     }
 
     // creates an unnamed event for today
@@ -221,6 +368,48 @@ export class RunboxCalendarEvent implements CalendarEvent {
         // necessarily the same as event.dtstart
         this._dtstart = startdate;
         this._dtend = enddate;
+    }
+
+    // An exception to the main (recurring) event
+    addExceptionEvent(
+        origdate: moment.Moment,
+        startdate: moment.Moment,
+        enddate: moment.Moment,
+        thisandfuture: boolean,
+        title: string,
+        description: string,
+        location: string): boolean {
+        if (this.isException) {
+            // This shouldnt be possible
+            console.log('Refusing to create an exception of an exception');
+            return false;
+        }
+        // clone existing one
+        const new_exception = new ICAL.Event(ICAL.Component.fromString(this.event.toString()));
+        new_exception.component.removeProperty('rrule');
+        const recurrence_id = this.momentToIcalTime(origdate, this.event.startDate.zone);
+        const new_start = this.momentToIcalTime(startdate, this.event.startDate.zone);
+        const new_end = this.momentToIcalTime(enddate, this.event.startDate.zone);
+        new_exception.recurrenceId = recurrence_id;
+        if (thisandfuture) {
+            // add RANGE=THISANDFUTURE
+            const rId = new_exception.component.getFirstProperty('recurrence-id');
+            rId.setParameter('range', 'THISANDFUTURE');
+            // new_exception.component.updatePropertyWithValue('recurrence-id',rId);
+        }
+        new_exception.startDate = new_start;
+        new_exception.endDate = new_end;
+        if (title) {
+            new_exception.summary = title;
+        }
+        if (description) {
+            new_exception.description = description;
+        }
+        if (location) {
+            new_exception.location = location;
+        }
+        this.ical.addSubcomponent(new_exception.component);
+        // recreate this.event to sort out the exceptions/recurrences?
     }
 
     // FIXME: do we still need this?
@@ -284,5 +473,15 @@ export class RunboxCalendarEvent implements CalendarEvent {
             // TODO localzone should perhaps be configurable
             return moment.utc(utc.toString()).tz(moment.tz.guess());
         }
+    }
+
+    private momentToIcalTime(input: moment.Moment, zone: ICAL.Timezone): ICAL.Time {
+        if (!zone) {
+            // This should probably use tz.guess() ?
+            zone = ICAL.Timezone.utcTimezone;
+        }
+        const ical_time = ICAL.Time.fromJSDate(input.toDate());
+        ical_time.zone = zone;
+        return ical_time;
     }
 }

--- a/src/app/calendar-app/runbox-calendar.ts
+++ b/src/app/calendar-app/runbox-calendar.ts
@@ -16,6 +16,9 @@
 // You should have received a copy of the GNU General Public License
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
+import { RunboxCalendarEvent } from './runbox-calendar-event';
+import * as ICAL from 'ical.js';
+import * as moment from 'moment';
 
 export class RunboxCalendar {
     id:           string;
@@ -31,6 +34,7 @@ export class RunboxCalendar {
         this.color       = props['color'] || props['calendar-color'];
         this.syncToken   = props['syncToken'] || props['sync-token'];
     }
+
 
     generateID(): void {
         let id = this.displayname.toLowerCase();

--- a/src/app/rmmapi/rbwebmail.ts
+++ b/src/app/rmmapi/rbwebmail.ts
@@ -647,6 +647,11 @@ export class RunboxWebmailAPI {
         );
     }
 
+    public getVTimezone(tzname: string): Observable<any> {
+        const tz_file = tzname + '.ics';
+        return this.http.get('/_ics/' + tz_file, {responseType: 'text'});
+    }
+
     public getAvailableProducts(): Observable<Product[]> {
         return this.http.get('/rest/v1/account_product/available').pipe(
             map((res: HttpResponse<any>) => res['result']['products']),

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -150,6 +150,10 @@ mat-chip.mat-chip.mat-standard-chip {
 
 /* Generic custom styles */
 
+.mat-dialog-container {
+    max-width: 550px;
+}
+
 mat-grid-tile.tableTitle {
     background-color: mat-color($rmm-default-foreground);
 }


### PR DESCRIPTION
Generate angular calendar event objects from "outside" the
RunboxCalendarEvent object (CalendarService now handles it), each RCE
object links to its main ICAL.Event object (which will be a separate
one if its an exception event).

TODO:
* [x] Tests! - Importing + see editing/saving notes
* [x] Sort out caching issue (caches fine, then re-caches at an extra level of depth!?) - FIXED
* Editing / saving of changes (changed nothing so far - needs to ensure we save/update recurring events, exceptions, or create new exceptions if needed?)
    * [x] 1. Can we edit a recurring event, and change (for eg) the time that it occurs, save updated ics back to DAV sanely 
    * [x] 2. Ditto above for non time related parts, eg description - DONE
    * [x] 3. Can we edit an event exception, change its time / description and save (whole event inc. exception) back to DAV
    * [x] 4. Can we create a new recurring event and save back to DAV (currently only daily/monthly etc, should clarify if thats "on same day/date of week/month" somehow on the UI) 
    * [x] 5. Can we edit a recurring event, change the time/ description on ONE of the instances, save back to DAV as a new exception
* [x] Ensure we handle/display recurring options we don't (yet) support gracefully - that is we can happily display events with "recurs 2nd Sunday of each month", but our UI doesn't yet support creating that type - grey out the "recurring" section of the edit dialog?
    * [x] Now implemented: editing of much more complex recurrence options: WEEKLY/MONTHLY/YEARLY, see images at https://gitlab.runbox.com/runbox/irc-meeting-actions/-/issues/274/ 
    * [x] Tests for the above needed!
* [x] Generate only the amount of events we can display, +/- 1 month - generating lots makes everything slllooow on events that never end (see Dave's iCloud examples)
    * [x] Update generated events when user moves to next/previous month, or next/previous week.. 
    * [x] Needs more visible "busy doing something" for event generation?  (via activities)
[x] Timezone support - set user timezone (from account settings) on new created events (and on floating/unset ones if edited) - display/edit things in user's timezone (no matter where their browser currently is)

* Simple test - 5 day event in April 2021, with one exception
[test45.txt](https://github.com/runbox/runbox7/files/5370279/test45.txt)

* Bigger test from iCloud/Dave, recurring daily/weekly/monthly with exceptions - no end dates! (slooww)
[RB Test2.txt](https://github.com/runbox/runbox7/files/5370287/RB.Test2.txt)

<s>See also matching backend branch. To use, set RUNBOX7_ANGULAR_BACKEND_HOST=http://rmm604test.gw01test.runbox.com:10004 before npm start.</s> - now live

Requires VTimezones on backend - https://gitlab.runbox.com/runbox/rmm/-/tree/castaway/vtimezones_for_ical

See also: #494 , #745, #331