### PR TITLE
Cope with far future dates, folder separators always a "."

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -319,7 +319,8 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
 
     this.messagelistservice.messagesInViewSubject.subscribe(res => {
       this.messagelist = res;
-      if (!this.showingSearchResults && !this.showingWebSocketSearchResults) {
+      if (!this.showingSearchResults && !this.showingWebSocketSearchResults
+         && res && res.length > 0) {
         this.setMessageDisplay('messagelist', this.messagelist);
         this.canvastable.hasChanges = true;
       }
@@ -643,7 +644,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
       },
       updateRemote: (msgIds: number[]) => {
         const userFolders = this.messagelistservice.folderListSubject.value;
-        const currentFolderId = userFolders.find(fld => fld.folderName === this.messagelistservice.currentFolder).folderId;
+        const currentFolderId = userFolders.find(fld => fld.folderPath === this.messagelistservice.currentFolder).folderId;
         const res = this.rmmapi.trainSpam({is_spam: params.is_spam, from_folder_id: currentFolderId, messages: messageIds});
         res.subscribe(data => {
           if ( data.status === 'error' ) {
@@ -983,7 +984,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
       },
       updateRemote: (msgIds: number[]) => {
         const userFolders = this.messagelistservice.folderListSubject.value;
-        const currentFolderId = userFolders.find(fld => fld.folderName === this.messagelistservice.currentFolder).folderId;
+        const currentFolderId = userFolders.find(fld => fld.folderPath === this.messagelistservice.currentFolder).folderId;
         return this.rmmapi.moveToFolder(messageIds, folderId, currentFolderId);
       }
     });
@@ -1019,7 +1020,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
           },
           updateRemote: (msgIds: number[]) => {
             const userFolders = this.messagelistservice.folderListSubject.value;
-            const currentFolderId = userFolders.find(fld => fld.folderName === this.messagelistservice.currentFolder).folderId;
+            const currentFolderId = userFolders.find(fld => fld.folderPath === this.messagelistservice.currentFolder).folderId;
             return this.messagelistservice.rmmapi.moveToFolder(msgIds, folder, currentFolderId);
           }
         });
@@ -1093,10 +1094,6 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
         this.updateSearch(true);
         this.canvastable.scrollTop();
       }, 0);
-  }
-
-  convertFolderPath(str) {
-    return '/' + str.replace(/\./g, '/');
   }
 
   resetColumns() {

--- a/src/app/common/messageinfo.spec.ts
+++ b/src/app/common/messageinfo.spec.ts
@@ -73,4 +73,41 @@ describe('MessageInfo', () => {
         expect(removeCalled).toBeFalsy();
         expect(addCalled).toBeTruthy();
     });
+
+    it('test AddMessageToIndex with bad dates', () => {
+        const msg = new MessageInfo(2,
+            new Date(),
+            new Date(-1 * 3600 * 24 * 1000),
+            'Inbox',
+            false,
+            false,
+            false,
+            MailAddressInfo.parse('test@example.com'),
+            MailAddressInfo.parse('test2@example.com'),
+            [],
+            [],
+            'Test bad date subject',
+            'The bad date text',
+            50,
+            false
+            );
+
+        let addCalled = false;
+        const indexingtools = new IndexingTools({
+            addSortableEmailToXapianIndex: () => {
+                addCalled = true;
+            },
+        }  as any);
+
+        indexingtools.addMessageToIndex(msg);
+        expect(addCalled).toBeTruthy();
+
+        addCalled = false;
+        // msg.messageDate = new Date(2040,1,1);
+        msg.messageDate = new Date(2211667200000);
+        indexingtools.addMessageToIndex(msg);
+        expect(addCalled).toBeTruthy();
+
+    });
+
 });

--- a/src/app/folder/folderlist.component.spec.ts
+++ b/src/app/folder/folderlist.component.spec.ts
@@ -107,7 +107,7 @@ describe('FolderListComponent', () => {
         rearrangedFolders = await comp.folders.pipe(take(1)).toPromise();
         console.log(rearrangedFolders.map(f => f.folderId));
         expect(rearrangedFolders.map(f => f.folderId)).toEqual([1, 2, 3, 4, 6, 7, 5]);
-        expect(rearrangedFolders[6].folderPath).toBe('folder3/subsubfolder2');
+        expect(rearrangedFolders[6].folderPath).toBe('folder3.subsubfolder2');
         expect(rearrangedFolders.map(f => f.folderLevel)).toEqual([0, 0, 1, 2, 2, 0, 1]);
 
         console.log('move folder with id 7 above 1');
@@ -116,7 +116,7 @@ describe('FolderListComponent', () => {
         console.log(rearrangedFolders.map(f => f.folderId));
         expect(rearrangedFolders.map(f => f.folderId)).toEqual([7, 5, 1, 2, 3, 4, 6]);
         expect(rearrangedFolders[0].folderPath).toBe('folder3');
-        expect(rearrangedFolders[1].folderPath).toBe('folder3/subsubfolder2');
+        expect(rearrangedFolders[1].folderPath).toBe('folder3.subsubfolder2');
         expect(rearrangedFolders.map(f => f.folderLevel)).toEqual([0, 1, 0, 0, 1, 2, 2]);
 
         console.log('move folder with id 7 below 1');
@@ -125,7 +125,7 @@ describe('FolderListComponent', () => {
         console.log(rearrangedFolders.map(f => f.folderId));
         expect(rearrangedFolders.map(f => f.folderId)).toEqual([1, 7, 5, 2, 3, 4, 6]);
         expect(rearrangedFolders[1].folderPath).toBe('folder3');
-        expect(rearrangedFolders[2].folderPath).toBe('folder3/subsubfolder2');
+        expect(rearrangedFolders[2].folderPath).toBe('folder3.subsubfolder2');
         expect(rearrangedFolders.map(f => f.folderLevel)).toEqual([0, 0, 1, 0, 1, 2, 2]);
 
         console.log('move folder with id 4 above 7');
@@ -135,7 +135,7 @@ describe('FolderListComponent', () => {
         expect(rearrangedFolders.map(f => f.folderId)).toEqual([1, 4, 7, 5, 2, 3, 6]);
         expect(rearrangedFolders[1].folderPath).toBe('subsubfolder');
         expect(rearrangedFolders[2].folderPath).toBe('folder3');
-        expect(rearrangedFolders[3].folderPath).toBe('folder3/subsubfolder2');
+        expect(rearrangedFolders[3].folderPath).toBe('folder3.subsubfolder2');
         expect(rearrangedFolders.map(f => f.folderLevel)).toEqual([0, 0, 0, 1, 0, 1, 2]);
 
         console.log('move folder with id 5 below 7');

--- a/src/app/folder/folderlist.component.ts
+++ b/src/app/folder/folderlist.component.ts
@@ -365,8 +365,8 @@ export class FolderListComponent implements OnChanges {
         let destinationParent = '';
 
         const getParentFromFolderPath = folderPath => {
-            const pathArr = folderPath.split('/');
-            return pathArr.slice(0, pathArr.length - 1).join('/');
+            const pathArr = folderPath.split('.');
+            return pathArr.slice(0, pathArr.length - 1).join('.');
         };
 
         let moveCount = 1;
@@ -432,7 +432,7 @@ export class FolderListComponent implements OnChanges {
             const folder = folders[sourceIndex + n];
 
             folder.folderPath =
-                `${destinationParent}${destinationParent.length > 0 ? '/' : ''}` +
+                `${destinationParent}${destinationParent.length > 0 ? '.' : ''}` +
                 `${folder.folderPath.substring(sourceParent.length ? sourceParent.length + 1 : 0)}`;
             folder.folderLevel = folder.folderLevel - sourceFolderLevel + destinationFolderLevel;
         }

--- a/src/app/mailviewer/rmm7messageactions.ts
+++ b/src/app/mailviewer/rmm7messageactions.ts
@@ -79,7 +79,7 @@ export class RMM7MessageActions implements MessageActions {
                     },
                     updateRemote: (msgIds: number[]) => {
                         const userFolders = this.messageListService.folderListSubject.value;
-                        const currentFolderId = userFolders.find(fld => fld.folderName === this.messageListService.currentFolder).folderId;
+                        const currentFolderId = userFolders.find(fld => fld.folderPath === this.messageListService.currentFolder).folderId;
                         return this.messageListService.rmmapi.moveToFolder(msgIds, folder, currentFolderId);
                     }
                 });

--- a/src/app/messagetable/messagetablerow.ts
+++ b/src/app/messagetable/messagetablerow.ts
@@ -28,7 +28,7 @@ export class MessageTableRowTool {
         const timezoneadjustedJSONDateString = mailTime.toJSON();
 
         const currentDateString: string = new Date().toJSON().substr(0, datelen);
-        if (timezoneadjustedJSONDateString.substr(0, datelen) >= currentDateString) {
+        if (timezoneadjustedJSONDateString.substr(0, datelen) === currentDateString) {
             return timezoneadjustedJSONDateString.substr(datelen + 1, 5);
         } else {
             return timezoneadjustedJSONDateString.substr(0, datelen);

--- a/src/app/rmmapi/messagelist.service.ts
+++ b/src/app/rmmapi/messagelist.service.ts
@@ -89,13 +89,14 @@ export class MessageListService {
                 filter((msgFlagChange) => this.messagesById[msgFlagChange.id] ? true : false)
             ).subscribe((msgFlagChange) => {
                 if (msgFlagChange.seenFlag === true || msgFlagChange.seenFlag === false) {
-                    const msg = this.messagesById[msgFlagChange.id];
-                    const msgSeenFlag = msg.seenFlag;
+                    const mfc = this.messagesById[msgFlagChange.id];
+                    const msgSeenFlag = mfc.seenFlag;
                     this.messagesById[msgFlagChange.id].seenFlag = msgFlagChange.seenFlag;
                     if (msgSeenFlag !== this.messagesById[msgFlagChange.id].seenFlag) {
-                        this.folderCounts[msg.folder].unread = msgFlagChange.seenFlag === true
-                            ? this.folderCounts[msg.folder].unread - 1
-                            : this.folderCounts[msg.folder].unread + 1;
+                        const msgFolder = this.messagesById[mfc.id].folder;
+                        this.folderCounts[msgFolder].unread = msgFlagChange.seenFlag === true
+                            ? this.folderCounts[msgFolder].unread - 1
+                            : this.folderCounts[msgFolder].unread + 1;
                         // remove from cache so that it will be
                         // refetched with the new status when we next
                         // visit it
@@ -146,10 +147,9 @@ export class MessageListService {
                 let countsChanged = false;
                 for (const folder of folders) {
                     const path = folder.folderPath;
-                    const xapianPath = path.replace(/\//g, '.');
 
-                    if (xapianFolders.has(xapianPath)) {
-                        const res = searchservice.api.getFolderMessageCounts(xapianPath);
+                    if (xapianFolders.has(path)) {
+                        const res = searchservice.api.getFolderMessageCounts(path);
                         folderCounts[path] = new FolderMessageCountEntry(res[1], res[0]);
                     } else {
                         folderCounts[path] = FolderMessageCountEntry.of(folder);

--- a/src/app/rmmapi/rbwebmail.spec.ts
+++ b/src/app/rmmapi/rbwebmail.spec.ts
@@ -244,13 +244,13 @@ describe('RBWebMail', () => {
             (f: FolderListEntry) => f.folderPath === 'HTML'
         ).folderLevel).toBe(0);
         expect(folders.find(
-            (f: FolderListEntry) => f.folderPath === 'HTML/lalala'
+            (f: FolderListEntry) => f.folderPath === 'HTML.lalala'
         ).folderLevel).toBe(1);
         expect(folders.find(
-            (f: FolderListEntry) => f.folderPath === 'HTML/lalala/Tester'
+            (f: FolderListEntry) => f.folderPath === 'HTML.lalala.Tester'
         ).folderLevel).toBe(2);
         expect(folders.find(
-            (f: FolderListEntry) => f.folderPath === 'HTML/lalala/hohohohahaha/subtest'
+            (f: FolderListEntry) => f.folderPath === 'HTML.lalala.hohohohahaha.subtest'
         ).folderLevel).toBe(3);
     });
 
@@ -631,11 +631,11 @@ describe('RBWebMail', () => {
         expect(folders[0].folderId).toBe(3692896);
         expect(folders.length).toBe(22);
         expect(folders.findIndex(folder => folder.folderPath === 'HTML')).toBe(10);
-        expect(folders[11].folderPath).toBe('HTML/lalala');
+        expect(folders[11].folderPath).toBe('HTML.lalala');
         expect(folders[11].folderLevel).toBe(1);
-        expect(folders[12].folderPath).toBe('HTML/lalala/Tester');
+        expect(folders[12].folderPath).toBe('HTML.lalala.Tester');
         expect(folders[12].folderLevel).toBe(2);
-        expect(folders[15].folderPath).toBe('HTML/lalala/hohohohahaha/subtest');
+        expect(folders[15].folderPath).toBe('HTML.lalala.hohohohahaha.subtest');
         expect(folders[15].folderLevel).toBe(3);
     });
 });

--- a/src/app/rmmapi/rbwebmail.ts
+++ b/src/app/rmmapi/rbwebmail.ts
@@ -64,7 +64,6 @@ export class FolderListEntry {
         public folderName: string,
         public folderPath: string,
         public folderLevel: number) {
-        this.folderPath = folderPath.replace(/\./g, '/');
     }
 }
 
@@ -294,7 +293,7 @@ export class RunboxWebmailAPI {
                     '&sinceid=' + sinceid +
                     '&sincechangeddate=' + Math.floor(sincechangeddate / 1000) +
                     '&pagesize=' + pagesize + (skipContent ? '&skipcontent=1' : '') +
-                    (folder ? '&folder=' + folder.replace(/\//g, '.') : '') +
+                    (folder ? '&folder=' + folder : '') +
                     '&avoidcacheuniqueparam=' + new Date().getTime();
 
         return this.http.get(url, { responseType: 'text' }).pipe(

--- a/src/app/xapian/search-expression-builder/search-expression-builder.component.ts
+++ b/src/app/xapian/search-expression-builder/search-expression-builder.component.ts
@@ -79,7 +79,7 @@ export class SearchExpressionBuilderComponent implements OnInit {
     let folder: string;
 
     if (this.currentFolder) {
-      folder = this.currentFolder.replace(/\//g, '\.');
+      folder = this.currentFolder;
     } else {
       // For RMM6
       folder = document.getElementById('rmm_current_folder_name').innerText;

--- a/src/app/xapian/searchservice.ts
+++ b/src/app/xapian/searchservice.ts
@@ -269,6 +269,9 @@ export class SearchService {
 
             try {
               this.indexLastUpdateTime = parseInt(FS.readFile('indexLastUpdateTime', { encoding: 'utf8' }), 10);
+              if (this.indexLastUpdateTime > new Date().getTime()) {
+                this.indexLastUpdateTime = new Date().getTime();
+              }
             } catch (e) {
               if (!this.updateIndexLastUpdateTime()) {
                 // Corrupt xapian index - delete it and subscribe to changes (fallback to websocket search)
@@ -341,8 +344,12 @@ export class SearchService {
                       .match(/([0-9][0-9][0-9][0-9])([0-9][0-9])([0-9][0-9])/)
                       .map((val, ndx) => ndx > 0 ? parseInt(val, 10) : 0);
 
-        const latestSearchIndexDate = new Date(dateParts[1], dateParts[2] - 1, dateParts[3]);
+        let latestSearchIndexDate = new Date(dateParts[1], dateParts[2] - 1, dateParts[3]);
+        // In case we get emails with dates far in the future!
         console.log('Latest search index date is', latestSearchIndexDate);
+        if (latestSearchIndexDate > new Date()) {
+          latestSearchIndexDate = new Date();
+        }
         this.indexLastUpdateTime = latestSearchIndexDate.getTime();
       } catch (e) {
         console.log('Corrupt Xapian index', e);
@@ -1012,6 +1019,10 @@ export class SearchService {
               newLastUpdateTime = msginfo.messageDate.getTime();
             }
           });
+          // In case we get emails with dates far in the future!
+          if (newLastUpdateTime > new Date().getTime()) {
+            newLastUpdateTime = new Date().getTime();
+          }
           if (newLastUpdateTime > this.indexLastUpdateTime) {
             this.indexLastUpdateTime = newLastUpdateTime;
           }


### PR DESCRIPTION
1. Messages with future message dates would cause the index updating to stop (as it was then fetching "messages changed after 2038" for example) - fixed by ensuring message fetching compares change dates no later than the current time.

2. Sub-Folder paths were in some places stored/used with a "/" separator, and in some with a "." As "." is officially used, and we don't display the names (except for in the url when bookmarking a folder), this is changed to be "." everywhere. This was likely causing folder count errors (storing counts as "." path, but reading out as "/" path).

3. Fixed tests to correctly send message times in seconds, not milli seconds (they broke after implementing no1)
