### PR TITLE
fix(maillist): Ensure actions involving 2 folders update counts on both

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -608,7 +608,9 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
         }
       },
       updateRemote: (msgIds: number[]) => {
-        const res = this.rmmapi.trainSpam({is_spam: params.is_spam, messages: messageIds});
+        const userFolders = this.messagelistservice.folderListSubject.value;
+        const currentFolderId = userFolders.find(fld => fld.folderName === this.messagelistservice.currentFolder).folderId;
+        const res = this.rmmapi.trainSpam({is_spam: params.is_spam, from_folder_id: currentFolderId, messages: messageIds});
         res.subscribe(data => {
           if ( data.status === 'error' ) {
             snackBarRef.dismiss();
@@ -932,7 +934,11 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
         }
         this.messagelistservice.moveMessages(msgIds, folderPath);
       },
-      updateRemote: (msgIds: number[]) => this.rmmapi.moveToFolder(messageIds, folderId)
+      updateRemote: (msgIds: number[]) => {
+        const userFolders = this.messagelistservice.folderListSubject.value;
+        const currentFolderId = userFolders.find(fld => fld.folderName === this.messagelistservice.currentFolder).folderId;
+        return this.rmmapi.moveToFolder(messageIds, folderId, currentFolderId);
+      }
     });
   }
 
@@ -963,8 +969,11 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
             this.clearSelection();
             this.canvastable.rows.clearOpenedRow();
           },
-          updateRemote: (msgIds: number[]) =>
-            this.messagelistservice.rmmapi.moveToFolder(msgIds, folder)
+          updateRemote: (msgIds: number[]) => {
+            const userFolders = this.messagelistservice.folderListSubject.value;
+            const currentFolderId = userFolders.find(fld => fld.folderName === this.messagelistservice.currentFolder).folderId;
+            return this.messagelistservice.rmmapi.moveToFolder(msgIds, folder, currentFolderId);
+          }
         });
       }
     });

--- a/src/app/mailviewer/rmm7messageactions.ts
+++ b/src/app/mailviewer/rmm7messageactions.ts
@@ -70,8 +70,11 @@ export class RMM7MessageActions implements MessageActions {
                         this.messageListService.moveMessages(msgIds, folderPath);
                         this.mailViewerComponent.close();
                     },
-                    updateRemote: (msgIds: number[]) =>
-                        this.messageListService.rmmapi.moveToFolder(msgIds, folder)
+                    updateRemote: (msgIds: number[]) => {
+                        const userFolders = this.messageListService.folderListSubject.value;
+                        const currentFolderId = userFolders.find(fld => fld.folderName === this.messageListService.currentFolder).folderId;
+                        return this.messageListService.rmmapi.moveToFolder(msgIds, folder, currentFolderId);
+                    }
                 });
             }
         });

--- a/src/app/rmmapi/rbwebmail.ts
+++ b/src/app/rmmapi/rbwebmail.ts
@@ -422,8 +422,8 @@ export class RunboxWebmailAPI {
         );
     }
 
-    public moveToFolder(messageIds: number[], folderId: number): Observable<any> {
-        return this.http.post('/rest/v1/email/move', { messages: messageIds, folder_id: folderId });
+    public moveToFolder(messageIds: number[], toFolderId: number, fromFolderId: number): Observable<any> {
+        return this.http.post('/rest/v1/email/move', { messages: messageIds, folder_id: toFolderId, from_folder_id: fromFolderId });
     }
 
     public trainSpam(params): Observable<any> {


### PR DESCRIPTION
Fixes issues with displayed folder counts being incorrect after message moves (including to spam/trash) - intermittent issue that happens when a move is made when an index sync is also in progress