### PR TITLE
Settings hub with menu based on existing Runbox7 items

### DIFF
--- a/src/app/account-app/account-app.component.html
+++ b/src/app/account-app/account-app.component.html
@@ -1,3 +1,15 @@
+<style>
+    #shoppingCartButton {
+        position: fixed;
+        top: 75px;
+        right: 50px;
+        z-index: 10;
+    }
+    mat-expansion-panel-header mat-icon {
+        padding-right: 8px;
+    }
+</style>
+
 <mat-sidenav-container autosize>
     <mat-sidenav #sidemenu
         [opened]="sideMenuOpened"
@@ -10,36 +22,144 @@
         <mat-nav-list dense>
             <app-sidenav-menu (closeMenu)="sideMenu.close()"></app-sidenav-menu>
 
-            <mat-list-item routerLink="/account/identities">
-                <mat-icon mat-list-icon svgIcon="border-inside"></mat-icon>
-                <p mat-line>Your Identities</p>
-            </mat-list-item>
-            <mat-list-item routerLink="/account/security">
-                <mat-icon mat-list-icon svgIcon="security"></mat-icon>
-                <p mat-line>Account Security</p>
-            </mat-list-item>
-            <mat-list-item routerLink="/account/upgrades">
-                <mat-icon mat-list-icon svgIcon="hot-tub"></mat-icon>
-                <p mat-line> Subscriptions </p>
-            </mat-list-item>
-            <mat-list-item routerLink="/account/addons">
-                <mat-icon mat-list-icon svgIcon="puzzle"></mat-icon>
-                <p mat-line> Add-ons </p>
-            </mat-list-item>
-            <mat-list-item routerLink="/account/renewals">
-                <mat-icon mat-list-icon svgIcon="autorenew"></mat-icon>
-                <p mat-line> Active products </p>
-            </mat-list-item>
-            <mat-list-item routerLink="/account/transactions">
-                <mat-icon mat-list-icon svgIcon="poll-box"></mat-icon>
-                <p mat-line> Transactions </p>
-            </mat-list-item>
-            <mat-list-item routerLink="/account/credit_cards">
-                <mat-icon mat-list-icon svgIcon="credit-card"></mat-icon>
-                <p mat-line> Credit cards </p>
-            </mat-list-item>
+            <mat-accordion>
+                <!-- MAIL -->
+                <mat-expansion-panel>
+                    <mat-expansion-panel-header>
+                        <p mat-line>
+                            <mat-icon mat-list-icon svgIcon="email"></mat-icon> Mail
+                        </p>
+                    </mat-expansion-panel-header>
+                    <mat-list-item routerLink="/account/identities">
+                        <p mat-line>
+                            <mat-icon mat-list-icon svgIcon="border-inside"></mat-icon> Identities
+                        </p>
+                    </mat-list-item>
+                </mat-expansion-panel>
+
+                <!-- MANAGER -->
+                <mat-expansion-panel>
+                    <mat-expansion-panel-header>
+                        <p mat-line>
+                            <mat-icon mat-list-icon svgIcon="briefcase"></mat-icon> Manager
+                        </p>
+                    </mat-expansion-panel-header>
+                    <a href="/mail/fetch" target="rmm6">
+                        <mat-list-item [matTooltip]="rmm6tooltip">
+                            <p mat-line>
+                                <mat-icon mat-list-icon svgIcon="cloud-download"></mat-icon> Retrieve
+                            </p>
+                        </mat-list-item>
+                    </a>
+                    <a href="/mail/rules" target="rmm6">
+                        <mat-list-item [matTooltip]="rmm6tooltip">
+                            <p mat-line>
+                                <mat-icon mat-list-icon svgIcon="filter-variant"></mat-icon> Filter
+                            </p>
+                        </mat-list-item>
+                    </a>
+                    <a href="/mail/access" target="rmm6">
+                        <mat-list-item [matTooltip]="rmm6tooltip">
+                            <p mat-line>
+                                <mat-icon mat-list-icon svgIcon="download"></mat-icon> Access
+                            </p>
+                        </mat-list-item>
+                    </a>
+                </mat-expansion-panel>
+
+                <!-- HOSTING -->
+                <mat-expansion-panel>
+                    <mat-expansion-panel-header>
+                        <p mat-line>
+                            <mat-icon mat-list-icon svgIcon="cloud"></mat-icon> Hosting
+                        </p>
+                    </mat-expansion-panel-header>
+                    <a href="/mail/account_domain" target="rmm6">
+                        <mat-list-item [matTooltip]="rmm6tooltip">
+                            <p mat-line>
+                                <mat-icon mat-list-icon svgIcon="email"></mat-icon> Email Hosting
+                            </p>
+                        </mat-list-item>
+                    </a>
+                    <a href="/mail/account_domain_hosting" target="rmm6">
+                        <mat-list-item [matTooltip]="rmm6tooltip">
+                            <p mat-line>
+                                <mat-icon mat-list-icon svgIcon="domain"></mat-icon> Domain Hosting
+                            </p>
+                        </mat-list-item>
+                    </a>
+                    <a href="/mail/account_webhosting" target="rmm6">
+                        <mat-list-item [matTooltip]="rmm6tooltip">
+                            <p mat-line>
+                                <mat-icon mat-list-icon svgIcon="earth"></mat-icon> Web Hosting
+                            </p>
+                        </mat-list-item>
+                    </a>
+                    <!-- <mat-list-item routerLink="/account/domainregistration">
+                        <p mat-line>
+                            <mat-icon mat-list-icon svgIcon="border-inside"></mat-icon> Domain Registration
+                        </p>
+                    </mat-list-item> -->
+                </mat-expansion-panel>
+
+                <!-- ACCOUNT -->
+                <mat-expansion-panel>
+                    <mat-expansion-panel-header>
+                        <p mat-line>
+                            <mat-icon mat-list-icon svgIcon="account"></mat-icon> Account & Security
+                        </p>
+                    </mat-expansion-panel-header>
+                    <a href="/mail/account" target="rmm6">
+                        <mat-list-item [matTooltip]="rmm6tooltip">
+                            <p mat-line>
+                                <mat-icon mat-list-icon svgIcon="details"></mat-icon> Account Details
+                            </p>
+                        </mat-list-item>
+                    </a>
+                    <mat-list-item routerLink="/account/security">
+                        <p mat-line>
+                            <mat-icon mat-list-icon svgIcon="security"></mat-icon> Account Security
+                        </p>
+                    </mat-list-item>
+                </mat-expansion-panel>
+
+                <!-- SUBSCRIPTIONS -->
+                <mat-expansion-panel>
+                    <mat-expansion-panel-header>
+                        <p mat-line>
+                            <mat-icon mat-list-icon svgIcon="hot-tub"></mat-icon> Subscriptions
+                        </p>
+                    </mat-expansion-panel-header>
+                    <mat-list-item routerLink="/account/upgrades">
+                        <p mat-line>
+                            <mat-icon mat-list-icon svgIcon="hot-tub"></mat-icon> Main Account Plans
+                        </p>
+                    </mat-list-item>
+                    <mat-list-item routerLink="/account/addons">
+                        <p mat-line>
+                            <mat-icon mat-list-icon svgIcon="puzzle"></mat-icon> Add-ons & Sub-Accounts
+                        </p>
+                    </mat-list-item>
+                    <mat-list-item routerLink="/account/renewals">
+                        <p mat-line>
+                            <mat-icon mat-list-icon svgIcon="autorenew"></mat-icon> Active products & Renewals
+                        </p>
+                    </mat-list-item>
+                    <mat-list-item routerLink="/account/transactions">
+                        <p mat-line>
+                            <mat-icon mat-list-icon svgIcon="poll-box"></mat-icon> Transactions
+                        </p>
+                    </mat-list-item>
+                    <mat-list-item routerLink="/account/credit_cards">
+                        <p mat-line>
+                            <mat-icon mat-list-icon svgIcon="credit-card"></mat-icon> Card Details
+                        </p>
+                    </mat-list-item>
+                </mat-expansion-panel>
+            </mat-accordion>
         </mat-nav-list>
     </mat-sidenav>
+
     <mat-sidenav-content>
         <mat-toolbar *ngIf="mobileQuery.matches" style="display: flex; justify-content: space-between;">
             <button mat-icon-button (click)="sidemenu.toggle()">
@@ -55,15 +175,6 @@
                 </button>
             </ng-container>
         </mat-toolbar>
-
-        <style>
-        #shoppingCartButton {
-            position: fixed;
-            top: 75px;
-            right: 50px;
-            z-index: 10;
-        }
-        </style>
 
         <div *ngIf="!mobileQuery.matches && cart.items | async as items">
             <button mat-fab id="shoppingCartButton"

--- a/src/app/account-app/account-app.component.ts
+++ b/src/app/account-app/account-app.component.ts
@@ -32,6 +32,7 @@ import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
 export class AccountAppComponent {
     @ViewChild(MatSidenav) sideMenu: MatSidenav;
     sideMenuOpened = true;
+    rmm6tooltip = 'This area isn\'t upgraded to Runbox 7 yet and will open in a new tab';
 
     constructor(
         public cart:   CartService,

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -780,18 +780,12 @@ a.mainMenu, mat-menu a, .mat-nav-list a {
     }
 }
 
-mat-expansion-panel-header {
-    min-height: 50px !important;
-    height: auto !important;
-    padding: 0 10px !important;
-}
-
 mat-expansion-panel {
     box-shadow: none !important;
 }
 
 .mat-expansion-panel-body {
-    padding: 0 10px 30px 10px !important;
+    padding: 0 !important;
 }
 
 /* Compose */


### PR DESCRIPTION
Current view of the menu:

* Mail
  * Identities
* Manager
  * Retrieve
  * Filter
  * Access
* Hosting
  * Email Hosting
  * Domain Hosting
  * Web Hosting
  * Domain Registration
* Account & Security
  * Account Details
  * Account Security
* Subscriptions
  * Main Account Plans
  * Add-ons & Sub-Accounts
  * Active products & Renewals
  * Transactions
  * Card Details

Next step: Account Security would be it's own header called Security and would be moved to the bottom:
* Security
  * Two-Factor Authentication
  * Manage Services
  * App passwords
  * Last logins
  * Sessions

<kbd><img src="https://i.imgur.com/o3wTcSU.png"></kbd>
