### PR TITLE
Fix unnamed contacts

### DIFF
--- a/src/app/contacts-app/contact-list.component.ts
+++ b/src/app/contacts-app/contact-list.component.ts
@@ -69,7 +69,7 @@ export class ContactListComponent {
 
             return c.categories.find(g => g === target);
         }).filter(c => {
-            return c.display_name() && (c.display_name().toLowerCase().indexOf(this.searchTerm.toLowerCase()) !== -1);
+            return (c.display_name() || '').toLowerCase().indexOf(this.searchTerm.toLowerCase()) !== -1;
         });
 
         this.sortContacts();

--- a/src/app/contacts-app/contact.spec.ts
+++ b/src/app/contacts-app/contact.spec.ts
@@ -20,9 +20,9 @@
 import { Contact, ContactKind, Address, AddressDetails } from './contact';
 
 describe('Contact', () => {
-    it('cannot create contact with no name', () => {
+    it('can create contact with no name', () => {
         const sut = new Contact({});
-        expect(() => sut.vcard()).toThrow();
+        expect(() => sut.vcard()).not.toThrow();
     });
 
     it('can create contact with a name', () => {

--- a/src/app/contacts-app/contact.ts
+++ b/src/app/contacts-app/contact.ts
@@ -535,7 +535,7 @@ export class Contact {
             } else if (this.primary_email()) {
                 fn = this.primary_email();
             } else {
-                throw new Error('Contact needs a name before it can be saved');
+                fn = '';
             }
             this.setPropertyValue('fn', fn);
         }

--- a/src/app/contacts-app/contacts-app.component.ts
+++ b/src/app/contacts-app/contacts-app.component.ts
@@ -322,7 +322,9 @@ export class ContactsAppComponent {
 
         if (typeof e === 'string') {
             message = e;
-        } else if (e.error.error) {
+        } else if (e instanceof Error) {
+            message = 'Error: ' + e.message;
+        } else if (e?.error?.error) {
             message = e.error.error;
         } else if (e.status === 500) {
             message = 'Internal server error';

--- a/src/app/contacts-app/contacts.service.ts
+++ b/src/app/contacts-app/contacts.service.ts
@@ -259,10 +259,7 @@ export class ContactsService implements OnDestroy {
                     this.informationLog.next('Contact modified successfuly');
                     console.log('Contact modified');
                     this.reload().then(() => resolve(contact.id));
-                }, e => {
-                    this.apiErrorHandler(e);
-                    reject();
-                });
+                }, e => reject(e));
             } else {
                 if (!contact.id) {
                     contact.id = uuidv4().toUpperCase();
@@ -276,12 +273,11 @@ export class ContactsService implements OnDestroy {
                     } else {
                         resolve(contact.id);
                     }
-                }, e => {
-                    this.apiErrorHandler(e);
-                    reject();
-                });
+                }, e => reject(e));
             }
         });
+
+        promise.catch(e => this.apiErrorHandler(e));
 
         promise.finally(() => this.activities.end(Activity.SavingContact));
 


### PR DESCRIPTION
This fixes some bugs reported by @davidbowdley, starting from unnamed contacts being filtered out by search (fixed in 81d4a253270ed886d7a2696598fa5e40db471102), followed up by other things uncovered by that.

The user-facing change is that creating contacts with no deducible name is no longer disallowed – explained more in depth in the [commit](https://github.com/runbox/runbox7/commit/89d3364c072febbb1e938fa3cb5572341eb8cb07) that changed it.