### PR TITLE
feat(account): Split renewals page into active and expired products

### DIFF
--- a/src/app/account-app/account-renewals.component.html
+++ b/src/app/account-app/account-renewals.component.html
@@ -6,149 +6,145 @@
         </app-runbox-loading>
     </div>
 
-    <ng-template #productsTable>
-
-        <p>
-            Here you can see all the active products in your account, and renew any of them at any time.
-        </p>
-
-        <table mat-table [dataSource]="active_products" [ngStyle]="{ width: '100%' }" multiTemplateDataRows>
-            <ng-container matColumnDef="name">
-                <th mat-header-cell *matHeaderCellDef> Name </th>
-                <td mat-cell *matCellDef="let p">
-                    {{ p.name }}
-                    <strong *ngIf="p.pid === current_subscription"> – your current subscription </strong>
-                </td>
-            </ng-container>
-            <ng-container matColumnDef="quantity">
-                <th mat-header-cell *matHeaderCellDef> Quantity </th>
-                <td mat-cell *matCellDef="let p">
-                    {{ p.quantity }}
-                    <span *ngIf="p.subtype === 'subaccount'">
-                        ({{ p.subaccounts.length }} in use)
-                        <button mat-icon-button *ngIf="p.subaccounts.length > 0" (click)="showSubsDialog(p)">
-                            <mat-icon svgIcon="information-outline"
-                                [matTooltip]="'Associated accounts: ' + p.subaccounts.join(', ')"></mat-icon>
-                        </button>
-                    </span>
-                </td>
-            </ng-container>
-            <ng-container matColumnDef="active_from">
-                <th mat-header-cell *matHeaderCellDef> Active from </th>
-                <td mat-cell *matCellDef="let p">
-                    {{ p.active_from.format('YYYY-MM-DD') }}
-                </td>
-            </ng-container>
-            <ng-container matColumnDef="active_until">
-                <th mat-header-cell *matHeaderCellDef> Active until </th>
-                <td mat-cell *matCellDef="let p">
-                    {{ p.active_until.format('YYYY-MM-DD') }}
-                </td>
-            </ng-container>
-            <ng-container matColumnDef="hints">
-                <th mat-header-cell *matHeaderCellDef> </th>
-                <td mat-cell *matCellDef="let p">
-                    <strong *ngIf="p.expired">
-                        (expired {{ p.active_until.fromNow() }})
-                    </strong>
-                    <mat-error *ngIf="p.expires_soon" style="font-weight: bold;">
-                        (expires {{ p.active_until.fromNow() }})
-                    </mat-error>
-                </td>
-            </ng-container>
-            <ng-container matColumnDef="smallhints">
-                <th mat-header-cell *matHeaderCellDef> </th>
-                <td mat-cell *matCellDef="let p">
-                    <mat-icon *ngIf="p.expired" svgIcon="cancel"></mat-icon>
-                    <mat-icon *ngIf="p.expires_soon" svgIcon="alert"></mat-icon>
-                </td>
-            </ng-container>
-            <ng-container matColumnDef="recur">
-                <th mat-header-cell *matHeaderCellDef> Auto renewal </th>
-                <td mat-cell *matCellDef="let p">
-                    <app-account-renewals-autorenew-toggle-component [p]="p" (toggle)="toggleAutorenew(p)">
-                    </app-account-renewals-autorenew-toggle-component>
-                </td>
-            </ng-container>
-            <ng-container matColumnDef="renew">
-                <th mat-header-cell *matHeaderCellDef> Renew now </th>
-                <td mat-cell *matCellDef="let p">
-                    <app-account-renewals-renew-now-button-component [p]="p" (clicked)="renew(p)">
-                    </app-account-renewals-renew-now-button-component>
-                </td>
-            </ng-container>
-            <ng-container matColumnDef="expansionIndicator">
-                <th mat-header-cell *matHeaderCellDef> </th>
-                <td mat-cell *matCellDef="let p">
-                    <mat-icon *ngIf="p == expandedProduct; else notExpanded" svgIcon="chevron-down"></mat-icon>
-                    <ng-template #notExpanded>
-                        <mat-icon svgIcon="chevron-right"></mat-icon>
-                    </ng-template>
-                </td>
-            </ng-container>
-            <ng-container matColumnDef="expandedDetails">
-                <td mat-cell *matCellDef="let p" [attr.colspan]="displayedColumns.length">
-                    <div class="expandedDetails" [@detailExpand]="p == expandedProduct ? 'expanded' : 'collapsed'">
-                        <!-- yo dawg, I heard you like tables -->
-                        <table class="detailsTable">
-                            <tr>
-                                <td> Quantity </td>
-                                <td> {{ p.quantity }} </td>
-                            </tr>
-                            <tr *ngIf="p.subtype === 'subaccount'">
-                                <td> In use </td>
-                                <td style="display: flex; align-items: baseline;">
-                                    {{ p.subaccounts.length }}
-                                    <button mat-icon-button *ngIf="p.subaccounts.length > 0"
-                                        (click)="showSubsDialog(p)">
-                                        <mat-icon svgIcon="information-outline"></mat-icon>
-                                    </button>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td> Active from </td>
-                                <td> {{ p.active_from.format('YYYY-MM-DD') }} </td>
-                            </tr>
-                            <tr>
-                                <td> Active until </td>
-                                <td> {{ p.active_until.format('YYYY-MM-DD') }} </td>
-                            </tr>
-                            <tr>
-                                <td> </td>
-                                <td>
-                                    <strong *ngIf="p.expired">
-                                        (expired {{ p.active_until.fromNow() }})
-                                    </strong>
-                                    <mat-error *ngIf="p.expires_soon" style="font-weight: bold;">
-                                        (expires {{ p.active_until.fromNow() }})
-                                    </mat-error>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td> Auto renewal </td>
-                                <td>
-                                    <app-account-renewals-autorenew-toggle-component [p]="p"
-                                        (toggle)="toggleAutorenew(p)">
-                                    </app-account-renewals-autorenew-toggle-component>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td> Renew now </td>
-                                <td>
-                                    <app-account-renewals-renew-now-button-component [p]="p" (clicked)="renew(p)">
-                                    </app-account-renewals-renew-now-button-component>
-                                </td>
-                            </tr>
-                        </table>
-                    </div>
-                </td>
-            </ng-container>
-            <tr mat-header-row *matHeaderRowDef="displayedColumns"
-                [ngStyle]="{ 'display': mobileQuery.matches ? 'none' : null }">
-            <tr mat-row *matRowDef="let row; columns: displayedColumns" class="regularRow" (click)="rowClicked(row)">
-            </tr>
-            <tr mat-row *matRowDef="let row; columns: ['expandedDetails']" class="detailsRow"></tr>
-        </table>
-
-    </ng-template>
+    <mat-tab-group #productsTable mat-align-tabs="center">
+        <mat-tab *ngFor="let section of sections" [label]="section.label" >
+            <table mat-table [dataSource]="section.products" [ngStyle]="{ width: '100%' }" multiTemplateDataRows>
+                <ng-container matColumnDef="name">
+                    <th mat-header-cell *matHeaderCellDef> Name </th>
+                    <td mat-cell *matCellDef="let p">
+                        {{ p.name }}
+                        <strong *ngIf="p.pid === current_subscription"> – your current subscription </strong>
+                    </td>
+                </ng-container>
+                <ng-container matColumnDef="quantity">
+                    <th mat-header-cell *matHeaderCellDef> Quantity </th>
+                    <td mat-cell *matCellDef="let p">
+                        {{ p.quantity }}
+                        <span *ngIf="p.subtype === 'subaccount'">
+                            ({{ p.subaccounts.length }} in use)
+                            <button mat-icon-button *ngIf="p.subaccounts.length > 0" (click)="showSubsDialog(p)">
+                                <mat-icon svgIcon="information-outline"
+                                    [matTooltip]="'Associated accounts: ' + p.subaccounts.join(', ')"></mat-icon>
+                            </button>
+                        </span>
+                    </td>
+                </ng-container>
+                <ng-container matColumnDef="active_from">
+                    <th mat-header-cell *matHeaderCellDef> Active from </th>
+                    <td mat-cell *matCellDef="let p">
+                        {{ p.active_from.format('YYYY-MM-DD') }}
+                    </td>
+                </ng-container>
+                <ng-container matColumnDef="active_until">
+                    <th mat-header-cell *matHeaderCellDef> Active until </th>
+                    <td mat-cell *matCellDef="let p">
+                        {{ p.active_until.format('YYYY-MM-DD') }}
+                    </td>
+                </ng-container>
+                <ng-container matColumnDef="hints">
+                    <th mat-header-cell *matHeaderCellDef> </th>
+                    <td mat-cell *matCellDef="let p">
+                        <strong *ngIf="p.expired">
+                            (expired {{ p.active_until.fromNow() }})
+                        </strong>
+                        <mat-error *ngIf="p.expires_soon" style="font-weight: bold;">
+                            (expires {{ p.active_until.fromNow() }})
+                        </mat-error>
+                    </td>
+                </ng-container>
+                <ng-container matColumnDef="smallhints">
+                    <th mat-header-cell *matHeaderCellDef> </th>
+                    <td mat-cell *matCellDef="let p">
+                        <mat-icon *ngIf="p.expired" svgIcon="cancel"></mat-icon>
+                        <mat-icon *ngIf="p.expires_soon" svgIcon="alert"></mat-icon>
+                    </td>
+                </ng-container>
+                <ng-container matColumnDef="recur">
+                    <th mat-header-cell *matHeaderCellDef> Auto renewal </th>
+                    <td mat-cell *matCellDef="let p">
+                        <app-account-renewals-autorenew-toggle-component [p]="p" (toggle)="toggleAutorenew(p)">
+                        </app-account-renewals-autorenew-toggle-component>
+                    </td>
+                </ng-container>
+                <ng-container matColumnDef="renew">
+                    <th mat-header-cell *matHeaderCellDef> Renew now </th>
+                    <td mat-cell *matCellDef="let p">
+                        <app-account-renewals-renew-now-button-component [p]="p" (clicked)="renew(p)">
+                        </app-account-renewals-renew-now-button-component>
+                    </td>
+                </ng-container>
+                <ng-container matColumnDef="expansionIndicator">
+                    <th mat-header-cell *matHeaderCellDef> </th>
+                    <td mat-cell *matCellDef="let p">
+                        <mat-icon *ngIf="p == expandedProduct; else notExpanded" svgIcon="chevron-down"></mat-icon>
+                        <ng-template #notExpanded>
+                            <mat-icon svgIcon="chevron-right"></mat-icon>
+                        </ng-template>
+                    </td>
+                </ng-container>
+                <ng-container matColumnDef="expandedDetails">
+                    <td mat-cell *matCellDef="let p" [attr.colspan]="displayedColumns.length">
+                        <div class="expandedDetails" [@detailExpand]="p == expandedProduct ? 'expanded' : 'collapsed'">
+                            <!-- yo dawg, I heard you like tables -->
+                            <table class="detailsTable">
+                                <tr>
+                                    <td> Quantity </td>
+                                    <td> {{ p.quantity }} </td>
+                                </tr>
+                                <tr *ngIf="p.subtype === 'subaccount'">
+                                    <td> In use </td>
+                                    <td style="display: flex; align-items: baseline;">
+                                        {{ p.subaccounts.length }}
+                                        <button mat-icon-button *ngIf="p.subaccounts.length > 0"
+                                            (click)="showSubsDialog(p)">
+                                            <mat-icon svgIcon="information-outline"></mat-icon>
+                                        </button>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td> Active from </td>
+                                    <td> {{ p.active_from.format('YYYY-MM-DD') }} </td>
+                                </tr>
+                                <tr>
+                                    <td> Active until </td>
+                                    <td> {{ p.active_until.format('YYYY-MM-DD') }} </td>
+                                </tr>
+                                <tr>
+                                    <td> </td>
+                                    <td>
+                                        <strong *ngIf="p.expired">
+                                            (expired {{ p.active_until.fromNow() }})
+                                        </strong>
+                                        <mat-error *ngIf="p.expires_soon" style="font-weight: bold;">
+                                            (expires {{ p.active_until.fromNow() }})
+                                        </mat-error>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td> Auto renewal </td>
+                                    <td>
+                                        <app-account-renewals-autorenew-toggle-component [p]="p"
+                                            (toggle)="toggleAutorenew(p)">
+                                        </app-account-renewals-autorenew-toggle-component>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td> Renew now </td>
+                                    <td>
+                                        <app-account-renewals-renew-now-button-component [p]="p" (clicked)="renew(p)">
+                                        </app-account-renewals-renew-now-button-component>
+                                    </td>
+                                </tr>
+                            </table>
+                        </div>
+                    </td>
+                </ng-container>
+                <tr mat-header-row *matHeaderRowDef="displayedColumns"
+                    [ngStyle]="{ 'display': mobileQuery.matches ? 'none' : null }">
+                <tr mat-row *matRowDef="let row; columns: displayedColumns" class="regularRow" (click)="rowClicked(row)">
+                </tr>
+                <tr mat-row *matRowDef="let row; columns: ['expandedDetails']" class="detailsRow"></tr>
+            </table>
+        </mat-tab>
+    </mat-tab-group>
 </section>


### PR DESCRIPTION
This should make it easier to tell the ones the user cares about from the ones that are long gone, especially in older accounts.

Looks like this:

![active](https://user-images.githubusercontent.com/86378/110934093-e09bb580-832d-11eb-927d-0a1484a04fcc.png)

![expired](https://user-images.githubusercontent.com/86378/110934105-e2fe0f80-832d-11eb-9566-d08f4d0a231c.png)

The order of importance is: the soonest-expiring first on the Active tab, latest-expired first on the Expired tab.

I do have a problem with the naming though. The Active/Expired naming makes sense to me, but we call the entire page Active products, which now makes it awkward. This was a problem with variable naming in the source as well, which I noted down in the comment. @davidbowdley suggested renaming the entire page to Products – on the other hand, the whole Account section is called "Account products", referring to both available and, ugh, active-and-expired ones. Ideas?