### PR TITLE
fix(mailview): Delete trash more efficiently (with less errors)

### DIFF
--- a/e2e/cypress/integration/folders.ts
+++ b/e2e/cypress/integration/folders.ts
@@ -23,7 +23,7 @@ describe('Folder management', () => {
             .click();
 
         cy.server();
-        cy.route('DELETE', '/rest/v1/email/**').as('emptyTrashReq');
+        cy.route('PUT', '/rest/v1/email_folder/empty').as('emptyTrashReq');
         cy.contains('div.mat-menu-content button', 'Empty trash').click();
         cy.wait('@emptyTrashReq');
     });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -513,16 +513,24 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     });
   }
 
-  async emptyTrash(trashFolderName: string) {
-    console.log('found trash folder with name', trashFolderName);
+  async emptyTrash(trashFolder: FolderListEntry) {
+    console.log('found trash folder with name', trashFolder.folderName);
     const messageLists = await this.rmmapi.listAllMessages(
       0, 0, 0,
       RunboxWebmailAPI.LIST_ALL_MESSAGES_CHUNK_SIZE,
-      true, trashFolderName
+      true, trashFolder.folderName
     ).toPromise();
-    await this.rmmapi.deleteMessages(messageLists.map(msg => msg.id)).toPromise();
+
+    // remove local copies
+    this.searchService.deleteMessages(messageLists.map((msg) => msg.id));
+    this.searchService.updateIndexWithNewChanges();
+    // empty remote folder
+    await this.rmmapi.emptyFolder(trashFolder.folderId).toPromise();
+    // ensure the view empties if we're looking at the trash
+    this.messagelistservice.setCurrentFolder(trashFolder.folderName);
+    // update local copies
     this.messagelistservice.refreshFolderList();
-    console.log('Deleted from', trashFolderName);
+    console.log('Deleted from', trashFolder.folderName);
   }
 
   async emptySpam(spamFolderName) {

--- a/src/app/folder/folderlist.component.html
+++ b/src/app/folder/folderlist.component.html
@@ -83,7 +83,7 @@
           </ng-container>  
           <ng-container *ngSwitchCase="'trash'">
             <mat-menu #trashFolderActionsMenu="matMenu">
-              <button mat-menu-item (click)="emptyTrash.next(node.folderName)">
+              <button mat-menu-item (click)="emptyTrash.next(node)">
                 <mat-icon svgIcon="notification-clear-all"></mat-icon>
                 <span>Empty trash</span>              
               </button>

--- a/src/app/rmmapi/rbwebmail.ts
+++ b/src/app/rmmapi/rbwebmail.ts
@@ -340,6 +340,14 @@ export class RunboxWebmailAPI {
         return req.pipe(map((res: any) => res.status === 'success'));
     }
 
+    emptyFolder(folderId: number): Observable<boolean> {
+        const req = this.http.put('/rest/v1/email_folder/empty', {
+            'folder_id': folderId
+        }).pipe(share());
+        this.subscribeShowBackendErrors(req);
+        return req.pipe(map((res: any) => res.status === 'success'));
+    }
+
     moveFolder(folderId: number, newParentFolderId: number, ordered_ids?: number[]): Observable<boolean> {
         const requestBody: any = {
                 'to_folder': newParentFolderId,


### PR DESCRIPTION
Fixes: #858

Also added: updates to local index so that the changes are seen faster.

Not working (how on does this work when we delete using the canvas pop up menu?) - removing items from the canvas, if we open the Trash folder, then hit the "empty trash" button on the folder