### PR TITLE
fix(mailviewer): Display image attachments in HTML unless inline

### DIFF
--- a/src/app/mailviewer/singlemailviewer.component.ts
+++ b/src/app/mailviewer/singlemailviewer.component.ts
@@ -433,8 +433,11 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
           if (isImage) {
             att.thumbnailURL = '/rest/v1/email/' + this.messageId + '/attachmentimagethumbnail/' + ndx;
             if (html) {
-              html = html.replace(new RegExp('src="cid:' + att.cid), 'src="' + att.downloadURL);
-              att.internal = true;
+              const newHtml = html.replace(new RegExp('src="cid:' + att.cid), 'src="' + att.downloadURL);
+              if (newHtml !== html) {
+                att.internal = true;
+                html = newHtml;
+              }
             }
           }
         }


### PR DESCRIPTION
Whoops - Previous changes made all image attachments disappear in HTML, whether they were displayed inline in the HTML or not. Here we actually check whether the HTML contains the image, and then act accordingly.