### PR TITLE
Main Identity changes

### DIFF
--- a/src/app/profiles/profiles.component.html
+++ b/src/app/profiles/profiles.component.html
@@ -31,6 +31,15 @@
                         </button>
                     </div>
                 </app-profiles-lister>
+
+                <app-profiles-default *ngIf="rmm.profile && rmm.profile.profiles" (ev_reload)="ev_reload_emiter($event)">
+                    <div section-description>
+                        <h3 style="margin-bottom: 0;">
+                            Choose the address picked by default when composing a new email:
+                        </h3>
+                    </div>
+                </app-profiles-default>
+
                 <app-profiles-lister
                     *ngIf="rmm.profile && rmm.profile.profiles && rmm.profile.profiles.hasOwnProperty('aliases')"
                     [values]="rmm.profile.profiles.aliases"

--- a/src/app/profiles/profiles.component.html
+++ b/src/app/profiles/profiles.component.html
@@ -76,7 +76,8 @@
                     </div>
                     <div section-description>
                         <h3>
-                            Identities lets you send email from addresses that are not among your Main Identity or Aliases, and require verification via an email sent to the given From Address.
+                            Identities allow to send emails from addresses that are not among your username email or Aliases.<br>
+                            Added identities require verification via an email sent to the given address.
                         </h3>
                     </div>
                     <div section-buttons>

--- a/src/app/profiles/profiles.component.html
+++ b/src/app/profiles/profiles.component.html
@@ -50,11 +50,6 @@
                             Aliases
                         </h2>
                     </div>
-                    <div section-description>
-                        <h3>
-                            Your aliases
-                        </h3>
-                    </div>
                     <div section-buttons>
                         <button 
                             mat-raised-button 

--- a/src/app/profiles/profiles.component.html
+++ b/src/app/profiles/profiles.component.html
@@ -11,12 +11,12 @@
                 >
                     <div section-header>
                         <h2>
-                            Main Identity
+                            Default Identity
                         </h2>
                     </div>
                     <div section-description>
                         <h3>
-                            Your Main Identity is the address you signed up for Runbox with, and is your main profile.
+                            Address picked by default when composing a new email.
                         </h3>
                     </div>
                     <div section-buttons>
@@ -35,7 +35,7 @@
                 <app-profiles-default *ngIf="rmm.profile && rmm.profile.profiles" (ev_reload)="ev_reload_emiter($event)">
                     <div section-description>
                         <h3 style="margin-bottom: 0;">
-                            Choose the address picked by default when composing a new email:
+                            Select your Default Identity:
                         </h3>
                     </div>
                 </app-profiles-default>

--- a/src/app/profiles/profiles.component.html
+++ b/src/app/profiles/profiles.component.html
@@ -6,87 +6,68 @@
             <div>
                 <app-profiles-lister
                     *ngIf="rmm.profile && rmm.profile.profiles && rmm.profile.profiles.hasOwnProperty('main')"
-                    [values]="rmm.profile.profiles.main"
-                    (ev_reload)="ev_reload_emiter($event)"
-                >
+                    [values]="rmm.profile.profiles.main" (ev_reload)="ev_reload_emiter($event)">
                     <div section-header>
                         <h2>
                             Default Identity
                         </h2>
                     </div>
                     <div section-description>
-                        <h3>
+                        <p>
                             Address picked by default when composing a new email.
-                        </h3>
-                    </div>
-                    <div section-buttons>
-                        <button 
-                            *ngIf="!rmm.profile.profiles.main.length"
-                            mat-raised-button 
-                            color='primary'
-                            style="margin: 10px;"
-                            (click)='add_profile("main")'
-                        >
-                            Add Main Identity
-                        </button>
+                        </p>
                     </div>
                 </app-profiles-lister>
 
-                <app-profiles-default *ngIf="rmm.profile && rmm.profile.profiles" (ev_reload)="ev_reload_emiter($event)">
+                <app-profiles-default *ngIf="rmm.profile && rmm.profile.profiles"
+                    (ev_reload)="ev_reload_emiter($event)">
                     <div section-description>
-                        <h3 style="margin-bottom: 0;">
+                        <p style="margin-bottom: 0;">
                             Select your Default Identity:
-                        </h3>
+                        </p>
                     </div>
                 </app-profiles-default>
+                <br>
 
                 <app-profiles-lister
                     *ngIf="rmm.profile && rmm.profile.profiles && rmm.profile.profiles.hasOwnProperty('aliases')"
-                    [values]="rmm.profile.profiles.aliases"
-                    (ev_reload)="ev_reload_emiter($event)"
-                >
+                    [values]="rmm.profile.profiles.aliases" (ev_reload)="ev_reload_emiter($event)">
                     <div section-header>
                         <h2>
                             Aliases
                         </h2>
                     </div>
                     <div section-buttons>
-                        <button 
-                            mat-raised-button 
-                            color='primary'
-                            style="margin: 10px;"
-                            (click)='add_alias()'
-                        >
+                        <button mat-raised-button color='primary' style="margin: 10px;" (click)='add_alias()'>
                             Add Alias
                         </button>
                         <span *ngIf="rmm.alias && rmm.alias.aliases_counter">
-                            {{rmm.alias.aliases_counter.current}} of {{rmm.alias.aliases_counter.total}} available aliases created
+                            {{rmm.alias.aliases_counter.current}} of {{rmm.alias.aliases_counter.total}} available
+                            aliases created
                         </span>
                     </div>
                 </app-profiles-lister>
+                <br><br>
+
                 <app-profiles-lister
                     *ngIf="rmm.profile && rmm.profile.profiles && rmm.profile.profiles.hasOwnProperty('others')"
-                    [values]="rmm.profile.profiles.others"
-                    (ev_reload)="ev_reload_emiter($event)"
-                >
+                    [values]="rmm.profile.profiles.others" (ev_reload)="ev_reload_emiter($event)">
                     <div section-header>
                         <h2>
                             Other identities
                         </h2>
                     </div>
                     <div section-description>
-                        <h3>
-                            Identities allow to send emails from addresses that are not among your username email or Aliases.<br>
+                        <p>
+                            Identities allow to send emails from addresses that are not among your username email or
+                            Aliases.
+                        </p>
+                        <p>
                             Added identities require verification via an email sent to the given address.
-                        </h3>
+                        </p>
                     </div>
                     <div section-buttons>
-                        <button
-                            mat-raised-button
-                            color='primary'
-                            style="margin: 10px;"
-                            (click)='add_profile()'
-                        >
+                        <button mat-raised-button color='primary' style="margin: 10px;" (click)='add_profile()'>
                             Add identity
                         </button>
                         {{rmm.profile.profiles.others.length}} identities created

--- a/src/app/profiles/profiles.default.html
+++ b/src/app/profiles/profiles.default.html
@@ -8,6 +8,9 @@
                     {{profile.email}}
                 </mat-option>
             </mat-select>
+            <mat-error *ngIf="field_errors?.from_priorities">
+                {{field_errors.from_priorities[0]}}
+            </mat-error>
         </mat-form-field>
 
         <button type="submit" (click)="updateDefaultProfile()" mat-raised-button color="primary">

--- a/src/app/profiles/profiles.default.html
+++ b/src/app/profiles/profiles.default.html
@@ -1,0 +1,17 @@
+<div class="profiles-default">
+    <ng-content select="[section-description]"></ng-content>
+
+    <div class="profiles-select">
+        <mat-form-field id="default-identity-form">
+            <mat-select [(value)]="selected" [(ngModel)]="selected">
+                <mat-option class="identity-profile" *ngFor="let profile of profiles" [value]="profile">
+                    {{profile.email}}
+                </mat-option>
+            </mat-select>
+        </mat-form-field>
+
+        <button type="submit" (click)="updateDefaultProfile()" mat-raised-button color="primary">
+            Confirm
+        </button>
+    </div>
+</div>

--- a/src/app/profiles/profiles.default.scss
+++ b/src/app/profiles/profiles.default.scss
@@ -1,0 +1,31 @@
+.profiles-default {
+    margin-top: 25px;
+}
+
+.profiles-default mat-form-field {
+    overflow: hidden;
+}
+
+.profiles-select {
+    display: flex;
+    align-items: center;
+    margin-left: 5px;
+
+    @media only screen and (max-width: 700px) {
+        justify-content: space-between;
+    }
+}
+
+.identity-type {
+    text-transform: capitalize;
+}
+
+.identity-profile {
+    text-transform: lowercase;
+}
+
+#default-identity-form {
+    margin-right: 20px;
+    min-width: 200px;
+    width: auto;
+}

--- a/src/app/profiles/profiles.default.ts
+++ b/src/app/profiles/profiles.default.ts
@@ -47,18 +47,14 @@ export class DefaultProfileComponent {
         await this.fetchProfiles();
         const defaultProfiles = [];
         for (const profile of this.profiles) {
-            if (profile.priority === '0' || profile.priority === 0) {
+            if (profile.priority === 0) {
                 defaultProfiles.push(profile);
             }
         }
         if (defaultProfiles.length === 1) {
             this.selected = defaultProfiles[0];
         } else {
-            for (const profile of defaultProfiles) {
-                if (profile.type === 'main') {
-                    this.selected = profile;
-                }
-            }
+            this.selected = this.profiles.find(p => p.type === 'main');
         }
     }
 

--- a/src/app/profiles/profiles.default.ts
+++ b/src/app/profiles/profiles.default.ts
@@ -76,7 +76,7 @@ export class DefaultProfileComponent {
     }
 
     updateFromPriorities(values: { from_priorities: any[] }) {
-        const req = this.rmm.ua.http.put('/rest/v1/profile/from_priority/', values).pipe(retry(3), timeout(60000), share());
+        const req = this.rmm.ua.http.put('/rest/v1/profile/from_priority/', values).pipe(retry(3), timeout(10000), share());
         req.subscribe(
             (reply) => {
                 if (reply['status'] === 'success') {

--- a/src/app/profiles/profiles.default.ts
+++ b/src/app/profiles/profiles.default.ts
@@ -23,6 +23,17 @@ import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
 import { timeout, share, retry } from 'rxjs/operators';
 import { MatSnackBar } from '@angular/material/snack-bar';
 
+export interface Profile {
+    email: string;
+    id: number;
+    name: string;
+    nameAndAddress: string;
+    priority: number;
+    reply_to: string;
+    signature: string;
+    type: string;
+}
+
 @Component({
     selector: 'app-profiles-default',
     styleUrls: ['profiles.default.scss'],
@@ -30,7 +41,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 })
 export class DefaultProfileComponent {
     field_errors: any;
-    profiles: any[] = new Array();
+    profiles: Profile[];
     selected: any;
 
     constructor(public rmm: RMM, public rmmapi: RunboxWebmailAPI, private snackBar: MatSnackBar) {

--- a/src/app/profiles/profiles.default.ts
+++ b/src/app/profiles/profiles.default.ts
@@ -29,6 +29,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
     templateUrl: 'profiles.default.html',
 })
 export class DefaultProfileComponent {
+    field_errors: any;
     profiles: any[] = new Array();
     selected: any;
 
@@ -64,10 +65,12 @@ export class DefaultProfileComponent {
     updateDefaultProfile() {
         const priorities: any[] = new Array();
         const priority_data = { from_priorities: priorities };
+        const type_data = { type: 'main' };
         for (const profile of this.profiles) {
             if (profile === this.selected) {
                 const values = { id: profile.id, from_priority: 0 };
                 priorities.push(values);
+                this.updateType(profile.id, type_data, this.field_errors);
             } else {
                 const values = { id: profile.id, from_priority: 1 };
                 priorities.push(values);
@@ -85,6 +88,20 @@ export class DefaultProfileComponent {
                     this.showNotification('Default Identity updated');
                 } else if (reply['status'] === 'error') {
                     this.showNotification('Could not update Default Identity');
+                    return;
+                }
+            }
+        );
+    }
+
+    updateType(id: number, values: { type: string }, field_errors: any) {
+        const req = this.rmm.profile.update(id, values, field_errors);
+        req.subscribe(
+            (reply) => {
+                if (reply['status'] === 'success') {
+                    this.rmm.profile.load();
+                } else if (reply['status'] === 'error') {
+                    this.showNotification('Could not update Identity Type');
                     return;
                 }
             }

--- a/src/app/profiles/profiles.lister.html
+++ b/src/app/profiles/profiles.lister.html
@@ -1,5 +1,5 @@
 <div class="profile-lister">
-    <ng-content select="[section-header]" style="margin-top: 20px;"></ng-content>
+    <ng-content select="[section-header]"></ng-content>
     <ng-content select="[section-description]"></ng-content>
     <ng-content select="[section-buttons]"></ng-content>
     <mat-card class="mat-elevation-z2 profile-card" *ngFor="let item of values; let i = index;">

--- a/src/app/profiles/profiles.lister.scss
+++ b/src/app/profiles/profiles.lister.scss
@@ -20,9 +20,6 @@
 .mat_header {
     align-items: center;
 }
-.profile-lister {
-    margin-top: 35px;
-}
 .profile-card {
     display: inline-flex;
     width: calc(100% - 10px);

--- a/src/app/profiles/profiles.module.ts
+++ b/src/app/profiles/profiles.module.ts
@@ -40,6 +40,7 @@ import { ProfilesListerComponent } from './profiles.lister';
 import { AliasesListerComponent } from '../aliases/aliases.lister';
 import { ProfilesEditorModalComponent } from './profiles.editor.modal';
 import { AliasesEditorModalComponent } from '../aliases/aliases.editor.modal';
+import { DefaultProfileComponent } from './profiles.default';
 
 @NgModule({
     declarations: [
@@ -48,6 +49,7 @@ import { AliasesEditorModalComponent } from '../aliases/aliases.editor.modal';
       ProfilesListerComponent,
       ProfilesEditorModalComponent,
       AliasesEditorModalComponent,
+      DefaultProfileComponent,
     ],
     imports: [
     CommonModule,

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -127,10 +127,6 @@ ul.square-list li {
     font-size: 16px  !important;
 }
 
-.mat-select-value {
-    display: inline !important;
-}
-
 mat-icon {
     margin-bottom: 3px;
     vertical-align: middle !important;


### PR DESCRIPTION
Backend changes it needs: 
- ability to edit profile's "type" from stage001
- "from_priorities" changes from stage002

Adds a way to choose identity for compose. The user can choose from all the identities and aliases.

- [x] Allow user to pick which identity they want as their default/main
- [x] Reposition identity tiles accordingly (Default Identity shows on the top)
- [x] Update description for all the identity sections

Screenshots:
<kbd><img src="https://i.imgur.com/2FVBsqq.png"></kbd>