### PR TITLE
Startdesk folder selector

### DIFF
--- a/src/app/start/startdesk.component.html
+++ b/src/app/start/startdesk.component.html
@@ -28,11 +28,19 @@
         </mat-form-field>
         <mat-form-field>
           <mat-select [(ngModel)]="folder" (selectionChange)="changeFolder($event)">
-            <mat-option [value]=""> Current folder </mat-option>
-            <mat-option [value]=""> All folders </mat-option>
+            <mat-option [value]="FolderSelection.INBOX">  Inbox only </mat-option>
+            <mat-option [value]="FolderSelection.ALL">    All folders </mat-option>
+            <mat-option [value]="FolderSelection.CUSTOM"> Custom selection </mat-option>
           </mat-select>
         </mat-form-field>
         <mat-checkbox [checked]="unreadOnly" (change)="toggleUnreadOnly($event)"> Unread only </mat-checkbox>
+      </div>
+      <div id="folderSelector" *ngIf="folder === FolderSelection.CUSTOM">
+          <mat-checkbox
+              *ngFor="let folder of folderSelectorSwitches"
+              [checked]="folder.shown"
+              (change)="toggleFolderVisibility(folder.name, $event)"
+         > {{ folder.name }} ({{ folder.count }}) </mat-checkbox>
       </div>
       <mat-tab-group>
         <mat-tab label="All emails ({{ totalEmailCount }})">

--- a/src/app/start/startdesk.component.html
+++ b/src/app/start/startdesk.component.html
@@ -26,6 +26,12 @@
             <mat-option [value]="TimeSpan.CUSTOM"> Custom (NYI) </mat-option>
           </mat-select>
         </mat-form-field>
+        <mat-form-field>
+          <mat-select [(ngModel)]="folder" (selectionChange)="changeFolder($event)">
+            <mat-option [value]=""> Current folder </mat-option>
+            <mat-option [value]=""> All folders </mat-option>
+          </mat-select>
+        </mat-form-field>
         <mat-checkbox [checked]="unreadOnly" (change)="toggleUnreadOnly($event)"> Unread only </mat-checkbox>
       </div>
       <mat-tab-group>

--- a/src/app/start/startdesk.component.scss
+++ b/src/app/start/startdesk.component.scss
@@ -171,5 +171,9 @@ $rmm-default-highlight: mat-palette($mat-light-blue, 50, 25, 75);
         #title {
             display: none;
         }
+        #hilightsSettings {
+            justify-content: space-between;
+            flex-wrap: wrap;
+        }
     }
 }

--- a/src/app/start/startdesk.component.scss
+++ b/src/app/start/startdesk.component.scss
@@ -81,6 +81,12 @@ $rmm-default-highlight: mat-palette($mat-light-blue, 50, 25, 75);
                 }
             }
         }
+        #folderSelector {
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: space-around;
+            align-items: center;
+        }
         .contact {
             width: 33%;
             font-weight: bold;

--- a/src/app/start/startdesk.component.ts
+++ b/src/app/start/startdesk.component.ts
@@ -46,6 +46,18 @@ enum TimeSpan {
     CUSTOM,
 }
 
+enum FolderSelection {
+    ALL,
+    INBOX,
+    CUSTOM,
+}
+
+interface FolderSelectorEntry {
+    name:  string;
+    count: number;
+    shown: boolean;
+}
+
 @Component({
     selector: 'app-start',
     templateUrl: './startdesk.component.html',
@@ -58,10 +70,21 @@ export class StartDeskComponent implements OnInit {
     regularOverview: ContactHilights[] = [];
     mailingListOverview: ContactHilights[] = [];
 
-    TimeSpan = TimeSpan; // exposing enum to the template
+    // exposing enums to the template
+    TimeSpan = TimeSpan;
+    FolderSelection = FolderSelection;
     // TODO: from appsettings or such?
     unreadOnly = false;
     timeSpan = TimeSpan.TODAY;
+    folder = FolderSelection.ALL;
+    // for the folder message selector.
+    // We store the number of currently available messages in each folder,
+    // as well as the set of folders explicitely hidden (they're all shown by default).
+    folderMessages: Map<string, number> = new Map();
+    hiddenFolders = new Set<string>();
+    // a pre-calculated set of values for the folder selector, so that the angular template
+    // doesn't have to do too much too often
+    folderSelectorSwitches: FolderSelectorEntry[] = [];
 
     totalEmailCount = 0;
     regularEmailCount = 0;
@@ -84,10 +107,31 @@ export class StartDeskComponent implements OnInit {
 
     private async updateCommsOverview(): Promise<void> {
         const dateRange = this.dateRange();
+        const folderMessages = new Map<string, number>();
         const messages = this.searchService.getMessagesInTimeRange(
             dateRange[0], dateRange[1]
-        ).map(id => this.searchService.getDocData(id)
-        ).filter(msg => !this.unreadOnly || !msg.seen);
+        ).map(
+            id => this.searchService.getDocData(id)
+        ).filter(
+            msg => !this.unreadOnly || !msg.seen
+        ).filter(
+            msg => msg.folder !== 'Sent'
+        ).filter(
+            msg => {
+                const folderMessageCount = folderMessages.get(msg.folder) || 0;
+                folderMessages.set(msg.folder, folderMessageCount + 1);
+                switch (this.folder) {
+                    case FolderSelection.ALL:
+                        return true;
+                    case FolderSelection.INBOX:
+                        return msg.folder === 'Inbox';
+                    case FolderSelection.CUSTOM:
+                        return !this.hiddenFolders.has(msg.folder);
+                }
+            }
+        );
+        this.folderMessages = folderMessages;
+        this.updateFolderSelectorSwitches();
 
         // Ideally, we'll obtain a list of mailing lists from List-ID across the entirety of search index
         // We don't have that luxury currently, so this hack will have to do
@@ -221,6 +265,16 @@ export class StartDeskComponent implements OnInit {
         return mailingLists;
     }
 
+    public toggleFolderVisibility(folderName: string, event: MatCheckboxChange) {
+        if (event.checked) {
+            this.hiddenFolders.delete(folderName);
+        } else {
+            this.hiddenFolders.add(folderName);
+        }
+        // TODO: persist hiddenFolders in settings or something
+        this.updateCommsOverview();
+    }
+
     public toggleUnreadOnly(event: MatCheckboxChange) {
         this.unreadOnly = event.checked;
         this.updateCommsOverview();
@@ -228,6 +282,11 @@ export class StartDeskComponent implements OnInit {
 
     public changeTimeSpan(event: MatSelectChange) {
         this.timeSpan = event.value;
+        this.updateCommsOverview();
+    }
+
+    public changeFolder(event: MatSelectChange) {
+        this.folder = event.value;
         this.updateCommsOverview();
     }
 
@@ -243,6 +302,17 @@ export class StartDeskComponent implements OnInit {
                 return [moment().subtract(6, 'day').toDate(), null];
             case TimeSpan.CUSTOM:
                 return [new Date(), null];
+        }
+    }
+
+    private updateFolderSelectorSwitches() {
+        this.folderSelectorSwitches = [];
+        for (const folder of Array.from(this.folderMessages.keys()).sort()) {
+            this.folderSelectorSwitches.push({
+                name:  folder,
+                count: this.folderMessages.get(folder),
+                shown: !this.hiddenFolders.has(folder),
+            });
         }
     }
 }


### PR DESCRIPTION
Extracted from https://github.com/runbox/runbox7/pull/794 and applied on top of current master.

Looks pretty bad on mobile and takes up a ton of space though:

![desk](https://user-images.githubusercontent.com/86378/100639489-8609bb00-3335-11eb-9016-7ace310d3989.png)

Any ideas for improvements (@kvviecien? :))