### PR TITLE
fix(loading): Only refresh message list after index loaded

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -82,7 +82,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
 
   lastSearchText = '';
   searchText = '';
-  dataReady: boolean;
+  dataReady = false;
 
   usewebsocketsearch = false;
 
@@ -315,7 +315,6 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     this.canvastable = this.canvastablecontainer.canvastable;
     this.canvastablecontainer.sortColumn = 2;
     this.canvastablecontainer.sortDescending = true;
-    this.resetColumns();
 
     this.messagelistservice.messagesInViewSubject.subscribe(res => {
       this.messagelist = res;
@@ -401,19 +400,12 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
   ngAfterViewInit() {
     this.searchService.searchResultsSubject.subscribe(() => {
       console.log('Redrawing after search results update');
-      this.updateSearch(true, true);
+      this.afterLoadIndex();
     });
 
     this.searchService.noLocalIndexFoundSubject.subscribe(() => {
       this.messagelistservice.fetchFolderMessages();
       this.promptLocalSearch();
-    });
-
-    this.searchService.initSubject.subscribe((res) => {
-      this.dataReady = false;
-      if (res) {
-        setTimeout(() => this.afterLoadIndex(), 0);
-      }
     });
 
     this.router.events.pipe(
@@ -931,7 +923,6 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
   public downloadIndexFromServer() {
     this.searchService.downloadIndexFromServer().subscribe((res) => {
       if (res) {
-        this.afterLoadIndex();
         this.searchService.downloadPartitions().subscribe();
       } else {
 

--- a/src/app/canvastable/canvastable.ts
+++ b/src/app/canvastable/canvastable.ts
@@ -580,7 +580,9 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
         }
         try {
           this.dopaint();
-          this.repaintDoneSubject.next();
+          if (this.rows) {
+            this.repaintDoneSubject.next();
+          }
         } catch (e) {
           console.log(e);
         }
@@ -778,7 +780,7 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
   }
 
   public autoAdjustColumnWidths(minwidth: number, tryFitScreenWidth = false) {
-    if (!this.canv) {
+    if (!this.canv || this._columns.length === 0) {
       return;
     }
 
@@ -911,9 +913,9 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
   private enforceScrollLimit() {
     if (this.topindex < 0) {
       this.topindex = 0;
-    } else if (this.rows.rowCount() < this.maxVisibleRows) {
+    } else if (this.rows && this.rows.rowCount() < this.maxVisibleRows) {
       this.topindex = 0;
-    } else if (this.topindex + this.maxVisibleRows > this.rows.rowCount()) {
+    } else if (this.rows && this.topindex + this.maxVisibleRows > this.rows.rowCount()) {
       this.topindex = this.rows.rowCount() - this.maxVisibleRows;
       // send max rows hit events (use to fetch more data)
       this.scrollLimitHit.next(this.rows.rowCount());
@@ -1057,7 +1059,7 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
       colx += col.width;
     }
 
-    if (this.rows.rowCount() < 1) {
+    if (!this.rows || this.rows.rowCount() < 1) {
       return;
     }
 

--- a/src/app/folder/folderlist.component.ts
+++ b/src/app/folder/folderlist.component.ts
@@ -146,7 +146,11 @@ export class FolderListComponent implements OnChanges {
     }
 
     ngOnChanges(): void {
-        this.folders.subscribe(folders => this.updateFolderTree(folders));
+      this.folders.subscribe(folders => {
+        if (folders.length > 0) {
+          this.updateFolderTree(folders);
+        }
+      });
     }
 
     private updateFolderTree(folders: FolderListEntry[]) {

--- a/src/app/rmmapi/messagelist.service.ts
+++ b/src/app/rmmapi/messagelist.service.ts
@@ -83,20 +83,21 @@ export class MessageListService {
             }))
             .subscribe((folders) => {
                 // Will fallback on the folder counters set above for folders not in the search index
-                this.refreshFolderCounts();
+                if (folders.length > 0 ) {
+                    this.refreshFolderCounts();
+                }
             });
         rmmapi.messageFlagChangeSubject.pipe(
                 filter((msgFlagChange) => this.messagesById[msgFlagChange.id] ? true : false)
             ).subscribe((msgFlagChange) => {
                 if (msgFlagChange.seenFlag === true || msgFlagChange.seenFlag === false) {
-                    const mfc = this.messagesById[msgFlagChange.id];
-                    const msgSeenFlag = mfc.seenFlag;
+                    const msg = this.messagesById[msgFlagChange.id];
+                    const msgSeenFlag = msg.seenFlag;
                     this.messagesById[msgFlagChange.id].seenFlag = msgFlagChange.seenFlag;
                     if (msgSeenFlag !== this.messagesById[msgFlagChange.id].seenFlag) {
-                        const msgFolder = this.messagesById[mfc.id].folder;
-                        this.folderCounts[msgFolder].unread = msgFlagChange.seenFlag === true
-                            ? this.folderCounts[msgFolder].unread - 1
-                            : this.folderCounts[msgFolder].unread + 1;
+                        this.folderCounts[msg.folder].unread = msgFlagChange.seenFlag === true
+                            ? this.folderCounts[msg.folder].unread - 1
+                            : this.folderCounts[msg.folder].unread + 1;
                         // remove from cache so that it will be
                         // refetched with the new status when we next
                         // visit it


### PR DESCRIPTION
2nd try - more places where we were refreshing the list before the
index was finished found and removed.

Add more robustness to canvastable when .rows not set yet.