### PR TITLE
refactor(mailviewer): Display a list of attachments at the top

### DIFF
--- a/src/app/mailviewer/mailviewer.module.ts
+++ b/src/app/mailviewer/mailviewer.module.ts
@@ -26,6 +26,7 @@ import { MatDialogModule } from '@angular/material/dialog';
 import { MatDividerModule } from '@angular/material/divider';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatGridListModule } from '@angular/material/grid-list';
+import { MatListModule } from '@angular/material/list';
 import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatRadioModule } from '@angular/material/radio';
@@ -51,6 +52,7 @@ export { SingleMailViewerComponent } from './singlemailviewer.component';
         ResizerModule,
         MatIconModule,
         MatGridListModule,
+        MatListModule,
         MatToolbarModule,
         MatTooltipModule,
         MatDividerModule,

--- a/src/app/mailviewer/singlemailviewer.component.html
+++ b/src/app/mailviewer/singlemailviewer.component.html
@@ -237,6 +237,32 @@
 
     </mat-expansion-panel>
 
+    <mat-expansion-panel *ngIf="showAttachments" [expanded]="mobileQuery.matches ? false : true" id="attachmentsListHeader">
+      <mat-expansion-panel-header class="messageHeaders" title="Toggle attachments list">
+	    <mat-panel-title>
+          <div id="messageHeaderSubject">List attachments</div>
+        </mat-panel-title>
+      </mat-expansion-panel-header>
+      <ng-container>
+        <mat-list>
+          <mat-list-item
+            *ngFor="let att of mailObj.attachments; let i=index"
+            (click)="openAttachment(att)">
+            <ng-container *ngIf="!att.internal || !(mailContentHTML && showHTML && SUPPORTS_IFRAME_SANDBOX)">
+              <ng-container *ngIf="att.thumbnailURL; else attachment_icon">
+                <img  matListAvatar
+                      [src]="att.thumbnailURL" />
+              </ng-container>
+              <ng-template #attachment_icon>
+                <mat-icon matListAvatar  svgIcon="{{attachmentIconFromContentType(att.contentType)}}"></mat-icon>
+              </ng-template>
+              <span>{{att.filename}}</span>
+            </ng-container>
+          </mat-list-item>
+        </mat-list>
+      </ng-container>
+    </mat-expansion-panel>
+    <mat-divider></mat-divider>
 
     <!-- Used when forwarding mail - do not delete -->
 
@@ -314,7 +340,7 @@
       </iframe>
     </div>
 
-    <mat-card *ngIf="showAttachments">
+    <mat-card #attachmentsSection *ngIf="showAttachments">
       <mat-card-title><mat-icon svgIcon="attachment"></mat-icon>Attachments</mat-card-title>
       <mat-card-content>
         <mat-grid-list [cols]="attachmentAreaCols">


### PR DESCRIPTION
Add an expandable list of attachments near the top of the email view. Needs some tweaking (please @kvviecien - how do we get the horizontal divider?)

Fixes: #883