### PR TITLE
Castaway/message load errors

### DIFF
--- a/e2e/cypress/integration/mailviewer.ts
+++ b/e2e/cypress/integration/mailviewer.ts
@@ -7,12 +7,24 @@ describe('Interacting with mailviewer', () => {
 
     beforeEach(() => {
         localStorage.setItem('localSearchPromptDisplayed221', 'true');
+        localStorage.setItem('messageSubjectDragTipShown', 'true');
+        indexedDB.deleteDatabase('messageCache');
+    });
+
+    it('Loading an email with loading errors displays an error', () => {
+        cy.intercept('/rest/v1/email/14').as('get14');
+        cy.visit('/');
+        cy.wait('@get14', {'timeout':10000});
+        cy.visit('/#Inbox:14');
+
+        cy.get('simple-snack-bar').contains('Email content missing');
     });
 
     it('can open an email and go back and forth in browser history', () => {
+        cy.intercept('/rest/v1/email/9').as('get9');
         cy.visit('/');
 
-        cy.wait(1000); // should be long enough for the canvas to appear
+        cy.wait('@get9', {'timeout':10000});
         canvas().click(400, 300);
 
         cy.hash().should('equal', '#Inbox:9');

--- a/e2e/mockserver/emailresponse.ts
+++ b/e2e/mockserver/emailresponse.ts
@@ -1,4 +1,4 @@
-export const mail_message_obj = {
+export const mail_message_obj: { status: string, errors?: string[], result?: any } = {
     'status': 'success',
     'result': {
         'folder': 'Inbox',

--- a/e2e/mockserver/mockserver.ts
+++ b/e2e/mockserver/mockserver.ts
@@ -250,6 +250,15 @@ END:VCALENDAR
                     message_obj.result.headers['cc'] = to;
                     message_obj.result.headers['subject'] = "";
                 }
+                // This one warns, we couldnt find it!
+                if (mailid === '14') {
+                    message_obj = {
+                        'status':'warning',
+                        'errors': [
+                            'Email content missing'
+                        ]
+                    };
+                }
 
                 if (requesturl.endsWith('/html')) {
                     response.end(message_obj.result.text.html);
@@ -404,6 +413,9 @@ END:VCALENDAR
         inboxlines.push(`13	1548071424	1547830045	Inbox	1	0	0	"Test" <test@runbox.com>	` +
                 `Test2<test2@lalala.no>		709	n	 `);
 
+        // id=14: broken email
+        inboxlines.push(`14	1548071425	1547830046	Inbox	1	0	0	"Test" <test@runbox.com>	` +
+                `Test2<test2@lalala.no>	Default from fix test	709	n	 `);
 
         return inboxlines.join('\n');
     }

--- a/src/app/canvastable/canvastable.ts
+++ b/src/app/canvastable/canvastable.ts
@@ -891,6 +891,7 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
     // currently selected row in the centre:
     if (this.rows.openedRowIndex) {
       this.topindex = this.rows.openedRowIndex - Math.round(this.maxVisibleRows / 2);
+      this.enforceScrollLimit();
     }
   }
 

--- a/src/app/rmmapi/messagecache.ts
+++ b/src/app/rmmapi/messagecache.ts
@@ -24,7 +24,7 @@ import { MessageContents } from './rbwebmail';
 @Injectable()
 export class MessageCache {
     db: Dexie;
-    message_version = 3;
+    message_version = 4;
 
     constructor() {
         try {

--- a/src/app/xapian/searchservice.ts
+++ b/src/app/xapian/searchservice.ts
@@ -948,8 +948,12 @@ export class SearchService {
               return new SearchIndexDocumentUpdate(messageId, async () => {
                 try {
                   const docIdTerm = `Q${messageId}`;
-                  const messageText = (await this.rmmapi.getMessageContents(messageId).toPromise()).text.text;
-                  this.api.addTextToDocument(docIdTerm, true, messageText);
+                  const msg = (await this.rmmapi.getMessageContents(messageId).toPromise());
+                  if (msg.status === 'success') {
+                    this.api.addTextToDocument(docIdTerm, true, msg.text.text);
+                  }
+                  // There may have been known backend warnings, so
+                  // don't keep repeating the attempt
                   this.api.removeTermFromDocument(docIdTerm, XAPIAN_TERM_MISSING_BODY_TEXT);
                 } catch (e) {
                   console.error('Failed to add text to document', messageId, e);


### PR DESCRIPTION
Fixes #1067 among other things.

Splits existing "errors" into "warnings" and "errors" - an error is when the backend had perl errors and couldn't actually complete the request, a warning is when the backend completed, but couldn't do what was asked. For warnings we can continue, and display the user a reason, and a prompt to contact support.

This will require a backend change to determine which errors should actually be warnings.