### PR TITLE
feat(rmm): add pubsub pattern to rmm.profiles

### DIFF
--- a/src/app/rmm/profile.ts
+++ b/src/app/rmm/profile.ts
@@ -20,6 +20,7 @@ import { timeout, share } from 'rxjs/operators';
 import { Observable } from 'rxjs';
 import { RMM } from '../rmm';
 import { FromAddress } from '../rmmapi/from_address';
+import { PubSub } from './pubsub';
 
 export class Profile {
     public profiles: any;
@@ -27,9 +28,11 @@ export class Profile {
     is_busy: boolean;
     compose_froms: any;
     public from_addresses: FromAddress[] = [];
+    public pubsub;
     constructor(
         public app: RMM,
     ) {
+        this.pubsub = new PubSub();
     }
     load(): Observable<any> {
         this.is_busy = true;
@@ -80,6 +83,7 @@ export class Profile {
                     this.from_addresses.push(profile);
                 });
             });
+            this.pubsub.publish('profiles_verified.updated', [ this.profiles_verified ]);
           },
           error => {
             this.is_busy = false;

--- a/src/app/rmm/pubsub.ts
+++ b/src/app/rmm/pubsub.ts
@@ -29,14 +29,14 @@ export class PubSub {
   subscribe(subject, callback) {
     this.subject[subject] = this.subject[subject] || [];
     this.subject[subject].push(callback);
-    var subscription = [subject, callback];
+    const subscription = [subject, callback];
     return subscription;
   }
   unsubscribe(subscription) {
-    var subject = subscription[0];
-    var callback = subscription[1];
+    const subject = subscription[0];
+    const callback = subscription[1];
     this.subject[subject].forEach( (v, i) => {
-        if ( v == callback ) { this.subject[subject].splice(i, 1) }
-    } )
+        if ( v === callback ) { this.subject[subject].splice(i, 1); }
+    } );
   }
 }

--- a/src/app/rmm/pubsub.ts
+++ b/src/app/rmm/pubsub.ts
@@ -1,0 +1,42 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2018 Runbox Solutions AS (runbox.com).
+// 
+// This file is part of Runbox 7.
+// 
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+// 
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+import { Observable } from 'rxjs';
+
+export class PubSub {
+  public subject = {};
+  publish(subject, args) {
+    args = args || [];
+    this.subject[subject].forEach( ( callback ) => {
+        callback.apply( args );
+    } );
+  }
+  subscribe(subject, callback) {
+    this.subject[subject] = this.subject[subject] || [];
+    this.subject[subject].push(callback);
+    var subscription = [subject, callback];
+    return subscription;
+  }
+  unsubscribe(subscription) {
+    var subject = subscription[0];
+    var callback = subscription[1];
+    this.subject[subject].forEach( (v, i) => {
+        if ( v == callback ) { this.subject[subject].splice(i, 1) }
+    } )
+  }
+}


### PR DESCRIPTION
can be used by the draftdesk to get signaled when identitys are loaded/reloaded. subscribe from inside the draftdesk. ie:

var subscription1 = profile.pubsub.subscribe('profiles_verified.updated', function ( profiles_verified ) {
  console.log( 'profiles_verified has changed, do something' );
});