### PR TITLE
Identities fixes

### DIFF
--- a/src/app/profiles/profiles.component.html
+++ b/src/app/profiles/profiles.component.html
@@ -29,6 +29,7 @@
                 <p>Aliases are extra email addresses that deliver to your email account, just as your main email address
                     does. An alias can't be used to log in or have any storage of its own, and does not work independently from
                     your account.</p>
+                <p style="color: crimson" *ngIf="rmm.alias?.aliases_counter.current === 100">You have reached the maximum allowed number of Runbox aliases.</p>
                 <p>To manage your aliases visit <a target="rmm6" href="https://runbox.com/mail/account_alias">Alias Administration</a>.</p>
             </div>
             <div section-buttons>

--- a/src/app/profiles/profiles.component.html
+++ b/src/app/profiles/profiles.component.html
@@ -35,8 +35,6 @@
                 <button mat-raised-button color='primary' style="margin: 10px;" (click)='add_alias()'>
                     Add Alias
                 </button>
-                <span *ngIf="rmm.alias && rmm.alias.aliases_counter">{{rmm.alias.aliases_counter.current}} of
-                    {{rmm.alias.aliases_counter.total}} available aliases created</span>
             </div>
         </app-profiles-lister>
         <br><br>

--- a/src/app/profiles/profiles.component.html
+++ b/src/app/profiles/profiles.component.html
@@ -29,6 +29,7 @@
                 <p>Aliases are extra email addresses that deliver to your email account, just as your main email address
                     does. An alias can't be used to log in or have any storage of its own, and does not work independently from
                     your account.</p>
+                <p>To manage your aliases visit <a target="rmm6" href="https://runbox.com/mail/account_alias">Alias Administration</a>.</p>
             </div>
             <div section-buttons>
                 <button mat-raised-button color='primary' style="margin: 10px;" (click)='add_alias()'>

--- a/src/app/profiles/profiles.editor.modal.html
+++ b/src/app/profiles/profiles.editor.modal.html
@@ -114,7 +114,7 @@
 
     <mat-card-actions class="action-buttons">
         <span class="delete-button">
-            <button mat-raised-button (click)="delete()" color="warn">DELETE</button>
+            <button *ngIf="this.data.profile.type === 'external_email'" mat-raised-button (click)="delete()" color="warn">DELETE</button>
         </span>
         <span>
             <button mat-raised-button (click)="close()" color="accent">CANCEL</button>

--- a/src/app/profiles/profiles.editor.modal.html
+++ b/src/app/profiles/profiles.editor.modal.html
@@ -10,7 +10,7 @@
         </mat-card-subtitle>
     </mat-card-header>
 
-    <mat-card-content class="content">
+    <mat-card-content class="content" style="margin-bottom: 0;">
         <form>
             <mat-form-field class="form-field form-item">
                 <input matInput placeholder="From" name="from" [(ngModel)]="data.profile.from_name"
@@ -111,6 +111,8 @@
         <a href="javascript:void(0)" (click)="resend_validate_email(data.profile.id)">
             re-send</a>.
     </div>
+
+    <p class="mat-small" style="text-align: center; margin-top: 0;" *ngIf="this.data.profile.type === 'aliases'">To manage aliases visit <a target="rmm6" href="https://runbox.com/mail/account_alias">Alias Administration</a>.</p>
 
     <mat-card-actions class="action-buttons">
         <span class="delete-button">


### PR DESCRIPTION
* Add links to alias management (https://runbox.com/mail/account_alias)
-- On Identities page - [Screenshot](https://i.imgur.com/u0OzFz7.png)
-- In the edit dialog (only if editing an alias) - [Screenshot](https://i.imgur.com/AHnlVBL.png)
* Remove Delete button from aliases and current default identity (the one visible on the top)
* Remove alias count info
* Add warning for the user if they reached maximum number of allowed aliases - [Screenshot](https://i.imgur.com/U31jaLw.png)