### PR TITLE
Castaway/1025 hidden message list

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -295,7 +295,7 @@
     </mat-progress-bar>
 
     <div [hidden]="hasChildRouterOutlet">
-      <div id="canvasTableContainerArea" [ngStyle]="{'bottom.px': !mailViewerOnRightSide && singlemailviewer ? singlemailviewer.height: 0}">
+      <div id="canvasTableContainerArea" [ngStyle]="{'bottom.px': canvasTableBtmOffset}">
         <canvastablecontainer [canvastableselectlistener]="this" (sortToggled)="updateSearch(true)"></canvastablecontainer>
       </div>
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -278,6 +278,12 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     this.updateTime();
   }
 
+  public get canvasTableBtmOffset() {
+    return this.singlemailviewer && this.singlemailviewer.adjustableHeight
+      ? this.singlemailviewer.resizerHeight
+      : 0;
+  }
+
   ngDoCheck(): void {
     if (!this.usewebsocketsearch && this.searchService.api && this.xapianDocCount) {
       this.dynamicSearchFieldPlaceHolder = 'Start typing to search ' +

--- a/src/app/canvastable/canvastable.ts
+++ b/src/app/canvastable/canvastable.ts
@@ -887,6 +887,10 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
   }
 
   private enforceScrollLimit() {
+    // currently selected row in the centre:
+    if (this.rows.openedRowIndex) {
+      this.topindex = this.rows.openedRowIndex - Math.round(this.maxVisibleRows / 2);
+    }
     if (this.topindex < 0) {
       this.topindex = 0;
     } else if (this.rows.rowCount() < this.maxVisibleRows) {
@@ -998,6 +1002,7 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
         this.ctx.scale(devicePixelRatio, devicePixelRatio);
       }
       this.maxVisibleRows = this.canv.scrollHeight / this.rowheight;
+      this.enforceScrollLimit();
       this.hasChanges = true;
       if (this.canv.clientWidth < this.autoRowWrapModeWidth) {
         this.rowWrapMode = true;

--- a/src/app/directives/horizresizer.directive.ts
+++ b/src/app/directives/horizresizer.directive.ts
@@ -39,6 +39,10 @@ export class HorizResizerDirective implements OnInit {
 
     }
 
+    get currentHeight() {
+        return this.el.nativeElement.getBoundingClientRect().height;
+    }
+
     ngOnInit(): void {
         if (!this.resizableDisabled) {
             this.el.nativeElement.style['border-top'] = `${this.resizableGrabHeight}px solid darkgrey`;
@@ -65,7 +69,14 @@ export class HorizResizerDirective implements OnInit {
 
                 this.isFullHeight = newTop - parentOffsetTop < this.fullHeightThreshold;
                 const newHeight = elementRect.bottom - newTop;
-                const percentage = Math.round(newHeight / fullheight * 100);
+                let percentage = Math.round(newHeight / fullheight * 100);
+
+                // This is apparently possible - unclear how!
+                if (percentage > 100 ) {
+                    percentage = 100;
+                } else if (percentage < 0) {
+                    percentage = 0;
+                }
 
                 this.resized.emit(percentage);
             };

--- a/src/app/mailviewer/singlemailviewer.component.ts
+++ b/src/app/mailviewer/singlemailviewer.component.ts
@@ -158,11 +158,15 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
     }
   }
 
+  public get resizerHeight() {
+    return this.resizer ? this.resizer.currentHeight : 0;
+  }
+
   public get messageId() {
     return this._messageId;
   }
 
-  private get showAttachments() {
+  public get showAttachments() {
     // Show attachments section IIF:
     // We have any attachments at all AND
     // we have non-inline (image) attachments OR
@@ -177,7 +181,12 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
     this.showHTMLDecision = localStorage.getItem(showHtmlDecisionKey);
     // Update 2020-12, now preferring resizerPercentageKey
     this.previousHeight = parseInt(localStorage.getItem(resizerHeightKey), 10);
-    this.previousHeightPercentage = parseInt(localStorage.getItem(resizerPercentageKey), 10);
+    const storedHeightPercentage  = parseInt(localStorage.getItem(resizerPercentageKey), 10);
+    this.previousHeightPercentage = storedHeightPercentage > 100
+      ? 100
+      : storedHeightPercentage < 0
+        ? 0
+      : storedHeightPercentage;
   }
 
   public ngAfterViewInit() {
@@ -195,9 +204,9 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
             localStorage.removeItem(resizerHeightKey);
           }
           if (this.previousHeightPercentage) {
-            this.resizer.resizePercentage(this.previousHeightPercentage);
+            resizer.first.resizePercentage(this.previousHeightPercentage);
           } else {
-            this.resizer.resizePercentage(50);
+            resizer.first.resizePercentage(50);
           }
         }
       }, 0);


### PR DESCRIPTION
1. Ensure canvas/message list isn't hidden until the horizontal mail pane when it's open (this seems to have been broken a while). Also make sure we scroll to the selected message when we reload a page with a msg id in the url

2. Ensure we only ever store "horizontal mail pane height percentage" at a value between 0 and 100 (I got 109, which hid the mail pane menu behind the main menu)