### PR TITLE
fix(folders): Display top-level folders in user-sorted order

### DIFF
--- a/src/app/folder/folderlist.component.ts
+++ b/src/app/folder/folderlist.component.ts
@@ -192,6 +192,7 @@ export class FolderListComponent implements OnChanges {
         };
 
         treedata.forEach(node => sortSubfolders(node));
+        treedata.sort((a, b) => a.data.priority - b.data.priority);
 
         this.dataSource.data = treedata;
     }


### PR DESCRIPTION
Fixes (partially) #1002