### PR TITLE
WIP: fix(mailviewer): Update folderlist quicker when deleting messages

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -648,7 +648,15 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
   public deleteMessages() {
     const messageIds = this.canvastable.rows.selectedMessageIds();
 
-    this.searchService.deleteMessages(messageIds);
+    if (this.selectedFolder == this.messagelistservice.trashFolderName) {
+      // permanent delete
+      this.searchService.deleteMessages(messageIds);
+    } else {
+      // moved to trash
+      const tFolder = this.displayedFolders.find((folder) => folder.folderName == this.messagelistservice.trashFolderName);
+      this.searchService.moveMessagesToFolder(messageIds, tFolder.folderPath);
+    }
+    this.searchService.updateIndexWithNewChanges();
     this.searchService.rmmapi.deleteMessages(messageIds)
       .subscribe(() => {
         this.clearSelection();


### PR DESCRIPTION
Discovered while testing "emptyTrash" fix: When deleting messages from any other folder, messages are moved to trash on the backend - the frontend just deletes them from the searchindex. It would be saner if, when deleting from anything but the trash, we instead did a searchindex move (just like movetofolder).

This doesn't work yet as I need a way to get the trash folder id..