### PR TITLE
refactor(settings): Add missing menu items and adjust items order

### DIFF
--- a/src/app/account-app/account-app.component.html
+++ b/src/app/account-app/account-app.component.html
@@ -35,6 +35,13 @@
                             <mat-icon mat-list-icon svgIcon="account-group"></mat-icon> Identities
                         </p>
                     </mat-list-item>
+                    <a href="/mail/account_alias" target="rmm6">
+                        <mat-list-item [matTooltip]="rmm6tooltip">
+                            <p mat-line>
+                                <mat-icon mat-list-icon svgIcon="account-circle"></mat-icon> Email Aliases
+                            </p>
+                        </mat-list-item>
+                    </a>
                 </mat-expansion-panel>
 
                 <!-- MANAGER -->
@@ -106,43 +113,45 @@
                 <mat-expansion-panel>
                     <mat-expansion-panel-header>
                         <p mat-line>
-                            <mat-icon mat-list-icon svgIcon="account"></mat-icon> Account & Security
+                            <mat-icon mat-list-icon svgIcon="account-cog"></mat-icon> Account
                         </p>
                     </mat-expansion-panel-header>
                     <a href="/mail/account" target="rmm6">
                         <mat-list-item [matTooltip]="rmm6tooltip">
                             <p mat-line>
-                                <mat-icon mat-list-icon svgIcon="details"></mat-icon> Account Details
+                                <mat-icon mat-list-icon svgIcon="account-details"></mat-icon> Account Details
                             </p>
                         </mat-list-item>
                     </a>
-                    <mat-list-item routerLink="/account/security">
-                        <p mat-line>
-                            <mat-icon mat-list-icon svgIcon="security"></mat-icon> Account Security
-                        </p>
-                    </mat-list-item>
+                    <a href="/mail/account_account" target="rmm6" *ngIf="isMainAccount">
+                        <mat-list-item [matTooltip]="rmm6tooltip">
+                            <p mat-line>
+                                <mat-icon mat-list-icon svgIcon="account-supervisor"></mat-icon> Sub-Accounts
+                            </p>
+                        </mat-list-item>
+                    </a>
                 </mat-expansion-panel>
 
                 <!-- SUBSCRIPTIONS -->
                 <mat-expansion-panel>
                     <mat-expansion-panel-header>
                         <p mat-line>
-                            <mat-icon mat-list-icon svgIcon="hot-tub"></mat-icon> Subscriptions & Payments
+                            <mat-icon mat-list-icon svgIcon="credit-card-check"></mat-icon> Subscriptions & Payments
                         </p>
                     </mat-expansion-panel-header>
                     <mat-list-item routerLink="/account/subscriptions">
                         <p mat-line>
-                            <mat-icon mat-list-icon svgIcon="autorenew"></mat-icon> Your Subscriptions
+                            <mat-icon mat-list-icon svgIcon="folder-star-multiple"></mat-icon> Your Subscriptions
                         </p>
                     </mat-list-item>
                     <mat-list-item routerLink="/account/plans">
                         <p mat-line>
-                            <mat-icon mat-list-icon svgIcon="hot-tub"></mat-icon> Plans & Upgrades
+                            <mat-icon mat-list-icon svgIcon="card-account-details"></mat-icon> Plans & Upgrades
                         </p>
                     </mat-list-item>
                     <mat-list-item routerLink="/account/payments">
                         <p mat-line>
-                            <mat-icon mat-list-icon svgIcon="poll-box"></mat-icon> Payment History
+                            <mat-icon mat-list-icon svgIcon="receipt"></mat-icon> Payment History
                         </p>
                     </mat-list-item>
                     <mat-list-item routerLink="/account/credit_cards">
@@ -151,6 +160,21 @@
                         </p>
                     </mat-list-item>
                 </mat-expansion-panel>
+
+                <!-- SECURITY -->
+                <mat-expansion-panel>
+                    <mat-expansion-panel-header>
+                        <p mat-line>
+                            <mat-icon mat-list-icon svgIcon="security"></mat-icon>Security
+                        </p>
+                    </mat-expansion-panel-header>
+                    <mat-list-item routerLink="/account/security">
+                        <p mat-line>
+                            <mat-icon mat-list-icon svgIcon="security"></mat-icon> Account Security
+                        </p>
+                    </mat-list-item>
+                </mat-expansion-panel>
+
             </mat-accordion>
         </mat-nav-list>
     </mat-sidenav>

--- a/src/app/account-app/account-app.component.ts
+++ b/src/app/account-app/account-app.component.ts
@@ -23,6 +23,7 @@ import { MatSidenav } from '@angular/material/sidenav';
 
 import { CartService } from './cart.service';
 import { MobileQueryService } from '../mobile-query.service';
+import { RunboxMe, RunboxWebmailAPI } from '../rmmapi/rbwebmail';
 
 @Component({
     selector: 'app-account-app-component',
@@ -32,15 +33,21 @@ export class AccountAppComponent {
     @ViewChild(MatSidenav) sideMenu: MatSidenav;
     sideMenuOpened = true;
     rmm6tooltip = 'This area isn\'t upgraded to Runbox 7 yet and will open in a new tab';
+    isMainAccount: boolean;
 
     constructor(
-        public cart:        CartService,
-        public mobileQuery: MobileQueryService,
-               router:      Router,
+        public  cart:        CartService,
+        public  mobileQuery: MobileQueryService,
+                rmmapi:      RunboxWebmailAPI,
+                router:      Router,
     ) {
         this.sideMenuOpened = !mobileQuery.matches;
         this.mobileQuery.changed.subscribe(mobile => {
             this.sideMenuOpened = !mobile;
+        });
+
+        rmmapi.me.subscribe((me: RunboxMe) => {
+            this.isMainAccount = !me.owner;
         });
 
         router.events.subscribe(event => {

--- a/src/app/account-app/account-welcome.component.html
+++ b/src/app/account-app/account-welcome.component.html
@@ -62,6 +62,14 @@
         <h3>
           <mat-icon svgIcon="account-group"></mat-icon> <strong>Identities</strong>
         </h3>
+        <p>Create and manage identities associated with your email aliases and external addresses.</p>
+      </a>
+    </mat-card>
+    <mat-card class="settingsItem">
+      <a href="/mail/account_alias" target="rmm6" [matTooltip]="rmm6tooltip">
+        <h3>
+          <mat-icon svgIcon="account-circle"></mat-icon> <strong>Email Aliases</strong>
+        </h3>
         <p>Set up and manage alternative email addresses that deliver email to your account.</p>
       </a>
     </mat-card>
@@ -141,7 +149,7 @@
 
   <div>
     <h4 class="themePaletteBlack">
-      <mat-icon svgIcon="account-cog" class="category"></mat-icon> Account & Security
+      <mat-icon svgIcon="account-cog" class="category"></mat-icon> Account
     </h4>
     <p>Configure settings for your account and its security.</p>
   </div>
@@ -151,15 +159,15 @@
         <h3>
           <mat-icon svgIcon="account-details"></mat-icon> <strong>Account Details</strong>
         </h3>
-        <p>View and update your personal and account data.</p>
+        <p>View and update your personal information and account preferences.</p>
       </a>
     </mat-card>
-    <mat-card class="settingsItem">
-      <a routerLink="/account/security">
+    <mat-card *ngIf="isMainAccount" class="settingsItem">
+      <a href="/mail/account_account" target="rmm6" [matTooltip]="rmm6tooltip">
         <h3>
-          <mat-icon svgIcon="security"></mat-icon> <strong>Security</strong>
+          <mat-icon svgIcon="account-supervisor"></mat-icon> <strong>Sub-Accounts</strong>
         </h3>
-        <p>Manage your account's security settings.</p>
+        <p>Manage sub-accounts for people in your family, company, organization, or others.</p>
       </a>
     </mat-card>
   </div>
@@ -203,6 +211,25 @@
           <mat-icon svgIcon="credit-card"></mat-icon> <strong>Payment Cards</strong>
         </h3>
         <p>Details of your credit/debit cards.</p>
+      </a>
+    </mat-card>
+  </div>
+
+  <div class="divider"></div>
+
+  <div>
+    <h4 class="themePaletteBlack">
+      <mat-icon svgIcon="security" class="category"></mat-icon> Security
+    </h4>
+    <p>Configure settings for your account and its security.</p>
+  </div>
+  <div class="settingsRow">
+    <mat-card class="settingsItem">
+      <a routerLink="/account/security">
+        <h3>
+          <mat-icon svgIcon="security"></mat-icon> <strong>Security</strong>
+        </h3>
+        <p>Manage your account's security settings.</p>
       </a>
     </mat-card>
   </div>

--- a/src/app/account-app/account-welcome.component.ts
+++ b/src/app/account-app/account-welcome.component.ts
@@ -18,6 +18,7 @@
 // ---------- END RUNBOX LICENSE ----------
 
 import { Component } from '@angular/core';
+import { RunboxMe, RunboxWebmailAPI } from '../rmmapi/rbwebmail';
 
 @Component({
     selector: 'app-account-welcome-component',
@@ -25,6 +26,11 @@ import { Component } from '@angular/core';
 })
 export class AccountWelcomeComponent {
     rmm6tooltip = "This area isn't upgraded to Runbox 7 yet and will open in a new tab";
+    isMainAccount: boolean;
 
-    constructor() {}
+    constructor(rmmapi: RunboxWebmailAPI) {
+        rmmapi.me.subscribe((me: RunboxMe) => {
+            this.isMainAccount = !me.owner;
+        });
+    }
 }


### PR DESCRIPTION
- Add "Email Aliases" under "Mail" (link to https://runbox.com/mail/account_alias)
- Add "Sub-Accounts" under "Account" - visible only to main accounts (link to https://runbox.com/mail/account_account)
- Split "Account & Security" into "Account" and "Security"
- Match icons in the side menu with the ones in the main settings screen