### PR TITLE
fix(compose): always ser a reply to when the "From" changes

### DIFF
--- a/src/app/compose/compose.component.ts
+++ b/src/app/compose/compose.component.ts
@@ -548,10 +548,7 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
 
         const from = this.draftDeskservice.froms.find(
             (f) => this.model.from === f.nameAndAddress);
-
-        if (from.reply_to !== null && from.reply_to.length > 0) {
-            this.model.reply_to = from.reply_to;
-        }
+        this.model.reply_to = from.reply_to;
         if (send) {
             if (this.model.useHTML) {
                 // Replace RBWUL with ContentId


### PR DESCRIPTION
Fixes a problem where the wrong reply to is sent to the server.

Situation 1 -- when it leaks the main identity email: in RMM7, if click "compose", then fill in the "To" field, then change the "From" field to my identity, it uses the last loaded reply_to

Situation 2 -- when it does NOT leak the main identity email: in RMM7, if click "compose", then change the "From" field to my identity, then fill in the "To" field, it uses the expected reply to