### PR TITLE
feat(account): Add a way to view subaccounts associated with a product

### DIFF
--- a/src/app/account-app/account-app.module.ts
+++ b/src/app/account-app/account-app.module.ts
@@ -17,6 +17,7 @@
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
 
+import { CommonModule } from '@angular/common';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { NgModule, ErrorHandler } from '@angular/core';
 import { MenuModule } from '../menu/menu.module';
@@ -66,6 +67,7 @@ import { MatTableModule } from '@angular/material/table';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { CreditCardsComponent } from './credit-cards/credit-cards.component';
+import { SubAccountRenewalDialogComponent } from './sub-account-renewal-dialog';
 
 @NgModule({
   declarations: [
@@ -85,11 +87,13 @@ import { CreditCardsComponent } from './credit-cards/credit-cards.component';
     ProductComponent,
     ShoppingCartComponent,
     StripePaymentDialogComponent,
+    SubAccountRenewalDialogComponent,
     RunboxTimerComponent,
     CreditCardsComponent,
   ],
   imports: [
     BrowserAnimationsModule,
+    CommonModule,
     FormsModule,
     MenuModule,
     MatBadgeModule,

--- a/src/app/account-app/account-renewals.component.html
+++ b/src/app/account-app/account-renewals.component.html
@@ -23,7 +23,17 @@
     </ng-container>
     <ng-container matColumnDef="quantity">
         <th mat-header-cell *matHeaderCellDef> Quantity </th>
-        <td mat-cell *matCellDef="let p"> {{ p.quantity }} </td>
+        <td mat-cell *matCellDef="let p">
+            {{ p.quantity }}
+            <span *ngIf="p.subtype === 'subaccount'">
+                ({{ p.subaccounts.length }} in use)
+                <button mat-icon-button *ngIf="p.subaccounts.length > 0" (click)="showSubsDialog(p)">
+                    <mat-icon svgIcon="information-outline"
+                        [matTooltip]="'Associated accounts: ' + p.subaccounts.join(', ')"
+                    ></mat-icon>
+                </button>
+            </span>
+        </td>
     </ng-container>
     <ng-container matColumnDef="active_from">
         <th mat-header-cell *matHeaderCellDef> Active from </th>

--- a/src/app/account-app/account-renewals.component.ts
+++ b/src/app/account-app/account-renewals.component.ts
@@ -19,11 +19,13 @@
 
 import { Component } from '@angular/core';
 import { Router } from '@angular/router';
+import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 
 import { CartService } from './cart.service';
 import { ProductOrder } from './product-order';
 import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
+import { SubAccountRenewalDialogComponent } from './sub-account-renewal-dialog';
 
 import * as moment from 'moment';
 
@@ -37,6 +39,7 @@ export class AccountRenewalsComponent {
 
     constructor(
         private cart: CartService,
+        private dialog: MatDialog,
         private rmmapi: RunboxWebmailAPI,
         private router: Router,
         private snackbar: MatSnackBar,
@@ -82,6 +85,15 @@ export class AccountRenewalsComponent {
                 this.snackbar.open('Failed to determine domain for the product. Try again later or contact Runbox Support', 'Okay');
             },
         );
+    }
+
+    showSubsDialog(p: any) {
+        const dialogRef = this.dialog.open(SubAccountRenewalDialogComponent, { data: p });
+        dialogRef.afterClosed().subscribe(renew => {
+            if (renew) {
+                this.renew(p);
+            }
+        });
     }
 
     toggleAutorenew(p: any) {

--- a/src/app/account-app/sub-account-renewal-dialog.ts
+++ b/src/app/account-app/sub-account-renewal-dialog.ts
@@ -1,0 +1,52 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2020 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { Component, Inject } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+
+@Component({
+    selector: 'app-sub-account-renewal-dialog-component',
+    template: `
+<h1 mat-dialog-title> Sub-account product </h1>
+<div mat-dialog-content style="display: flex; flex-direction: column;">
+    <div>
+        <p> The following sub-accounts are associated with this product: </p>
+        <ol>
+            <li *ngFor="let username of product.subaccounts"> {{ username }} </li>
+        </ol>
+    </div>
+</div>
+<div mat-dialog-actions style="justify-content: space-between;">
+    <button mat-button (click)="dialogRef.close()"> Close </button>
+    <button mat-flat-button class="contentButton" (click)="dialogRef.close(true)">
+        Renew <mat-icon svgIcon="cart"></mat-icon>
+    </button>
+</div>
+    `,
+})
+export class SubAccountRenewalDialogComponent {
+    product: any;
+
+    constructor(
+        public dialogRef: MatDialogRef<SubAccountRenewalDialogComponent>,
+        @Inject(MAT_DIALOG_DATA) public data: any
+    ) {
+        this.product = data;
+    }
+}


### PR DESCRIPTION
Fixes GH-425.

Looks like this:

Hovered: 
![image](https://user-images.githubusercontent.com/86378/98560818-73591480-22a8-11eb-9726-bdde26826fca.png)

Clicked:
![subs2](https://user-images.githubusercontent.com/86378/98560878-87047b00-22a8-11eb-8ac3-40040283e314.png)
