### PR TITLE
Castaway/turn index verification back on

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -395,7 +395,12 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
 
         if (fragment !== this.fragment) {
           this.fragment = fragment;
-          this.jumpToFragment = true;
+          if (this.canvastable.rows) {
+            this.selectMessageFromFragment(this.fragment);
+            this.canvastable.jumpToOpenMessage();
+          } else {
+            this.jumpToFragment = true;
+          }
         }
       }
     );

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -133,6 +133,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
   canvastable: CanvasTableComponent;
 
   fragment: string;
+  jumpToFragment = false;
 
   messagelist: Array<MessageInfo> = [];
 
@@ -321,6 +322,11 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
       if (!this.showingSearchResults && !this.showingWebSocketSearchResults
          && res && res.length > 0) {
         this.setMessageDisplay('messagelist', this.messagelist);
+        if (this.jumpToFragment) {
+          this.selectMessageFromFragment(this.fragment);
+          this.canvastable.jumpToOpenMessage();
+          this.jumpToFragment = false;
+        }
         this.canvastable.hasChanges = true;
       }
     });
@@ -389,8 +395,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
 
         if (fragment !== this.fragment) {
           this.fragment = fragment;
-          this.selectMessageFromFragment(fragment);
-          this.canvastable.jumpToOpenMessage();
+          this.jumpToFragment = true;
         }
       }
     );
@@ -816,15 +821,19 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
   }
 
   public filterMessageDisplay() {
-    const options = new Map();
-    options.set('unreadOnly', this.unreadMessagesOnlyCheckbox);
-    options.set('searchText', this.searchText);
-    this.canvastable.rows.filterBy(options);
-    this.canvastable.hasChanges = true;
+    if (this.canvastable.rows) {
+      const options = new Map();
+      options.set('unreadOnly', this.unreadMessagesOnlyCheckbox);
+      options.set('searchText', this.searchText);
+      this.canvastable.rows.filterBy(options);
+      this.canvastable.hasChanges = true;
+    }
   }
 
   public clearSelection() {
-    this.canvastable.rows.clearSelection();
+    if (this.canvastable.rows) {
+      this.canvastable.rows.clearSelection();
+    }
     this.canvastable.hasChanges = true;
     this.showSelectOperations = false;
     this.showSelectMarkOpMenu = false;

--- a/src/app/xapian/searchservice.ts
+++ b/src/app/xapian/searchservice.ts
@@ -774,16 +774,15 @@ export class SearchService {
           const currentFolder = (await this.messagelistservice.folderListSubject.pipe(take(1)).toPromise())
                 .find(folder => folder.folderPath === this.messagelistservice.currentFolder);
           const folderPath = currentFolder.folderPath;
-          const xapianPath = folderPath.replace(/\//g, '.');
 
           // do this once per folder, and only if the folder is actually indexed
           if (
-              this.api.listFolders().find(f => f[0] === xapianPath) &&
-              this.folderCountDiscrepanciesCheckedCount[folderPath] === 0
+              this.api.listFolders().find(f => f[0] === folderPath) &&
+              !this.folderCountDiscrepanciesCheckedCount[folderPath]
           ) {
             this.folderCountDiscrepanciesCheckedCount[folderPath] = 1;
 
-            const [numberOfMessages, numberOfUnreadMessages] = this.api.getFolderMessageCounts(xapianPath);
+            const [numberOfMessages, numberOfUnreadMessages] = this.api.getFolderMessageCounts(folderPath);
             if (
                 numberOfMessages !== currentFolder.totalMessages ||
                 numberOfUnreadMessages !== currentFolder.newMessages

--- a/src/app/xapian/searchservice.ts
+++ b/src/app/xapian/searchservice.ts
@@ -1263,6 +1263,9 @@ export class SearchService {
           if (this.messagelistservice.messagesById[messageId]) {
             this.messagelistservice.messagesById[messageId].plaintext = content.text.text;
           }
+        } else {
+          // stop repeatedly looking up broken ones
+          this.messageTextCache.set(messageId, '');
         }
       });
       return true;

--- a/src/app/xapian/searchservice.ts
+++ b/src/app/xapian/searchservice.ts
@@ -844,6 +844,7 @@ export class SearchService {
 
         msginfos.forEach(msginfo => {
             const uniqueIdTerm = `Q${msginfo.id}`;
+            let msgIsTrashed = false;
             const docid = this.api.getDocIdFromUniqueIdTerm(uniqueIdTerm);
             if (
               docid === 0 && // document not found in the index
@@ -893,7 +894,9 @@ export class SearchService {
                     // Folder changed
                     const destinationFolder = folders.find(folder => folder.folderPath === msginfo.folder);
                     if (destinationFolder && (destinationFolder.folderType === 'spam' || destinationFolder.folderType === 'trash')) {
+                      console.log('Delete doc from index as now in Trash');
                       addSearchIndexDocumentUpdate(() => this.api.deleteDocumentByUniqueTerm(uniqueIdTerm));
+                      msgIsTrashed = true;
                     } else {
                       addSearchIndexDocumentUpdate(() => this.api.changeDocumentsFolder(uniqueIdTerm, msginfo.folder));
                     }
@@ -908,36 +911,38 @@ export class SearchService {
                 }
               });
 
-              if (msginfo.answeredFlag && !messageStatusInIndex.answered) {
-                addSearchIndexDocumentUpdate(() =>
-                  this.api.addTermToDocument(uniqueIdTerm, XAPIAN_TERM_ANSWERED));
-              } else if (!msginfo.answeredFlag && messageStatusInIndex.answered) {
-                addSearchIndexDocumentUpdate(() =>
-                  this.api.removeTermFromDocument(uniqueIdTerm, XAPIAN_TERM_ANSWERED));
-              }
+              if (!msgIsTrashed) {
+                if (msginfo.answeredFlag && !messageStatusInIndex.answered) {
+                  addSearchIndexDocumentUpdate(() =>
+                    this.api.addTermToDocument(uniqueIdTerm, XAPIAN_TERM_ANSWERED));
+                } else if (!msginfo.answeredFlag && messageStatusInIndex.answered) {
+                  addSearchIndexDocumentUpdate(() =>
+                    this.api.removeTermFromDocument(uniqueIdTerm, XAPIAN_TERM_ANSWERED));
+                }
 
-              if (msginfo.flaggedFlag && !messageStatusInIndex.flagged) {
-                addSearchIndexDocumentUpdate(() =>
-                  this.api.addTermToDocument(uniqueIdTerm, XAPIAN_TERM_FLAGGED));
-              } else if (!msginfo.flaggedFlag && messageStatusInIndex.flagged) {
-                addSearchIndexDocumentUpdate(() =>
-                  this.api.removeTermFromDocument(uniqueIdTerm, XAPIAN_TERM_FLAGGED));
-              }
+                if (msginfo.flaggedFlag && !messageStatusInIndex.flagged) {
+                  addSearchIndexDocumentUpdate(() =>
+                    this.api.addTermToDocument(uniqueIdTerm, XAPIAN_TERM_FLAGGED));
+                } else if (!msginfo.flaggedFlag && messageStatusInIndex.flagged) {
+                  addSearchIndexDocumentUpdate(() =>
+                    this.api.removeTermFromDocument(uniqueIdTerm, XAPIAN_TERM_FLAGGED));
+                }
 
-              if (msginfo.seenFlag && !messageStatusInIndex.seen) {
-                addSearchIndexDocumentUpdate(() =>
-                  this.api.addTermToDocument(uniqueIdTerm, XAPIAN_TERM_SEEN));
-              } else if (!msginfo.seenFlag && messageStatusInIndex.seen) {
-                addSearchIndexDocumentUpdate(() =>
-                  this.api.removeTermFromDocument(uniqueIdTerm, XAPIAN_TERM_SEEN));
-              }
+                if (msginfo.seenFlag && !messageStatusInIndex.seen) {
+                  addSearchIndexDocumentUpdate(() =>
+                    this.api.addTermToDocument(uniqueIdTerm, XAPIAN_TERM_SEEN));
+                } else if (!msginfo.seenFlag && messageStatusInIndex.seen) {
+                  addSearchIndexDocumentUpdate(() =>
+                    this.api.removeTermFromDocument(uniqueIdTerm, XAPIAN_TERM_SEEN));
+                }
 
-              if (msginfo.deletedFlag && !messageStatusInIndex.deleted) {
-                addSearchIndexDocumentUpdate(() =>
-                  this.api.addTermToDocument(uniqueIdTerm, XAPIAN_TERM_DELETED));
-              } else if (!msginfo.deletedFlag && messageStatusInIndex.deleted) {
-                addSearchIndexDocumentUpdate(() =>
-                  this.api.removeTermFromDocument(uniqueIdTerm, XAPIAN_TERM_DELETED));
+                if (msginfo.deletedFlag && !messageStatusInIndex.deleted) {
+                  addSearchIndexDocumentUpdate(() =>
+                    this.api.addTermToDocument(uniqueIdTerm, XAPIAN_TERM_DELETED));
+                } else if (!msginfo.deletedFlag && messageStatusInIndex.deleted) {
+                  addSearchIndexDocumentUpdate(() =>
+                    this.api.removeTermFromDocument(uniqueIdTerm, XAPIAN_TERM_DELETED));
+                }
               }
             }
           });


### PR DESCRIPTION
"verifymessages" a system to compare rest api + index folder counts at idle points (aka when no new index updates are happening), was broken in late 2020 - this fixes it. This will fix recent issues where the folder display counts are wildly incorrect until scrolling to the bottom of the folder. (papering over whatever the actual issue is, tho)

Also tweaked, a few bits that showed up in tests (like endlessly rerunning code to find the text of a message thats erroring on the backend)