### PR TITLE
Startdesk fixes

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -72,6 +72,11 @@
         <span class="foldersidebarcount" style="margin-right: 24px"> {{ draftDeskService.draftModels.length }} </span>
       </mat-list-item>
 
+      <mat-list-item (click)="overview()" id="overviewButton" [ngClass]="{'selectedFolder' : overviewSelected}">
+        <mat-icon mat-list-icon svgIcon="blur" class="folderIconStandard"></mat-icon>
+        <p mat-line class="folderName">Overview</p>
+      </mat-list-item>
+
       <mat-divider></mat-divider>
     </mat-nav-list>
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -98,6 +98,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
   selectedFolder = 'Inbox';
   composeSelected: boolean;
   draftsSelected: boolean;
+  overviewSelected: boolean;
 
   timeOfDay: string;
 
@@ -381,6 +382,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     ).subscribe((event: NavigationEnd) => {
       this.composeSelected = this.router.url === '/compose?new=true';
       this.draftsSelected = this.router.url === '/compose';
+      this.overviewSelected = this.router.url === '/overview';
     });
 
     // Download visible messages in the background
@@ -492,6 +494,15 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     this.rmmapi.moveFolder(event.sourceId, event.destinationId, event.order).subscribe(
       () => this.messagelistservice.refreshFolderList()
     );
+  }
+
+  public overview() {
+    this.router.navigate(['/overview']);
+    setTimeout(() => {
+        if (this.mobileQuery.matches && this.sidemenu.opened) {
+          this.sidemenu.close();
+        }
+      }, 0);
   }
 
   renameFolder(folder: RenameFolderEvent) {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -81,6 +81,7 @@ import { HotkeyModule } from 'angular2-hotkeys';
 import { RMM } from './rmm';
 import { PopularRecipientsComponent } from './popular-recipients/popular-recipients.component';
 import { OverviewComponent } from './start/overview.component';
+import { StartDeskComponent } from './start/startdesk.component';
 import { SearchService } from './xapian/searchservice';
 import { SavedSearchesComponent } from './saved-searches/saved-searches.component';
 import { SavedSearchesService } from './saved-searches/saved-searches.service';
@@ -106,6 +107,10 @@ const routes: Routes = [
           {
             path: 'compose',
             component: DraftDeskComponent
+          },
+          {
+            path: 'overview',
+            component: StartDeskComponent
           },
           {
             path: 'welcome',

--- a/src/app/start/startdesk.component.html
+++ b/src/app/start/startdesk.component.html
@@ -1,16 +1,4 @@
 <div id="startdesk">
-  <div id="heading">
-    <div id="title">
-      <h1>Runbox Dash Desk</h1>
-    </div>
-    <!-- <div id="panelControls">
-      Panel size:&nbsp;
-      <mat-icon id="panelControlSmall">check_box_outline_blank</mat-icon>
-      <mat-icon id="panelControlMedium">check_box_outline_blank</mat-icon>
-      <mat-icon id="panelControlLarge">check_box_outline_blank</mat-icon>
-    </div> -->
-  </div>
-
   <div id="dashdeskOverviewContainer">
     <mat-card class="mat-card communicationOverview">
       <h3><mat-icon>blur_on</mat-icon>Communication overview</h3>

--- a/src/app/start/startdesk.component.html
+++ b/src/app/start/startdesk.component.html
@@ -1,7 +1,7 @@
 <div id="startdesk">
   <div id="dashdeskOverviewContainer">
     <mat-card class="mat-card communicationOverview">
-      <h3><mat-icon>blur_on</mat-icon>Communication overview</h3>
+      <h3 class="communicationTitle"><mat-icon>blur_on</mat-icon>Communication overview</h3>
       <h4>Activity highlights</h4>
       <div id="hilightsSettings">
         <mat-form-field>

--- a/src/app/start/startdesk.component.html
+++ b/src/app/start/startdesk.component.html
@@ -56,7 +56,7 @@
           <mat-card class="mat-card dashdeskCard senderItem" *ngFor="let sender of regularOverview.concat(mailingListOverview)">
             <div class="contact">
               <mat-icon> {{ sender.icon }}</mat-icon> <h4> {{ sender.name }} </h4>
-              <div class="messages">{{ sender.emails.length }} messages today</div>
+              <div class="messages">{{ sender.emails.length }} messages</div>
             </div>
             <div class="subject">
               <ul>
@@ -74,7 +74,7 @@
           <mat-card class="mat-card dashdeskCard senderItem" *ngFor="let sender of regularOverview">
             <div class="contact">
               <mat-icon> {{ sender.icon }}</mat-icon> <h4> {{ sender.name }} </h4>
-              <div class="messages">{{ sender.emails.length }} messages today</div>
+              <div class="messages">{{ sender.emails.length }} messages</div>
             </div>
             <div class="subject">
               <ul>
@@ -92,7 +92,7 @@
           <mat-card class="mat-card dashdeskCard senderItem" *ngFor="let sender of mailingListOverview">
             <div class="contact">
               <mat-icon> {{ sender.icon }}</mat-icon> <h4> {{ sender.name }} </h4>
-              <div class="messages">{{ sender.emails.length }} messages today</div>
+              <div class="messages">{{ sender.emails.length }} messages</div>
             </div>
             <div class="subject">
               <ul>

--- a/src/app/start/startdesk.component.html
+++ b/src/app/start/startdesk.component.html
@@ -2,26 +2,28 @@
   <div id="dashdeskOverviewContainer">
     <mat-card class="mat-card communicationOverview">
       <h3 class="communicationTitle"><mat-icon>blur_on</mat-icon>Communication overview</h3>
-      <h4>Activity highlights</h4>
-      <div id="hilightsSettings">
-        <mat-form-field>
-          <mat-label> Time span </mat-label>
-          <mat-select [(ngModel)]="timeSpan" (selectionChange)="changeTimeSpan($event)">
-            <mat-option [value]="TimeSpan.TODAY"> Today </mat-option>
-            <mat-option [value]="TimeSpan.YESTERDAY"> Yesterday </mat-option>
-            <mat-option [value]="TimeSpan.LAST3"> Last 3 days </mat-option>
-            <mat-option [value]="TimeSpan.LAST7"> Last 7 days </mat-option>
-            <mat-option [value]="TimeSpan.CUSTOM"> Custom (NYI) </mat-option>
-          </mat-select>
-        </mat-form-field>
-        <mat-form-field>
-          <mat-select [(ngModel)]="folder" (selectionChange)="changeFolder($event)">
-            <mat-option [value]="FolderSelection.INBOX">  Inbox only </mat-option>
-            <mat-option [value]="FolderSelection.ALL">    All folders </mat-option>
-            <mat-option [value]="FolderSelection.CUSTOM"> Custom selection </mat-option>
-          </mat-select>
-        </mat-form-field>
-        <mat-checkbox [checked]="unreadOnly" (change)="toggleUnreadOnly($event)"> Unread only </mat-checkbox>
+      <div class="highlights">
+        <h4>Activity highlights</h4>
+        <div id="hilightsSettings">
+          <mat-form-field>
+            <mat-label> Time span </mat-label>
+            <mat-select [(ngModel)]="timeSpan" (selectionChange)="changeTimeSpan($event)">
+              <mat-option [value]="TimeSpan.TODAY"> Today </mat-option>
+              <mat-option [value]="TimeSpan.YESTERDAY"> Yesterday </mat-option>
+              <mat-option [value]="TimeSpan.LAST3"> Last 3 days </mat-option>
+              <mat-option [value]="TimeSpan.LAST7"> Last 7 days </mat-option>
+              <mat-option [value]="TimeSpan.CUSTOM"> Custom (NYI) </mat-option>
+            </mat-select>
+          </mat-form-field>
+          <mat-form-field>
+            <mat-select [(ngModel)]="folder" (selectionChange)="changeFolder($event)">
+              <mat-option [value]="FolderSelection.INBOX">  Inbox only </mat-option>
+              <mat-option [value]="FolderSelection.ALL">    All folders </mat-option>
+              <mat-option [value]="FolderSelection.CUSTOM"> Custom selection </mat-option>
+            </mat-select>
+          </mat-form-field>
+          <mat-checkbox [checked]="unreadOnly" (change)="toggleUnreadOnly($event)"> Unread only </mat-checkbox>
+        </div>
       </div>
       <div id="folderSelector" *ngIf="folder === FolderSelection.CUSTOM">
           <mat-checkbox

--- a/src/app/start/startdesk.component.scss
+++ b/src/app/start/startdesk.component.scss
@@ -2,21 +2,16 @@
 $rmm-default-highlight: mat-palette($mat-light-blue, 50, 25, 75);
 
 #startdesk {
-    position: relative;
-    margin: 0 30px;
+    position: absolute;
+    top: 64px;
+    bottom: 0px;
+    left: 0px;
+    right: 0px;
+    padding: 15px;
 
-    #heading {
-        display: flex;
-    }
-    #title {
-        display: flex;
-        flex-grow: 1;
-    }
-    #panelControls {
-        display: flex;
-        flex-grow: 1;
-        justify-content: flex-end;
-        align-items: center;
+    @media only screen and (max-width: 768px) {
+        padding: 0;
+        top: 56px;
     }
     h3 {
         margin: 0;

--- a/src/app/start/startdesk.component.scss
+++ b/src/app/start/startdesk.component.scss
@@ -12,14 +12,35 @@ $rmm-default-highlight: mat-palette($mat-light-blue, 50, 25, 75);
     @media only screen and (max-width: 768px) {
         padding: 0;
         top: 56px;
+
+        .communicationTitle{
+            position: absolute;
+            top: -39px;
+            left: 60px;
+
+            mat-icon {
+                display: none;
+            }
+        }
     }
     h3 {
         margin: 0;
         padding: 0;
+        @media only screen and (max-width: 768px) {
+            font-size: 21px;
+        }
     }
     h3 mat-icon {
         margin-right: 5px;
     }
+    h4 {
+        margin-block-start: 1em;
+        margin-block-end: 1em;
+        @media only screen and (max-width: 768px) {
+            margin-block-start: 0;
+        }
+    }
+    
     mat-card {
         float: left;
         width: 100%;

--- a/src/app/start/startdesk.component.scss
+++ b/src/app/start/startdesk.component.scss
@@ -140,10 +140,31 @@ $rmm-default-highlight: mat-palette($mat-light-blue, 50, 25, 75);
     justify-content: center;
     padding: 20px 0 0 0;
 }
+.highlights{
+    display: flex;
+    justify-content: space-between;
+    padding-left: 20px;
+    padding-right: 20px;
+
+    @media only screen and (max-width: 768px) {
+        flex-direction: column;
+        justify-content: space-around;
+        padding-left: 0;
+        padding-right: 0;
+    }
+}
 #hilightsSettings {
     display: flex;
-    justify-content: space-around;
+    justify-content: space-between;
     align-items: center;
+
+    mat-checkbox {
+        padding-left: 10px;
+    }
+
+    @media only screen and (max-width: 768px) {
+        justify-content: space-around;
+    }
 }
 
 @media only screen and (max-width: 768px) {

--- a/src/app/start/startdesk.component.scss
+++ b/src/app/start/startdesk.component.scss
@@ -88,6 +88,12 @@ $rmm-default-highlight: mat-palette($mat-light-blue, 50, 25, 75);
             }
         }
     }
+    #folderSelector {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: space-between;
+        align-items: center;
+    }
     .contact {
         width: 33%;
         font-weight: bold;
@@ -164,6 +170,7 @@ $rmm-default-highlight: mat-palette($mat-light-blue, 50, 25, 75);
 
     @media only screen and (max-width: 768px) {
         justify-content: space-around;
+        flex-direction: column;
     }
 }
 

--- a/src/app/start/startdesk.component.scss
+++ b/src/app/start/startdesk.component.scss
@@ -17,154 +17,121 @@ $rmm-default-highlight: mat-palette($mat-light-blue, 50, 25, 75);
         margin: 0;
         padding: 0;
     }
+    h3 mat-icon {
+        margin-right: 5px;
+    }
     mat-card {
         float: left;
         width: 100%;
         padding: 20px;
-    }
-    // #panelControls mat-icon {
-    //     vertical-align: bottom;
-    //     line-height: 24px;
-    // }
-    // #panelControlSmall {
-    //     font-size: 16px;
-    //     width: 16px;
-    //     height: auto;
-    // }
-    // #panelControlMedium {
-    //     font-size: 24px;
-    //     width: 24px;
-    //     height: auto;
-    // }
-    // #panelControlLarge {
-    //     font-size: 40px;
-    //     width: 40px;
-    //     height: auto;
-    // }
-    #dashdeskOverviewContainer {
-        display: block;
-        width: 100%;
-        height: 100%;
 
-        .communicationOverview {
-            box-sizing: border-box;
-
-            /* For mobile screens: */
-            @media only screen and (max-width: 768px) {
-                margin: 0;
-                min-height: calc(100vh - 56px);
-            }
-        }
-        .dashdeskCard {
-            box-sizing: border-box;
-            display: flex;
-            width: calc(100% - 20px);
-            margin: 20px 0 1px 10px;
-
-            /* For mobile screens: */
-            @media only screen and (max-width: 768px) {
-                margin: 20px 0 0 0;
-                width: 100%;
-                display: block;
-                border: 0;
-                .contact,
-                .subject {
-                    width: 100%;
-                }
-                .subject {
-                    padding-top: 10px;
-                }
-            }
-        }
-        #folderSelector {
-            display: flex;
-            flex-wrap: wrap;
-            justify-content: space-around;
-            align-items: center;
-        }
-        .contact {
-            width: 33%;
-            font-weight: bold;
-        }
-        .contact mat-icon {
-            margin-right: 10px;
-            font-size: 40px;
-            width: 40px;
-            height: auto;
-        }
-        .contact h4 {
-            display: inline;
-            margin: 10px 0;
-        }
-        .messages {
-            margin: 0 5px;
-        }
-        .subject {
-            width: 66%;
-            text-decoration: underline;
-        }
-        .subject ul {
-            margin: 0;
-        }
-        .subject li {
-            list-style-type: square;
-        }
-    }
-    #dashdeskSections {
-        mat-card {
-            width: 43%;
-            height: 250px;
-            padding: 20px;
-        }
-        mat-card div {
-            margin: 10px 0;
-        }
-        mat-card h3 mat-icon {
-            font-size: 1.4em;
-            height: 1em;
-            margin-right: 20px;
-        }
-        .start_chart {
-            font-size: 3em;
-            height: auto;
-        }
-    }
-    .noMessagesCard {
-        display: flex;
-        justify-content: center;
-        padding: 20px 0 0 0;
-    }
-    #hilightsSettings {
-        display: flex;
-        justify-content: space-around;
-        align-items: center;
-    }
-
-    /* For mobile screens: */
-    @media only screen and (max-width: 768px) {
-        margin: 0;
-
-        #heading {
-            padding: 0 20px;
-        }
-        mat-card {
+        @media only screen and (max-width: 768px) {
             border-radius: 0;
             border: 0;
             padding: 16px;
         }
-        h3 mat-icon {
-            margin-right: 5px;
+    }
+}
+#dashdeskOverviewContainer {
+    display: block;
+    width: 100%;
+    height: 100%;
+
+    .communicationOverview {
+        box-sizing: border-box;
+
+        /* For mobile screens: */
+        @media only screen and (max-width: 768px) {
+            margin: 0;
+            min-height: calc(100vh - 56px);
         }
-        .senderItem {
+    }
+    .dashdeskCard {
+        box-sizing: border-box;
+        display: flex;
+        width: calc(100% - 20px);
+        margin: 20px 0 1px 10px;
+
+        /* For mobile screens: */
+        @media only screen and (max-width: 768px) {
+            margin: 20px 0 0 0;
+            width: 100%;
             display: block;
-            margin-right: 0;
-            div {
-                display: block !important;
+            border: 0;
+            .contact,
+            .subject {
                 width: 100%;
             }
+            .subject {
+                padding-top: 10px;
+            }
         }
-        #title {
-            display: none;
+    }
+    .contact {
+        width: 33%;
+        font-weight: bold;
+    }
+    .contact mat-icon {
+        margin-right: 10px;
+        font-size: 40px;
+        width: 40px;
+        height: auto;
+    }
+    .contact h4 {
+        display: inline;
+        margin: 10px 0;
+    }
+    .messages {
+        margin: 0 5px;
+    }
+    .subject {
+        width: 66%;
+        text-decoration: underline;
+    }
+    .subject ul {
+        margin: 0;
+    }
+    .subject li {
+        list-style-type: square;
+    }
+}
+#dashdeskSections {
+    mat-card {
+        width: 43%;
+        height: 250px;
+        padding: 20px;
+    }
+    mat-card div {
+        margin: 10px 0;
+    }
+    mat-card h3 mat-icon {
+        font-size: 1.4em;
+        height: 1em;
+        margin-right: 20px;
+    }
+    .start_chart {
+        font-size: 3em;
+        height: auto;
+    }
+}
+.noMessagesCard {
+    display: flex;
+    justify-content: center;
+    padding: 20px 0 0 0;
+}
+#hilightsSettings {
+    display: flex;
+    justify-content: space-around;
+    align-items: center;
+}
+
+@media only screen and (max-width: 768px) {
+    .senderItem {
+        display: block;
+        margin-right: 0;
+        div {
+            display: block !important;
+            width: 100%;
         }
         #hilightsSettings {
             justify-content: space-between;

--- a/src/app/start/startdesk.component.scss
+++ b/src/app/start/startdesk.component.scss
@@ -13,7 +13,7 @@ $rmm-default-highlight: mat-palette($mat-light-blue, 50, 25, 75);
         padding: 0;
         top: 56px;
 
-        .communicationTitle{
+        .communicationTitle {
             position: absolute;
             top: -39px;
             left: 60px;
@@ -40,7 +40,7 @@ $rmm-default-highlight: mat-palette($mat-light-blue, 50, 25, 75);
             margin-block-start: 0;
         }
     }
-    
+
     mat-card {
         float: left;
         width: 100%;
@@ -146,7 +146,7 @@ $rmm-default-highlight: mat-palette($mat-light-blue, 50, 25, 75);
     justify-content: center;
     padding: 20px 0 0 0;
 }
-.highlights{
+.highlights {
     display: flex;
     justify-content: space-between;
     padding-left: 20px;
@@ -163,6 +163,7 @@ $rmm-default-highlight: mat-palette($mat-light-blue, 50, 25, 75);
     display: flex;
     justify-content: space-between;
     align-items: center;
+    padding-bottom: 20px;
 
     mat-checkbox {
         padding-left: 10px;
@@ -170,6 +171,10 @@ $rmm-default-highlight: mat-palette($mat-light-blue, 50, 25, 75);
 
     @media only screen and (max-width: 768px) {
         justify-content: space-around;
+        flex-wrap: wrap;
+    }
+
+    @media only screen and (max-width: 400px) {
         flex-direction: column;
     }
 }
@@ -181,10 +186,6 @@ $rmm-default-highlight: mat-palette($mat-light-blue, 50, 25, 75);
         div {
             display: block !important;
             width: 100%;
-        }
-        #hilightsSettings {
-            justify-content: space-between;
-            flex-wrap: wrap;
         }
     }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -605,13 +605,13 @@ a.mainMenu, mat-menu a, .mat-nav-list a {
 }
 
 @media(min-width: 1025px) {
-    #composeButton, #draftsButton {
+    #composeButton, #draftsButton, #overviewButton {
 	    display: block;
     }
 }
 
 @media(max-width: 1024px) {
-    #composeButton, #draftsButton {
+    #composeButton, #draftsButton, #overviewButton {
 	    display: none;
     }
 }


### PR DESCRIPTION
Most changes extracted from #794 (except for Folder Selector which is being integrated by tadzik in #841) and applied on top of current master.

Desktop view for consistency is styled the same way as Compose.
Applied condensed layout in heading area (Geir's suggestion in #794).
<kbd><img src="https://user-images.githubusercontent.com/24294620/101672281-f7441f00-3a55-11eb-8287-963f6cf474f7.png" width="800">
</kbd>

For mobile the section title moved to the top bar to save space
<kbd>
<img src="https://user-images.githubusercontent.com/24294620/101668675-1be9c800-3a51-11eb-914a-be9eacf3f454.png">
</kbd>