### PR TITLE
Castaway/html caching again

### DIFF
--- a/e2e/mockserver/emailresponse.ts
+++ b/e2e/mockserver/emailresponse.ts
@@ -12,6 +12,7 @@ export const mail_message_obj = {
             'text': 'Test\n',
             'type': 'text'
         },
+        'sanitized_html': '<div dir="ltr">Test</div>\n',
         'mid': '11574228',
         'flagged_flag': 0,
         'seen_flag': 1,

--- a/src/app/compose/draftdesk.service.ts
+++ b/src/app/compose/draftdesk.service.ts
@@ -49,6 +49,7 @@ export class DraftFormModel {
     reply_to: string = null;
     subject: string = null;
     msg_body = '';
+    html: string;
     preview: string;
     in_reply_to: string;
     reply_to_id: string = null;
@@ -130,11 +131,11 @@ export class DraftFormModel {
         } else if (!useHTML && !mailObj.rawtext) {
             ret.msg_body = '';
         } else {
-            ret.msg_body =
+            ret.html =
                 `<br /><div style="padding-left: 10px; border-left: black solid 1px">
                     <hr style="width: 100%" />
                     ${mailObj.origMailHeaderHTML}<br />
-                    ${mailObj.html}
+                    ${mailObj.sanitized_html}
                 </div>`;
             ret.useHTML = true;
         }
@@ -158,12 +159,12 @@ export class DraftFormModel {
             ret.msg_body = '\n\n----------------------------------------------\nForwarded message:\n' +
                 mailObj.origMailHeaderText + '\n\n' + mailObj.rawtext;
         } else {
-            ret.msg_body =
+            ret.html =
                 `<br />
                 <hr style="width: 100%" />
                 Forwarded message:<br />
                 ${mailObj.origMailHeaderHTML}<br />
-                ${mailObj.html}`;
+                ${mailObj.sanitized_html}`;
             ret.useHTML = true;
         }
         ret.attachments = mailObj.attachments.map((attachment, ndx) =>

--- a/src/app/mailviewer/singlemailviewer.component.html
+++ b/src/app/mailviewer/singlemailviewer.component.html
@@ -272,14 +272,14 @@
     </div>
 
     <!-- We have an HTML message -->
-    <div *ngIf="showHTML && !htmlObjectURL">
+    <div *ngIf="showHTML && !SUPPORTS_IFRAME_SANDBOX">
       <div class="notificationContainer">
 	<span class="inMessageNotification">This HTML message has been sanitized for your security.</span>
       </div>
       <div [innerHTML]="mailContentHTML"></div>
     </div>
 
-    <div *ngIf="showHTML && htmlObjectURL" class="notificationContainer">
+    <div *ngIf="showHTML && SUPPORTS_IFRAME_SANDBOX" class="notificationContainer">
       <span class="inMessageNotification">This HTML message has been sanitized for your security.</span>
     </div>
 
@@ -297,10 +297,10 @@
     <div *ngIf="!showHTML && mailObj.text !== 'undefined'" id="messageContent" style="white-space: pre-wrap" [innerHTML]='mailObj.text'>
     </div>
 
-    <div *ngIf="mailContentHTML && showHTML && htmlObjectURL" class="iframe-container">
+    <div *ngIf="mailContentHTML && showHTML && SUPPORTS_IFRAME_SANDBOX" class="iframe-container">
       <iframe
 	        #htmliframe
-          [src]="htmlObjectURL"
+          [srcdoc]="mailContentHTML"
           (load)="adjustIframeHTMLHeight()"
           sandbox="allow-same-origin allow-popups allow-popups-to-escape-sandbox"
           id="iframe"

--- a/src/app/mailviewer/singlemailviewer.component.html
+++ b/src/app/mailviewer/singlemailviewer.component.html
@@ -308,30 +308,32 @@
       </iframe>
     </div>
 
-    <mat-card *ngIf="mailObj.attachments && mailObj.attachments.length>0">
+    <mat-card *ngIf="mailObj.attachments && mailObj.visible_attachement_count>0">
       <mat-card-title><mat-icon svgIcon="attachment"></mat-icon>Attachments</mat-card-title>
       <mat-card-content>
         <mat-grid-list [cols]="attachmentAreaCols">
           <mat-grid-tile
             *ngFor="let att of mailObj.attachments; let i=index"
             (click)="openAttachment(att)">
-              <ng-container *ngIf="att.thumbnailURL; else attachment_icon">
-                <img  matListAvatar
-                  [src]="att.thumbnailURL" />
+              <ng-container *ngIf="!att.internal">
+                <ng-container *ngIf="att.thumbnailURL; else attachment_icon">
+                  <img  matListAvatar
+                    [src]="att.thumbnailURL" />
+                </ng-container>
+                <ng-template #attachment_icon>
+                  <mat-icon matListAvatar  svgIcon="{{attachmentIconFromContentType(att.contentType)}}"></mat-icon>
+                </ng-template>
+                <mat-grid-tile-footer style="display: flex; text-align: center">
+                    <span>{{att.filename}}</span>
+                    <button mat-icon-button *ngIf="att.filename==='encrypted.asc'"
+                      matTooltip="Decrypt message"
+                      (click)="decryptAttachment(i);$event.stopPropagation()"
+                    ><mat-icon svgIcon="lock-open"></mat-icon></button>
+                    <button mat-icon-button
+                      (click)="downloadAttachmentFromServer(i);$event.stopPropagation()"
+                    ><mat-icon svgIcon="cloud-download"></mat-icon></button>
+                </mat-grid-tile-footer>
               </ng-container>
-              <ng-template #attachment_icon>
-                <mat-icon matListAvatar  svgIcon="{{attachmentIconFromContentType(att.contentType)}}"></mat-icon>
-              </ng-template>
-              <mat-grid-tile-footer style="display: flex; text-align: center">
-                  <span>{{att.filename}}</span>
-                  <button mat-icon-button *ngIf="att.filename==='encrypted.asc'"
-                    matTooltip="Decrypt message"
-                    (click)="decryptAttachment(i);$event.stopPropagation()"
-                  ><mat-icon svgIcon="lock-open"></mat-icon></button>
-                  <button mat-icon-button
-                    (click)="downloadAttachmentFromServer(i);$event.stopPropagation()"
-                  ><mat-icon svgIcon="cloud-download"></mat-icon></button>
-              </mat-grid-tile-footer>
           </mat-grid-tile>
         </mat-grid-list>
 

--- a/src/app/mailviewer/singlemailviewer.component.spec.ts
+++ b/src/app/mailviewer/singlemailviewer.component.spec.ts
@@ -87,7 +87,7 @@ describe('SingleMailViewerComponent', () => {
           getFromAddress() { return of([]); },
           getMessageContents(messageId: number): Observable<MessageContents> {
             console.log('Get message contents for', messageId);
-            return of({
+            return of(Object.assign(new MessageContents(), {
               mid: messageId,
               headers: {
                 from: {
@@ -112,7 +112,7 @@ describe('SingleMailViewerComponent', () => {
                   content: Uint8Array.from([1, 2, 3, 4, 5, 6, 7, 8])
                 }
               ]
-            });
+            }));
           }
         } },
         { provide: ContactsService, useValue: {

--- a/src/app/mailviewer/singlemailviewer.component.ts
+++ b/src/app/mailviewer/singlemailviewer.component.ts
@@ -24,8 +24,7 @@ import {
   QueryList,
   ElementRef,
   AfterViewInit,
-  DoCheck,
-  SecurityContext
+  DoCheck
 } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 import { HttpClient, HttpEvent, HttpEventType } from '@angular/common/http';
@@ -313,7 +312,8 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
         if (res.text.html) {
           // Pre-sanitized, however we need to escape ampersands and
           // quotes for srcdoc, let angular do it:
-          res.html = this.domSanitizer.sanitize(SecurityContext.HTML, res.sanitized_html);
+//          res.html = this.domSanitizer.sanitize(SecurityContext.SCRIPT, res.sanitized_html);
+          res.html = this.domSanitizer.bypassSecurityTrustHtml(res.sanitized_html);
         } else {
           res.html = null;
         }

--- a/src/app/mailviewer/singlemailviewer.component.ts
+++ b/src/app/mailviewer/singlemailviewer.component.ts
@@ -24,7 +24,8 @@ import {
   QueryList,
   ElementRef,
   AfterViewInit,
-  DoCheck
+  DoCheck,
+  SecurityContext
 } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 import { HttpClient, HttpEvent, HttpEventType } from '@angular/common/http';
@@ -310,7 +311,9 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
         // Remove style tag otherwise angular sanitazion will display style tag content as text
 
         if (res.text.html) {
-          res.html = this.domSanitizer.bypassSecurityTrustHtml(res.sanitized_html);
+          // Pre-sanitized, however we need to escape ampersands and
+          // quotes for srcdoc, let angular do it:
+          res.html = this.domSanitizer.sanitize(SecurityContext.HTML, res.sanitized_html);
         } else {
           res.html = null;
         }

--- a/src/app/mailviewer/singlemailviewer.component.ts
+++ b/src/app/mailviewer/singlemailviewer.component.ts
@@ -19,7 +19,7 @@
 
 import { map } from 'rxjs/operators';
 import {
-  SecurityContext, Component, Input, OnInit, Output, EventEmitter, ViewChild,
+  Component, Input, OnInit, Output, EventEmitter, ViewChild,
   ViewChildren,
   QueryList,
   ElementRef,
@@ -36,7 +36,6 @@ import { MessageActions } from './messageactions';
 import { ProgressDialog } from '../dialog/progress.dialog';
 import { MobileQueryService } from '../mobile-query.service';
 
-import { SafeUrl } from '@angular/platform-browser';
 import { HorizResizerDirective } from '../directives/horizresizer.directive';
 import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
 import { of } from 'rxjs';
@@ -44,7 +43,6 @@ import { Router } from '@angular/router';
 import { MessageListService } from '../rmmapi/messagelist.service';
 import { loadLocalMailParser } from './mailparser';
 
-const SUPPORTS_IFRAME_SANDBOX = 'sandbox' in document.createElement('iframe');
 const showHtmlDecisionKey = 'rmm7showhtmldecision';
 const resizerHeightKey = 'rmm7resizerheight';
 const resizerPercentageKey = 'rmm7resizerpercentage';
@@ -110,12 +108,13 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
   public err: any;
 
   public mailContentHTML: string = null;
-  public htmlObjectURL: SafeUrl = null;
   public fullMailDownloaded = false;
 
   public showHTMLDecision = 'dontask';
   public showHTML = false;
   public showAllHeaders = false;
+
+  public SUPPORTS_IFRAME_SANDBOX = 'sandbox' in document.createElement('iframe');
 
   height = 0;
   previousHeight: number;
@@ -309,22 +308,8 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
         // Remove style tag otherwise angular sanitazion will display style tag content as text
 
         if (res.text.html) {
-          const styleFilterRegexp = new RegExp(/(<style[\S\s]*?>[\S\s]*?<\/style>)/ig);
-          const rawhtml = '' + res.text.html;
-          let filteredhtml = rawhtml;
-          filteredhtml = filteredhtml.replace(styleFilterRegexp, '');
-          filteredhtml = this.domSanitizer.sanitize(SecurityContext.HTML, filteredhtml);
-
-          res.html = filteredhtml;
-
-          // Use HTML rest endpoint
-          if (SUPPORTS_IFRAME_SANDBOX) {
-            this.htmlObjectURL = this.domSanitizer.bypassSecurityTrustResourceUrl('/rest/v1/email/' + this.messageId + '/html');
-          } else {
-            this.htmlObjectURL = null;
-          }
+          res.html = this.domSanitizer.bypassSecurityTrustHtml(res.sanitized_html);
         } else {
-          this.htmlObjectURL = null;
           res.html = null;
         }
 

--- a/src/app/rmmapi/messagecache.ts
+++ b/src/app/rmmapi/messagecache.ts
@@ -24,6 +24,7 @@ import { MessageContents } from './rbwebmail';
 @Injectable()
 export class MessageCache {
     db: Dexie;
+    message_version = 2;
 
     constructor() {
         try {
@@ -38,12 +39,13 @@ export class MessageCache {
 
     async get(id: number): Promise<MessageContents> {
         return this.db?.table('messages').get(id).then(
-            result => result,
+            result => Object.assign(new MessageContents(), result).version === this.message_version ? result : null,
             _error => null,
         );
     }
 
     set(id: number, contents: MessageContents): void {
+        contents.version = this.message_version;
         this.db?.table('messages').put(contents, id).catch(
             _err => {},
         );

--- a/src/app/rmmapi/messagecache.ts
+++ b/src/app/rmmapi/messagecache.ts
@@ -24,7 +24,7 @@ import { MessageContents } from './rbwebmail';
 @Injectable()
 export class MessageCache {
     db: Dexie;
-    message_version = 2;
+    message_version = 3;
 
     constructor() {
         try {

--- a/src/app/rmmapi/rbwebmail.ts
+++ b/src/app/rmmapi/rbwebmail.ts
@@ -150,6 +150,7 @@ export class MessageTextContents {
 
 export class MessageContents {
     text: MessageTextContents;
+    version = 1;
 }
 
 export class MessageFlagChange {
@@ -239,7 +240,7 @@ export class RunboxWebmailAPI {
                         map((r: any) => r.result),
                     ).subscribe((result) => {
                         this.messageCache.set(messageId, result);
-                        resolve(<MessageContents>result);
+                        resolve(Object.assign( new MessageContents(), result));
                     }, err => {
                         delete this.messageContentsRequestCache[messageId];
                         reject(err);


### PR DESCRIPTION
* Pre-load HTML content by including it in the initial "fetch message data" request - loads HTML emails faster 
* Trust backend pre-sanitized HTML, displays in original format in HTML view
*  Should not get security warnings on Replies or Forwards of HTML emails
* Reply/Fwd HTML email displays in original format

Fixes #998 #1020