### PR TITLE
fix(menu): Fix Settings URL

### DIFF
--- a/src/app/menu/headertoolbar.component.html
+++ b/src/app/menu/headertoolbar.component.html
@@ -27,7 +27,7 @@
   </div>
 
   <div class="mainMenu">
-    <a mat-button routerLink="/account/settings">
+    <a mat-button routerLink="/account">
       <mat-icon svgIcon="cog"></mat-icon>
       <p class="mainMenuDesc">Settings</p>
     </a>


### PR DESCRIPTION
Settings button in header has incorrect URL. It was pointing to non-existing page.