### PR TITLE
fix(app): Hide the overview button if no local index is available

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -72,7 +72,9 @@
         <span class="foldersidebarcount" style="margin-right: 24px"> {{ draftDeskService.draftModels.length }} </span>
       </mat-list-item>
 
-      <mat-list-item (click)="overview()" id="overviewButton" [ngClass]="{'selectedFolder' : overviewSelected}">
+      <mat-list-item (click)="overview()" id="overviewButton" [ngClass]="{'selectedFolder' : overviewSelected}"
+        *ngIf="dataReady"
+      >
         <mat-icon mat-list-icon svgIcon="blur" class="folderIconStandard"></mat-icon>
         <p mat-line class="folderName">Overview</p>
       </mat-list-item>


### PR DESCRIPTION
It doesn't work with no xapian index available, and it doesn't communicate that fact very well (at all).