### PR TITLE
fix(contacts): Only sync once during import of many contacts

### DIFF
--- a/src/app/contacts-app/contacts-app.component.ts
+++ b/src/app/contacts-app/contacts-app.component.ts
@@ -261,6 +261,7 @@ export class ContactsAppComponent {
             if (!result) {
                 return;
             }
+            const promises = [];
             for (const c of contacts) {
                 // Assign an uuid unless it already has one.
                 // Without it we won't be able to add them to groups if requested
@@ -278,9 +279,10 @@ export class ContactsAppComponent {
                     if (result.newCategory) {
                         c.categories = c.categories.concat(result.newCategory);
                     }
-                    this.contactsservice.saveContact(c);
+                    promises.push(this.contactsservice.saveContact(c, false));
                 }
             }
+            Promise.all(promises).finally(() => this.contactsservice.reload());
             if (result.addToGroup) {
                 this.addContactsToGroup(result.addToGroup, contacts);
             }

--- a/src/app/contacts-app/contacts.service.ts
+++ b/src/app/contacts-app/contacts.service.ts
@@ -249,7 +249,7 @@ export class ContactsService implements OnDestroy {
         });
     }
 
-    saveContact(contact: Contact): Promise<string> {
+  saveContact(contact: Contact, syncNow: boolean = true): Promise<string> {
         this.activities.begin(Activity.SavingContact);
 
         const promise = new Promise<string>((resolve, reject) => {
@@ -271,7 +271,11 @@ export class ContactsService implements OnDestroy {
                 this.rmmapi.addNewContact(contact).subscribe(url => {
                     this.informationLog.next('New contact has been created');
                     contact.url = url;
-                    this.reload().then(() => resolve(contact.id));
+                    if (syncNow) {
+                        this.reload().then(() => resolve(contact.id));
+                    } else {
+                        resolve(contact.id);
+                    }
                 }, e => {
                     this.apiErrorHandler(e);
                     reject();


### PR DESCRIPTION
Attempting to run all contact imports, then do the reload() rather than one per contact (which is a bit crazy for a large import)