### PR TITLE
fix(mailviewer): Add horizontal scroll to message view

### DIFF
--- a/src/app/mailviewer/singlemailviewer.component.css
+++ b/src/app/mailviewer/singlemailviewer.component.css
@@ -70,7 +70,8 @@
 }
 
 #messageContent {
-    overflow: hidden;
+    overflow-y: hidden;
+    overflow-x: scroll;
     margin: 0 2%;
     width: 96%;
     white-space: pre-wrap;


### PR DESCRIPTION
Improves issue #1072.

The horizontal scroll is visible now, but it appears on the very bottom of the message. It's a temporary fix while I'm still looking for a way to show it regardless of the message height.
It is possible to scroll easily on a touchpad. With a mouse I believe you'd have to scroll to the bottom of your email.