### PR TITLE
Castaway/979 preview unread filter non index

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -241,7 +241,7 @@
                 [disabled]="unreadMessagesOnlyCheckbox || !showingSearchResults"
                 class="tableViewOptionsMenuElement"
               >
-                <mat-icon  svgIcon="view-list" class="tableViewOptionsMenuElement" matTooltip="Threaded conversation view"></mat-icon>
+                <mat-icon  svgIcon="view-list" class="tableViewOptionsMenuElement" [matTooltip]="conversationGroupingToolTip"></mat-icon>
                 Threaded view
               </mat-checkbox>
             </mat-list-item>
@@ -253,7 +253,7 @@
                 [disabled]="viewmode==='conversations'"
                 class="tableViewOptionsMenuElement"
               >
-                <mat-icon  svgIcon="email-mark-as-unread" class="tableViewOptionsMenuElement" matTooltip="Unread messages only"></mat-icon>
+                <mat-icon  svgIcon="email-mark-as-unread" class="tableViewOptionsMenuElement" [matTooltip]="unreadOnlyToolTip"></mat-icon>
                 Unread only
               </mat-checkbox>
             </mat-list-item>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -219,46 +219,44 @@
 
         <mat-menu #tableViewOptionsMenu="matMenu">
           <mat-list>
-            <!-- <ng-container *ngIf="dataReady"> -->
-              <!-- currently only supporting threading / unread for local index -->
-              <mat-list-item>
-                <mat-checkbox
-                  *ngIf="canvastable"
-                  [(ngModel)]="canvastable.showContentTextPreview"
-                  matLine
-                  (change)="saveContentPreviewSetting()"
-                  (click)="$event.stopPropagation()"
-                  class="tableViewOptionsMenuElement"
-                >
-                  <mat-icon  svgIcon="format-align-right" class="tableViewOptionsMenuElement" matTooltip="Inline message previews"></mat-icon>
-                  Inline previews
-                </mat-checkbox>
-              </mat-list-item>
-              <mat-list-item>
-                <mat-checkbox [(ngModel)]="conversationGroupingCheckbox"
-                  matLine
-                  (change)="updateViewMode($event.source.checked ? 'conversations' : 'messages')"
-                  (click)="$event.stopPropagation()"
-                  [disabled]="unreadMessagesOnlyCheckbox"
-                  class="tableViewOptionsMenuElement"
-                >
-                  <mat-icon  svgIcon="view-list" class="tableViewOptionsMenuElement" matTooltip="Threaded conversation view"></mat-icon>
-                  Threaded view
-                </mat-checkbox>
-              </mat-list-item>
-              <mat-list-item>
-                <mat-checkbox [(ngModel)]="unreadMessagesOnlyCheckbox"
-                  matLine
-                  (change)="updateSearch(true)"
-                  (click)="$event.stopPropagation()"
-                  [disabled]="viewmode==='conversations'"
-                  class="tableViewOptionsMenuElement"
-                >
-                  <mat-icon  svgIcon="email-mark-as-unread" class="tableViewOptionsMenuElement" matTooltip="Unread messages only"></mat-icon>
-                  Unread only
-                </mat-checkbox>
-              </mat-list-item>
-            <!-- </ng-container> -->
+            <mat-list-item>
+              <mat-checkbox
+                *ngIf="canvastable"
+                [(ngModel)]="canvastable.showContentTextPreview"
+                matLine
+                (change)="saveContentPreviewSetting()"
+                (click)="$event.stopPropagation()"
+                class="tableViewOptionsMenuElement"
+              >
+                <mat-icon  svgIcon="format-align-right" class="tableViewOptionsMenuElement" matTooltip="Inline message previews"></mat-icon>
+                Inline previews
+              </mat-checkbox>
+            </mat-list-item>
+            <!-- currently only supporting threading for local index -->
+            <mat-list-item>
+              <mat-checkbox [(ngModel)]="conversationGroupingCheckbox"
+                matLine
+                (change)="updateViewMode($event.source.checked ? 'conversations' : 'messages')"
+                (click)="$event.stopPropagation()"
+                [disabled]="unreadMessagesOnlyCheckbox || !showingSearchResults"
+                class="tableViewOptionsMenuElement"
+              >
+                <mat-icon  svgIcon="view-list" class="tableViewOptionsMenuElement" matTooltip="Threaded conversation view"></mat-icon>
+                Threaded view
+              </mat-checkbox>
+            </mat-list-item>
+            <mat-list-item>
+              <mat-checkbox [(ngModel)]="unreadMessagesOnlyCheckbox"
+                matLine
+                (change)="updateSearch(true)"
+                (click)="$event.stopPropagation()"
+                [disabled]="viewmode==='conversations'"
+                class="tableViewOptionsMenuElement"
+              >
+                <mat-icon  svgIcon="email-mark-as-unread" class="tableViewOptionsMenuElement" matTooltip="Unread messages only"></mat-icon>
+                Unread only
+              </mat-checkbox>
+            </mat-list-item>
 
             <mat-list-item *ngIf="!mobileQuery.matches">
               <mat-checkbox [(ngModel)]="keepMessagePaneOpen"

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -219,7 +219,7 @@
 
         <mat-menu #tableViewOptionsMenu="matMenu">
           <mat-list>
-            <ng-container *ngIf="dataReady">
+            <!-- <ng-container *ngIf="dataReady"> -->
               <!-- currently only supporting threading / unread for local index -->
               <mat-list-item>
                 <mat-checkbox
@@ -258,7 +258,7 @@
                   Unread only
                 </mat-checkbox>
               </mat-list-item>
-            </ng-container>
+            <!-- </ng-container> -->
 
             <mat-list-item *ngIf="!mobileQuery.matches">
               <mat-checkbox [(ngModel)]="keepMessagePaneOpen"

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -89,7 +89,9 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
   viewmode = 'messages';
   keepMessagePaneOpen = true;
   conversationGroupingCheckbox = false;
+  conversationGroupingToolTip = 'Threaded conversation view';
   unreadMessagesOnlyCheckbox = false;
+  unreadOnlyToolTip = 'Unread messages only';
 
   indexDocCount = 0;
 
@@ -760,6 +762,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     this.searchService.deleteLocalIndex().subscribe(() => {
       this.messagelistservice.fetchFolderMessages();
 
+      this.updateTooltips();
       this.snackBar.open('The index has been deleted from your device', 'Dismiss');
     });
   }
@@ -1107,6 +1110,17 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     });
   }
 
+  updateTooltips() {
+    this.unreadOnlyToolTip = this.viewmode === 'conversations'
+      ? 'Leave threaded mode to view unread only'
+      : 'Unread messages only';
+    this.conversationGroupingToolTip = !this.showingSearchResults
+      ? 'Synchronise the index to see threaded view'
+      :  this.unreadMessagesOnlyCheckbox
+        ? 'Leave unread only to see threaded view'
+        : 'Threaded conversation view';
+  }
+
   // FIXME: Why do we run this when searchText is empty?
   // FIXME: move updateSearch (for index searches) into
   // searchmessagedisplay filterBy ?
@@ -1118,6 +1132,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     }
     const setting = this.unreadMessagesOnlyCheckbox ? 'true' : 'false';
     localStorage.setItem(LOCAL_STORAGE_SHOW_UNREAD_ONLY, setting);
+    this.updateTooltips();
 
     if (always || this.lastSearchText !== this.searchText) {
       this.lastSearchText = this.searchText;
@@ -1274,6 +1289,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
             } else {
               this.usewebsocketsearch = true;
             }
+            this.updateTooltips();
           });
         }
       })

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -786,6 +786,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
         this.canvastable.rows = new WebSocketSearchMailList(...args);
       }
     }
+    this.filterMessageDisplay();
 
     // FIXME: looks weird, should probably rename "rows" to "messagedisplay"
     // in canvastable, and anyway get CV to just read the columns itself
@@ -798,6 +799,14 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
 
     // messages updated, check if we need to select a message from the fragment
     this.selectMessageFromFragment(this.fragment);
+  }
+
+  public filterMessageDisplay() {
+    const options = new Map();
+    options.set('unreadOnly', this.unreadMessagesOnlyCheckbox);
+    options.set('searchText', this.searchText);
+    this.canvastable.rows.filterBy(options);
+    this.canvastable.hasChanges = true;
   }
 
   public clearSelection() {
@@ -1099,8 +1108,12 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
   }
 
   // FIXME: Why do we run this when searchText is empty?
+  // FIXME: move updateSearch (for index searches) into
+  // searchmessagedisplay filterBy ?
   updateSearch(always?: boolean, noscroll?: boolean) {
     if (!this.dataReady || this.showingWebSocketSearchResults) {
+      // May have changed unread checkbox so reset / filter message display
+      this.filterMessageDisplay();
       return;
     }
     const setting = this.unreadMessagesOnlyCheckbox ? 'true' : 'false';

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -417,7 +417,9 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
             idx => idx < this.canvastable.rows.rowCount()
         ).map(idx => this.canvastable.rows.getRowMessageId(idx));
         for (const id of messageIds) {
-            this.rmmapi.getMessageContents(id).subscribe(() => this.canvastable.hasChanges = true);
+          if (this.searchService.updateMessageText(id)) {
+            this.canvastable.hasChanges = true;
+          }
         }
     });
 

--- a/src/app/canvastable/canvastable.ts
+++ b/src/app/canvastable/canvastable.ts
@@ -839,7 +839,7 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
   }
 
   public updateRows(newList) {
-    this.rows.rows = newList;
+    this.rows.setRows(newList);
     this.enforceScrollLimit();
     this.hasChanges = true;
   }

--- a/src/app/common/messagedisplay.ts
+++ b/src/app/common/messagedisplay.ts
@@ -26,9 +26,19 @@ export abstract class MessageDisplay {
   // public selectedRowIds: { [key: number]: boolean } = {};
   public hasChanges: boolean;
 
+  // ALL rows
+  public _rows = [];
+  // Rows for actual display
   public rows = [];
 
   constructor(rows: any) {
+    this._rows = rows;
+    // default to all rows, see filterBy for reduced sets
+    this.rows = rows;
+  }
+
+  setRows(rows: any) {
+    this._rows = rows;
     this.rows = rows;
   }
 
@@ -168,6 +178,9 @@ export abstract class MessageDisplay {
   clearOpenedRow() {
     this.openedRowIndex = null;
   }
+
+  // filtering:
+  abstract filterBy(options: Map<String, any>);
 
   // columns
   abstract getCanvasTableColumns(app: any): CanvasTableColumn[];

--- a/src/app/common/messagelist.ts
+++ b/src/app/common/messagelist.ts
@@ -89,7 +89,12 @@ export class MessageList extends MessageDisplay {
         name: 'Subject',
         sortColumn: null,
         getValue: (rowIndex: number): string => this.getRow(rowIndex).subject,
-        draggable: true
+        draggable: true,
+        getContentPreviewText: (rowIndex): string => {
+          const ret = this.getRow(rowIndex).plaintext;
+          return ret ? ret.trim() : '';
+        },
+        // tooltipText: 'Tip: Drag subject to a folder to move message(s)'
       },
       {
         sortColumn: null,

--- a/src/app/common/messagelist.ts
+++ b/src/app/common/messagelist.ts
@@ -62,6 +62,14 @@ export class MessageList extends MessageDisplay {
     '';
   }
 
+  // filter visible rows by whatever options the frontend has
+  filterBy(options: Map<String, any>) {
+    this.rows = this._rows;
+    if (options.has('unreadOnly') && options.get('unreadOnly')) {
+      this.rows = this._rows.filter((msg) => !msg.seenFlag);
+    }
+  }
+
   public getCanvasTableColumns(app: any): CanvasTableColumn[] {
     const columns: CanvasTableColumn[] = [
       {

--- a/src/app/websocketsearch/websocketsearchmaillist.ts
+++ b/src/app/websocketsearch/websocketsearchmaillist.ts
@@ -44,6 +44,12 @@ export class WebSocketSearchMailList extends MessageDisplay {
     return msg.id;
   }
 
+  filterBy(options: Map<String, any>) {
+    this.rows = this._rows;
+    if (options.has('unreadOnly') && options.get('unreadOnly')) {
+      this.rows = this._rows.filter((msg) => !msg.seen);
+    }
+  }
 
     public getCanvasTableColumns(app: any): CanvasTableColumn[] {
         const columns: CanvasTableColumn[] = [

--- a/src/app/xapian/searchmessagedisplay.ts
+++ b/src/app/xapian/searchmessagedisplay.ts
@@ -43,6 +43,9 @@ export class SearchMessageDisplay extends MessageDisplay {
     return this.searchService.getMessageIdFromDocId(this.rows[index][0]);
   }
 
+  filterBy(options: Map<String, any>) {
+  }
+
   // columns
   // app is a Component (currently)
   public getCanvasTableColumns(app: any): CanvasTableColumn[] {

--- a/src/app/xapian/searchservice.ts
+++ b/src/app/xapian/searchservice.ts
@@ -1229,5 +1229,18 @@ export class SearchService {
         return this.currentDocData;
     }
 
-}
+  // fetch message contents, we actually only want the "text.text" part here
+  // then we can use it for previews and search, both with/without local index
+  // skip haschanges/updates if we already saw this one ..
+  public updateMessageText(messageId: number): boolean {
+    if (!this.messageTextCache.has(messageId)) {
+      this.rmmapi.getMessageContents(messageId).subscribe((content) => {
+        this.messageTextCache.set(messageId, content.text.text);
+        this.messagelistservice.messagesById[messageId].plaintext = content.text.text;
+      });
+      return true;
+    }
+    return false;
+  }
 
+}


### PR DESCRIPTION
* Add "plain text" email source into the "messagelist" objects which we use for displaying emails when we're not using the xapian index.
* Use the above data to enable "inline previews" when index is not synced
* Filter the "messagelist" rows by seen/not seen, to enable "Unread only" when index is not synced
* "Threaded view" not available with no index - so this is greyed out/disabled if the index is not synced 

Fixes #959 and #1078