### PR TITLE
Fix default orientation when not set on narrow width

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -356,6 +356,7 @@
 <router-outlet (activate)="childRouteActivated(true)" (deactivate)="childRouteActivated(false)"></router-outlet>
 </mat-sidenav-container>
 
+<!-- This will cause an error in dev mode with the async pipe, should not be present however in production -->
 <div style="position: absolute; bottom: 2px; right: 2px; z-index: 10000;"
     *ngIf="progressService.httpRequestInProgress | async"
     >

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -259,7 +259,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
 
     this.sideMenuOpened = (mobileQuery.screenSize === ScreenSize.Desktop ? true : false);
     const storedMailViewerOrientationSettingMobile = localStorage.getItem(LOCAL_STORAGE_SETTING_MAILVIEWER_ON_RIGHT_SIDE);
-    
+
     if (mobileQuery.screenSize !== ScreenSize.Desktop) {
       if (storedMailViewerOrientationSettingMobile) {
         this.mailViewerOnRightSide = (storedMailViewerOrientationSettingMobile === 'false' ? false : true);
@@ -267,11 +267,11 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
         this.mailViewerOnRightSide = false;
       }
     }
-    
+
     mobileQuery.screenSizeChanged.subscribe(size => {
       this.sideMenuOpened = (size === ScreenSize.Desktop ? true : false);
       changeDetectorRef.detectChanges();
-      
+
       if (this.sideMenuOpened) {
         const storedMailViewerOrientationSetting = localStorage.getItem(LOCAL_STORAGE_SETTING_MAILVIEWER_ON_RIGHT_SIDE);
         this.mailViewerOnRightSide = !storedMailViewerOrientationSetting || storedMailViewerOrientationSetting === 'true';

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -51,7 +51,7 @@ import { from, Observable } from 'rxjs';
 import { xapianLoadedSubject } from './xapian/xapianwebloader';
 import { SwPush } from '@angular/service-worker';
 import { exportKeysFromJWK } from './webpush/vapid.tools';
-import { MobileQueryService } from './mobile-query.service';
+import { MobileQueryService, ScreenSize } from './mobile-query.service';
 import { ProgressService } from './http/progress.service';
 import { RMM } from './rmm';
 import { environment } from '../environments/environment';
@@ -257,11 +257,21 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
       this.resetColumns();
     });
 
-    this.sideMenuOpened = !mobileQuery.matches;
-    this.mobileQuery.changed.subscribe(onMobile => {
-      this.sideMenuOpened = !onMobile;
+    this.sideMenuOpened = (mobileQuery.screenSize === ScreenSize.Desktop ? true : false);
+    const storedMailViewerOrientationSettingMobile = localStorage.getItem(LOCAL_STORAGE_SETTING_MAILVIEWER_ON_RIGHT_SIDE);
+    
+    if (mobileQuery.screenSize !== ScreenSize.Desktop) {
+      if (storedMailViewerOrientationSettingMobile) {
+        this.mailViewerOnRightSide = (storedMailViewerOrientationSettingMobile === 'false' ? false : true);
+      } else {
+        this.mailViewerOnRightSide = false;
+      }
+    }
+    
+    mobileQuery.screenSizeChanged.subscribe(size => {
+      this.sideMenuOpened = (size === ScreenSize.Desktop ? true : false);
       changeDetectorRef.detectChanges();
-
+      
       if (this.sideMenuOpened) {
         const storedMailViewerOrientationSetting = localStorage.getItem(LOCAL_STORAGE_SETTING_MAILVIEWER_ON_RIGHT_SIDE);
         this.mailViewerOnRightSide = !storedMailViewerOrientationSetting || storedMailViewerOrientationSetting === 'true';
@@ -269,12 +279,13 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
         this.mailViewerRightSideWidth = '35%';
       }
 
-      if (onMobile) {
+      if (size !== ScreenSize.Desktop) {
         // #935 - Allow vertical preview also on mobile, and use full width
         this.mailViewerRightSideWidth = '100%';
         this.mailViewerOnRightSide = localStorage
               .getItem(LOCAL_STORAGE_SETTING_MAILVIEWER_ON_RIGHT_SIDE_IF_MOBILE) === `${true}`;
       }
+      console.log(this.mailViewerOnRightSide);
     });
 
     this.updateTime();


### PR DESCRIPTION
Fixes #1162 by checking width properly before setting if to put on the single mail view on side or bottom before it is set and saved in localStorage as before. Also uses the newer API for width check, making it one of the first to use it very demonstrably in app flow. Could be possible to tidy up to look nicer/more concise, but regardless it works from personal testing. Test with another platform such as Mac first ( @gtandersen ?) before merge though.