### PR TITLE
feat(sentry): Include user data in error reports

### DIFF
--- a/src/app/sentry-error-handler.ts
+++ b/src/app/sentry-error-handler.ts
@@ -17,16 +17,46 @@
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
 
-import { Injectable, ErrorHandler } from '@angular/core';
+import { Injectable, ErrorHandler, Injector } from '@angular/core';
 import * as Sentry from '@sentry/browser';
 
 import './sentry';
+import { RMMAuthGuardService } from './rmmapi/rmmauthguard.service';
+import { RunboxWebmailAPI } from './rmmapi/rbwebmail';
 
 @Injectable()
 export class SentryErrorHandler implements ErrorHandler {
-    constructor() {}
+    userDataSet = false;
+
+    constructor(private injector: Injector) {
+        // hack needed since angular modules instantiate ErrorHandlers before anything else
+        setTimeout(() => this.setUserData(), 0);
+    }
+
+    // this is a bit overly complicated, because RunboxWebmailAPI will break
+    // if it gets instantiated before the user is actually logged in
+    async setUserData() {
+        if (this.userDataSet) {
+            return;
+        }
+        const authguard = this.injector.get(RMMAuthGuardService);
+        const isLoggedIn = await authguard.isLoggedIn().toPromise();
+        if (isLoggedIn) {
+            const rmmapi = this.injector.get(RunboxWebmailAPI);
+            const me = await rmmapi.me.toPromise();
+            Sentry.setUser({
+                uid:      me.uid,
+                username: me.username,
+                email:    me.user_address,
+            });
+            this.userDataSet = true;
+        }
+    }
+
     handleError(error: any) {
-        Sentry.captureException(error.originalError || error);
+        this.setUserData().then(
+            () => Sentry.captureException(error.originalError || error)
+        );
         console.error(error);
     }
 }


### PR DESCRIPTION
Couldn't figure out an easier way to do it without breaking RunboxWebmailAPI (see the comments), so it is a bit awkward.