### PR TITLE
FIX for #235 "Reply header" missing separators or spaces

### DIFF
--- a/src/app/compose/draftdesk.service.ts
+++ b/src/app/compose/draftdesk.service.ts
@@ -162,7 +162,7 @@ export class DraftFormModel {
             ret.html =
                 `<br />
                 <hr style="width: 100%" />
-                Forwarded message:<br />
+                ---------- Forwarded message ----------<br />
                 ${mailObj.origMailHeaderHTML}<br />
                 ${mailObj.sanitized_html}`;
             ret.useHTML = true;

--- a/src/app/compose/draftdesk.service.ts
+++ b/src/app/compose/draftdesk.service.ts
@@ -134,7 +134,7 @@ export class DraftFormModel {
             ret.html =
                 `<br /><div style="padding-left: 10px; border-left: black solid 1px">
                     <hr style="width: 100%" />
-                    ${mailObj.origMailHeaderHTML}<br />
+                    ${mailObj.origReplyHeaderHTML}<br />
                     ${mailObj.sanitized_html}
                 </div>`;
             ret.useHTML = true;

--- a/src/app/mailviewer/singlemailviewer.component.html
+++ b/src/app/mailviewer/singlemailviewer.component.html
@@ -241,17 +241,15 @@
     <!-- Used when forwarding mail - do not delete -->
 
     <span style="display: none" #forwardMessageHeader>
-      From: {{mailObj.from[0].name}} &lt;{{mailObj.from[0].address}}&gt;<br />
-      Time:{{mailObj.date | date:'yyyy-MM-dd HH:mm'}}<br />
-      To:
-      <ng-container *ngIf="mailObj.to">
-            <span *ngFor="let to of mailObj.to">{{to.name}} &lt;{{to.address}}&gt;</span>
-      </ng-container>
-      <br />
-      <ng-container *ngIf="mailObj.cc">
-        <span>Cc:</span><span *ngFor="let to of mailObj.cc">{{to.name}} &lt;{{to.address}}&gt;</span>
-      </ng-container>
-      {{mailObj.subject}}
+      From: {{mailObj.from[0].name}} &lt;{{mailObj.from[0].address}}&gt; <br />
+      Time: {{mailObj.date | date:'yyyy-MM-dd HH:mm'}} <br />
+      Subject: {{mailObj.subject}} <br />
+      <span *ngIf="mailObj.to">
+        To: <span *ngFor="let to of mailObj.to">{{to.name}} &lt;{{to.address}}&gt;</span>
+      </span> <br />
+      <span *ngIf="mailObj.cc">
+        Cc: <span *ngFor="let to of mailObj.cc">{{to.name}} &lt;{{to.address}}&gt;</span>
+      </span> <br />
     </span>
 
     <!---->

--- a/src/app/mailviewer/singlemailviewer.component.html
+++ b/src/app/mailviewer/singlemailviewer.component.html
@@ -252,6 +252,12 @@
       </span> <br />
     </span>
 
+    <!-- Used when replying to mail - do not delete -->
+
+    <span style="display: none" #replyMessageHeader>
+      On {{mailObj.date | date:'yyyy-MM-dd HH:mm'}}, {{mailObj.from[0].name}} &lt;{{mailObj.from[0].address}}&gt; wrote:
+    </span>
+
     <!---->
     <div class="htmlButtons" *ngIf="mailContentHTML && showHTMLDecision!=='alwaysshowhtml'"
       style="display: flex; font-size: 12px;">

--- a/src/app/mailviewer/singlemailviewer.component.ts
+++ b/src/app/mailviewer/singlemailviewer.component.ts
@@ -217,7 +217,7 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
     // messageHeaderHTML loads after message is loaded
     this.messageHeaderHTMLQuery.changes.subscribe((messageHeaderHTML: ElementRef) => {
       setTimeout(() => {
-          this.mailObj.origMailHeaderHTML = '<table>' + this.messageHeaderHTML.nativeElement.innerHTML + '</table>';
+          this.mailObj.origMailHeaderHTML = this.messageHeaderHTML.nativeElement.innerHTML;
           this.mailObj.origMailHeaderText = this.messageHeaderHTML.nativeElement.innerText;
       }, 0);
     });
@@ -410,7 +410,7 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
         setTimeout(() => {
           // If forwarding HTML copy mail header from the visible mail viewer header
           if (this.messageHeaderHTML) {
-            this.mailObj.origMailHeaderHTML = '<table>' + this.messageHeaderHTML.nativeElement.innerHTML + '</table>';
+            this.mailObj.origMailHeaderHTML = this.messageHeaderHTML.nativeElement.innerHTML;
             this.mailObj.origMailHeaderText = this.messageHeaderHTML.nativeElement.innerText;
           }
         }, 0

--- a/src/app/mailviewer/singlemailviewer.component.ts
+++ b/src/app/mailviewer/singlemailviewer.component.ts
@@ -97,6 +97,8 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
   @ViewChild('messageContents') messageContents: ElementRef;
   @ViewChild('htmliframe') htmliframe: ElementRef;
   @ViewChild('htmlToggleButton') htmlToggleButton: MatButtonToggle;
+  @ViewChild('replyMessageHeader') replyHeaderHTML: ElementRef;
+  @ViewChildren('replyMessageHeader') replyHeaderHTMLQuery: QueryList<ElementRef>;
   @ViewChild('forwardMessageHeader') messageHeaderHTML: ElementRef;
   @ViewChildren('forwardMessageHeader') messageHeaderHTMLQuery: QueryList<ElementRef>;
   @ViewChild(HorizResizerDirective) resizer: HorizResizerDirective;
@@ -219,6 +221,13 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
       setTimeout(() => {
           this.mailObj.origMailHeaderHTML = this.messageHeaderHTML.nativeElement.innerHTML;
           this.mailObj.origMailHeaderText = this.messageHeaderHTML.nativeElement.innerText;
+      }, 0);
+    });
+
+    this.replyHeaderHTMLQuery.changes.subscribe((replyHeaderHTML: ElementRef) => {
+      setTimeout(() => {
+          this.mailObj.origReplyHeaderHTML = this.replyHeaderHTML.nativeElement.innerHTML;
+          this.mailObj.origReplyHeaderText = this.replyHeaderHTML.nativeElement.innerText;
       }, 0);
     });
 


### PR DESCRIPTION
Fixes #235 

Created a reply header for HTML messages. It didn't exist, we used the same header for everything. Now it looks like this:
<kbd><img src="https://i.imgur.com/C3Awhb0.png"></kbd>

Improved header for forwarding HTML messages, looks like this:
<kbd><img src="https://i.imgur.com/nPpvREC.png"></kbd>