### PR TITLE
fix(your-subscriptions): Make subscriptions table usable on small screens

### DIFF
--- a/src/app/account-app/account-renewals.component.html
+++ b/src/app/account-app/account-renewals.component.html
@@ -16,12 +16,12 @@
             subscription.
         </p>
 
-        <table mat-table [dataSource]="active_products" [ngStyle]="{ width: '100%' }" multiTemplateDataRows>
-            <ng-container matColumnDef="name">
+        <table mat-table [dataSource]="active_products" [ngStyle]="{ width: '100%' }" multiTemplateDataRows class="renewalsTable">
+            <ng-container matColumnDef="renewal_name">
                 <th mat-header-cell *matHeaderCellDef> Name </th>
                 <td mat-cell *matCellDef="let p">
                     {{ p.name }}
-                    <strong *ngIf="p.pid === current_subscription"> – your current subscription </strong>
+                    <span *ngIf="p.pid === current_subscription"> – your current subscription </span>
                 </td>
             </ng-container>
             <ng-container matColumnDef="quantity">
@@ -60,13 +60,6 @@
                     </mat-error>
                 </td>
             </ng-container>
-            <ng-container matColumnDef="smallhints">
-                <th mat-header-cell *matHeaderCellDef> </th>
-                <td mat-cell *matCellDef="let p">
-                    <mat-icon *ngIf="p.expired" svgIcon="cancel"></mat-icon>
-                    <mat-icon *ngIf="p.expires_soon" svgIcon="alert"></mat-icon>
-                </td>
-            </ng-container>
             <ng-container matColumnDef="recur">
                 <th mat-header-cell *matHeaderCellDef> Auto Renew </th>
                 <td mat-cell *matCellDef="let p">
@@ -83,18 +76,9 @@
                     </app-account-renewals-renew-now-button-component>
                 </td>
             </ng-container>
-            <ng-container matColumnDef="expansionIndicator">
-                <th mat-header-cell *matHeaderCellDef> </th>
-                <td mat-cell *matCellDef="let p">
-                    <mat-icon *ngIf="p == expandedProduct; else expandedProduct" svgIcon="chevron-down"></mat-icon>
-                    <ng-template #notExpanded>
-                        <mat-icon svgIcon="chevron-right"></mat-icon>
-                    </ng-template>
-                </td>
-            </ng-container>
             <ng-container matColumnDef="expandedDetails">
                 <td mat-cell *matCellDef="let p" [attr.colspan]="displayedColumns.length">
-                    <div class="expandedDetails" [@detailExpand]="p == expandedProduct ? 'expanded' : 'collapsed'">
+                    <div class="expandedDetails">
                         <!-- yo dawg, I heard you like tables -->
                         <table class="detailsTable">
                             <tr>
@@ -122,9 +106,9 @@
                             <tr>
                                 <td> </td>
                                 <td>
-                                    <strong *ngIf="p.expired">
+                                    <span *ngIf="p.expired">
                                         (expired {{ p.active_until.fromNow() }})
-                                    </strong>
+                                    </span>
                                     <mat-error *ngIf="p.expires_soon" style="font-weight: bold;">
                                         (expires {{ p.active_until.fromNow() }})
                                     </mat-error>
@@ -151,7 +135,7 @@
             </ng-container>
             <tr mat-header-row *matHeaderRowDef="displayedColumns"
                 [ngStyle]="{ 'display': mobileQuery.matches ? 'none' : null }">
-            <tr mat-row *matRowDef="let row; columns: displayedColumns" class="regularRow" (click)="rowClicked(row)">
+            <tr mat-row *matRowDef="let row; columns: displayedColumns" class="regularRow">
             </tr>
             <tr mat-row *matRowDef="let row; columns: ['expandedDetails']" class="detailsRow"></tr>
         </table>

--- a/src/app/account-app/account-renewals.component.html
+++ b/src/app/account-app/account-renewals.component.html
@@ -8,14 +8,15 @@
 
     <ng-template #productsTable>
 
-      <p>
-	These are the subscriptions associated with your account.
-      </p>
-      <p>
-	You may renew any of them at any time, which will add the new period to the end of your current subscription.
-      </p>
+        <p>
+            These are the subscriptions associated with your account.
+        </p>
+        <p>
+            You may renew any of them at any time, which will add the new period to the end of your current
+            subscription.
+        </p>
 
-      <table mat-table [dataSource]="active_products" [ngStyle]="{ width: '100%' }" multiTemplateDataRows>
+        <table mat-table [dataSource]="active_products" [ngStyle]="{ width: '100%' }" multiTemplateDataRows>
             <ng-container matColumnDef="name">
                 <th mat-header-cell *matHeaderCellDef> Name </th>
                 <td mat-cell *matCellDef="let p">

--- a/src/app/account-app/account-renewals.component.ts
+++ b/src/app/account-app/account-renewals.component.ts
@@ -19,7 +19,6 @@
 
 import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { Router } from '@angular/router';
-import { trigger, state, style, transition, animate } from '@angular/animations';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 
@@ -31,8 +30,8 @@ import { SubAccountRenewalDialogComponent } from './sub-account-renewal-dialog';
 
 import * as moment from 'moment';
 
-const columnsDefault = ['name', 'quantity', 'active_from', 'active_until', 'hints', 'recur', 'renew'];
-const columnsMobile = ['expansionIndicator', 'name', 'smallhints'];
+const columnsDefault = ['renewal_name', 'quantity', 'active_from', 'active_until', 'hints', 'recur', 'renew'];
+const columnsMobile = ['renewal_name'];
 
 // TODO define it as an interface
 type ActiveProduct = any;
@@ -40,13 +39,6 @@ type ActiveProduct = any;
 @Component({
     selector: 'app-account-renewals-component',
     templateUrl: './account-renewals.component.html',
-    animations: [
-        trigger('detailExpand', [
-            state('collapsed', style({height: '0px', minHeight: '0'})),
-            state('expanded', style({height: '*'})),
-            transition('expanded <=> collapsed', animate('225ms cubic-bezier(0.4, 0.0, 0.2, 1)')),
-        ]),
-    ],
 })
 export class AccountRenewalsComponent {
     active_products: ActiveProduct[] = [];
@@ -116,12 +108,6 @@ export class AccountRenewalsComponent {
                 this.snackbar.open('Failed to determine domain for the product. Try again later or contact Runbox Support', 'Okay');
             },
         );
-    }
-
-    rowClicked(p: ActiveProduct) {
-        if (this.mobileQuery.matches) {
-            this.expandedProduct = this.expandedProduct === p ? null : p;
-        }
     }
 
     showSubsDialog(p: ActiveProduct) {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1103,14 +1103,35 @@ tr.regularRow td {
 div.expandedDetails {
     overflow: hidden;
     display: flex;
+    min-height: 0;
+    @media only screen and (min-width: 1025px) {
+        height: 0px;
+    }
 }
+
+    td.mat-cell.cdk-column-expandedDetails.mat-column-expandedDetails {
+        @media only screen and (max-width: 1024px) {
+            padding-bottom: 10px;
+        }
+        @media only screen and (max-width: 500px) {
+            padding: 0 10px 10px;
+        }
+    }
+    
+    td.mat-cell.cdk-column-renewal_name.mat-column-renewal_name {
+        @media only screen and (max-width: 1024px) {
+            background-color: #f5f5f5;
+            padding-top: 10px;
+            padding-bottom: 10px;
+            font-weight: bold;
+        }
+        @media only screen and (max-width: 500px) {
+            padding: 10px 13px 10px;
+        }
+    }
 
 table.detailsTable {
     width: 100%;
-}
-
-table.detailsTable tr td:first-of-type {
-    font-weight: bold;
 }
 
 table.detailsTable tr td:nth-of-type(2) {


### PR DESCRIPTION
- Removed the option to expand subscription details and made it static. It didn't work properly.
- Made table indentation smaller on mobile screens.
- Changed font to not bold in the details section.
- Added background color to the header of each product (used the color from the top bar where hamburger menu is).
- Made the product header font bold.
- Removed small icon indicators.

Fixes #1116 
Before: [One](https://i.imgur.com/NnDuax0.png), [Two](https://i.imgur.com/RESxigj.png)

Now:
<kbd><img src="https://i.imgur.com/sN99hqU.png" width="350"></kbd> . <kbd><img src="https://i.imgur.com/D7bFW9r.png" width="350"></kbd>