### PR TITLE
fix(tinymce): Make icons load again

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -33,7 +33,8 @@
               "src/styles.scss"
             ],
             "scripts": [
-              "node_modules/tinymce/tinymce.min.js"
+              "node_modules/tinymce/tinymce.min.js",
+              "node_modules/tinymce/icons/default/icons.min.js"
             ]
           },
           "configurations": {


### PR DESCRIPTION
The usual (and recommended) way of just including these icons in
/assets/ didn't do anything, presumably because they're JS now, so won't
unless they're treated as part of scripts? I don't have a better idea.

Perhaps using tinymce-angular would be less of a PITA.