### PR TITLE
fix(loading): Complete index load before displaying list from index

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -398,8 +398,10 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
   }
 
   ngAfterViewInit() {
-    this.searchService.searchResultsSubject.subscribe(() =>
-      this.updateSearch(true, true));
+    this.searchService.searchResultsSubject.subscribe(() => {
+      console.log('Redrawing after search results update');
+      this.updateSearch(true, true);
+    });
 
     this.searchService.noLocalIndexFoundSubject.subscribe(() => {
       this.messagelistservice.fetchFolderMessages();

--- a/src/app/xapian/searchservice.spec.ts
+++ b/src/app/xapian/searchservice.spec.ts
@@ -93,6 +93,10 @@ describe('SearchService', () => {
         }
     };
 
+    beforeAll(function() {
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = 999999;
+    });
+
     beforeEach((() => {
         TestBed.configureTestingModule({
           imports: [

--- a/src/app/xapian/searchservice.ts
+++ b/src/app/xapian/searchservice.ts
@@ -280,11 +280,11 @@ export class SearchService {
             this.localSearchActivated = true;
             this.initSubject.next(true);
 
-            FS.syncfs(true, () => {
+            FS.syncfs(true, async () => {
               console.log('Loading partitions');
               this.openStoredPartitions();
+              await this.updateIndexWithNewChanges();
               this.searchResultsSubject.next();
-              this.updateIndexWithNewChanges();
             });
 
 
@@ -1144,7 +1144,7 @@ export class SearchService {
                 tap(() => {
                   console.log(`Opening partition ${p.folder}`);
                   this.api.addFolderXapianIndex(`${this.partitionsdir}/${p.folder}`);
-                  this.searchResultsSubject.next();
+//                  this.searchResultsSubject.next();
                 }),
                 map(() => true)
               );
@@ -1159,9 +1159,10 @@ export class SearchService {
               );
           })
         ).pipe(
-          tap(() => {
+          tap(async () => {
             this.partitionDownloadProgress = null;
-            this.updateIndexWithNewChanges();
+            await this.updateIndexWithNewChanges();
+            this.searchResultsSubject.next();
           })
         );
     }


### PR DESCRIPTION
Previously, if indexing was on, we would load initial an message list
from the REST api, then start loading any previously stored index
files. The stored index file contents were then displayed (likely
older than the REST api contents), then we would fetch message updates
from the api, add those in, and update the display again.

This change removes the "display update" after stored index loading,
and before fetching new updates. Thus we continue to display the
latest set of messages at all times, while starting up.

Fixes #843