### PR TITLE
fix(foldercounts): Update counts on index refresh, only when changed

### DIFF
--- a/src/app/xapian/searchservice.ts
+++ b/src/app/xapian/searchservice.ts
@@ -203,6 +203,9 @@ export class SearchService {
           this.initSubject.complete();
         }
       });
+
+    this.searchResultsSubject.subscribe(() =>
+      this.messagelistservice.refreshFolderCounts());
   }
 
   public init() {


### PR DESCRIPTION
Fixes an issue where if folder counts changed outside of runbox7 - eg user reads a message in IMAP or RMM6, the folder count status in Runbox7 remains one step behind.

This was caused by a) Only updating counts when the folder lists (via rest API) actually change, b) that being run independently of index update resulting in counting messages in folder from the index, before the index had updated.

Now changed so that we redo the counts every time the index changes as well, and only signal an update to the folder list component, when the resulting counts are actually different to the last time they were done.

Improves re #512 a bit, tho I wouldn't close it just yet!