### PR TITLE
fix(payment-history): Remove whitespace in payment rows

### DIFF
--- a/src/app/account-app/account-transactions.component.html
+++ b/src/app/account-app/account-transactions.component.html
@@ -71,7 +71,7 @@
                                 <td> Receipt </td>
                                 <td>
                                     <button mat-button class="contentButton" routerLink="/account/receipt/{{ t.tid }}" class="contentButton">
-                                      Show receipt </button>
+                                    Show receipt </button>
                                 </td>
                             </tr>
                         </table>
@@ -83,7 +83,7 @@
             <tr mat-row *matRowDef="let row; columns: displayedColumns;" class="regularRow" (click)="rowClicked(row)">
             </tr>
 
-            <tr mat-row *matRowDef="let row; columns: ['expandedDetails']" class="detailsRow"></tr>
+            <tr mat-row *matRowDef="let row; columns: ['expandedDetails']" class="detailsRow" style="height: 0px"></tr>
         </table>
 
     </div>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1225,6 +1225,13 @@ tr.regularRow td {
     border-bottom-width: 0;
 }
 
+tr.regularRow td.mat-cell:first-of-type {
+    padding-left: 0px;
+}
+tr.regularRow td.mat-cell:last-of-type {
+    padding-right: 0px;
+}
+
 div.expandedDetails {
     overflow: hidden;
     display: flex;


### PR DESCRIPTION
Fixes #827 

Removes the vertical whitespace on the bottom of every row and reduces indentations on the sides on mobile.

Mobile: [before](https://i.imgur.com/u69guMI.png) -> [after](https://i.imgur.com/VgeG28O.png)
Desktop: [before](https://i.imgur.com/y4ODFAA.png) -> [after](https://i.imgur.com/GIwk41y.png)