### PR TITLE
Castaway/1083 folder col width

### DIFF
--- a/src/app/xapian/searchmessagedisplay.ts
+++ b/src/app/xapian/searchmessagedisplay.ts
@@ -187,6 +187,19 @@ export class SearchMessageDisplay extends MessageDisplay {
         });
       }
 
+      // Empty col enables the final col to be resized (ugh..)
+      columns.push({
+        sortColumn: null,
+        name: '',
+        textAlign: 2,
+        rowWrapModeHidden: true,
+        font: '16px \'Material Icons\'',
+        getValue: (rowIndex) => '',
+        width: 0,
+        getFormattedValue: (val) => ''
+      });
+      
+
     }
     return columns;
   }

--- a/src/app/xapian/searchmessagedisplay.ts
+++ b/src/app/xapian/searchmessagedisplay.ts
@@ -198,7 +198,6 @@ export class SearchMessageDisplay extends MessageDisplay {
         width: 0,
         getFormattedValue: (val) => ''
       });
-      
 
     }
     return columns;


### PR DESCRIPTION
Allow the folder column to be resized on the right end - this is done by adding an empty/zero width column on the end (could not see how to add it otherwise!)

Also store the user's "saved column widths" in sets, so if the (search results) view including the folder column is resized, these sizes are not applied when viewing the normal message list.

Imports previously saved column width info, though this is unlikely to be usable, so users may need to recreate any saved widths they had.