### PR TITLE
fix(start): Fix case sensitivity for address matching

### DIFF
--- a/src/app/start/startdesk.component.ts
+++ b/src/app/start/startdesk.component.ts
@@ -75,7 +75,7 @@ export class StartDeskComponent implements OnInit {
 
     ngOnInit() {
         this.rmmapi.getFromAddress().subscribe(
-            froms => this.ownAddresses.next(new Set(froms.map(f => f.email))),
+            froms => this.ownAddresses.next(new Set(froms.map(f => f.email.toLowerCase()))),
             _err  => this.ownAddresses.next(new Set([])),
         );
         this.searchService.initSubject.pipe(filter(enabled => enabled)).subscribe(() => this.updateCommsOverview());
@@ -201,7 +201,7 @@ export class StartDeskComponent implements OnInit {
         const ownAddresses = await this.ownAddresses.pipe(take(1)).toPromise();
 
         for (const message of messages) {
-            if (!message.recipients.find(r => ownAddresses.has(r))) {
+            if (!message.recipients.find(r => ownAddresses.has(r.toLowerCase()))) {
                 for (const recipient of message.recipients) {
                     const recId = this.emailOf(recipient) || recipient;
                     let occurences = possibleMailingLists.get(recId) || 0;


### PR DESCRIPTION
If the email we received was sent to us with some capitalized letters in the address i.e. `ABC@runbox.com`, the overview didn't know it's our address and was showing it instead of the sender's email address.