### PR TITLE
fix(mailview): Remove deleted/moved messages before mesg list redraw

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -621,6 +621,8 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
       updateLocal: (msgIds: number[]) => {
         // Move to spam folder (delete from index), set spam flag
         if (params.is_spam) {
+          // remove from message display
+          this.canvastable.rows.removeMessages(messageIds);
           this.searchService.deleteMessages(msgIds);
           this.messagelistservice.moveMessages(msgIds, this.messagelistservice.spamFolderName, true);
         } else {
@@ -743,6 +745,8 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     this.messageActionsHandler.updateMessages({
       messageIds: messageIds,
       updateLocal: (msgIds: number[]) => {
+        // remove from message display
+        this.canvastable.rows.removeMessages(messageIds);
         this.searchService.deleteMessages(msgIds);
         if (this.selectedFolder === this.messagelistservice.trashFolderName) {
           this.messagelistservice.deleteTrashMessages(msgIds);
@@ -971,6 +975,8 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
         // moveMessagesToFolder cant see these cos not in index
         if (this.selectedFolder !== this.messagelistservice.spamFolderName &&
           this.selectedFolder !== this.messagelistservice.trashFolderName) {
+          // remove from current message display
+          this.canvastable.rows.removeMessages(messageIds);
           this.searchService.moveMessagesToFolder(msgIds, folderPath);
         }
         this.messagelistservice.moveMessages(msgIds, folderPath);
@@ -1003,6 +1009,8 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
             // moveMessagesToFolder cant see these cos not in index
             if (this.selectedFolder !== this.messagelistservice.spamFolderName &&
               this.selectedFolder !== this.messagelistservice.trashFolderName) {
+              // remove from current message display
+              this.canvastable.rows.removeMessages(messageIds);
               this.searchService.moveMessagesToFolder(msgIds, folderPath);
             }
             this.messagelistservice.moveMessages(msgIds, folderPath);

--- a/src/app/canvastable/canvastable.ts
+++ b/src/app/canvastable/canvastable.ts
@@ -1297,7 +1297,8 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
             (10 / this.fontheight) : 1)) - this.colpaddingleft); // We've already added colpaddingleft above
         }
       } else {
-        break;
+        // skipping rows we've removed while canvas was updating....
+        console.log('Skipped repainting a row as its data is missing, continuing anyway');
       }
       if (this.showContentTextPreview) {
         const contentTextPreviewColumn = this.columns

--- a/src/app/common/messagedisplay.ts
+++ b/src/app/common/messagedisplay.ts
@@ -95,6 +95,16 @@ export abstract class MessageDisplay {
     });
   }
 
+  public removeMessages(messageIds: number[]) {
+    const filteredRows = [];
+    this.rows.forEach((value, index) => {
+      if (!messageIds.includes(this.getRowMessageId(index))) {
+        filteredRows.push(value);
+      }
+    });
+    this.rows = filteredRows;
+  }
+
   public rowSelected(rowIndex: number, columnIndex: number, multiSelect?: boolean) {
     this.hasChanges = false;
     if (!this.rowExists(rowIndex)) {
@@ -153,7 +163,7 @@ export abstract class MessageDisplay {
   }
 
   rowExists(index: number): boolean {
-    return this.rows[index] ? true : false;
+    return this.rows[index] && this.getRowMessageId(index) > 0 ? true : false;
   }
 
   isBoldRow(index: number): boolean {

--- a/src/app/xapian/searchmessagedisplay.ts
+++ b/src/app/xapian/searchmessagedisplay.ts
@@ -40,7 +40,15 @@ export class SearchMessageDisplay extends MessageDisplay {
   }
 
   getRowMessageId(index: number): number {
-    return this.searchService.getMessageIdFromDocId(this.rows[index][0]);
+    let msgId = 0;
+    try {
+      msgId = this.searchService.getMessageIdFromDocId(this.rows[index][0]);
+    } catch (e) {
+      // This shouldnt happen, it means something changed the stored
+      // data without updating the messagedisplay rows.
+      console.log('Tried to lookup ' + index + ' in searchIndex, isnt there! ' + e);
+    }
+    return msgId;
   }
 
   filterBy(options: Map<String, any>) {

--- a/src/app/xapian/searchservice.ts
+++ b/src/app/xapian/searchservice.ts
@@ -1244,7 +1244,9 @@ export class SearchService {
       this.rmmapi.getMessageContents(messageId).subscribe((content) => {
         if (content['status'] === 'success') {
           this.messageTextCache.set(messageId, content.text.text);
-          this.messagelistservice.messagesById[messageId].plaintext = content.text.text;
+          if (this.messagelistservice.messagesById[messageId]) {
+            this.messagelistservice.messagesById[messageId].plaintext = content.text.text;
+          }
         }
       });
       return true;


### PR DESCRIPTION
Fixes #713 (hopefully!)

The logic for delete/move messages was not removing the messages from
the separate "message display" list of ids that the canvas uses to
paint its list from. A regular repaint was trying to redraw the list
using the old list of ids, fetching data from the index which had
already been deleted, this errored out, quitting in the middle of
redrawing the message list.

This fix:
1) ensures we remove the items from the message display first
2) ensures the repaint continues even if it cant find some of the
message data.