### PR TITLE
fix(login) Allow normal text in OTP input

### DIFF
--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -78,7 +78,7 @@
               <p>Please enter your OTP code.</p>
               <br />
               <mat-form-field>
-		<input matInput placeholder="One-time password" name="otp" id="otp" inputmode="numeric" ngModel />
+		<input matInput placeholder="One-time password" name="otp" id="otp" ngModel />
               </mat-form-field>
 	      <button mat-raised-button color="primary" type="submit">Log in</button>
 	      <br />


### PR DESCRIPTION
Input mode was set to numeric, so it didn't allow the user to type in letters. Changed to standard input mode.

Fixes #1059 