### PR TITLE
Fix Size and Folder columns issues

### DIFF
--- a/src/app/common/messagelist.ts
+++ b/src/app/common/messagelist.ts
@@ -108,7 +108,6 @@ export class MessageList extends MessageDisplay {
         sortColumn: null,
         name: 'Size',
         rowWrapModeHidden: true,
-        textAlign: 1,
         getValue: (rowIndex: number): number => this.getRow(rowIndex).size,
         getFormattedValue: MessageTableRowTool.formatBytes,
       },

--- a/src/app/websocketsearch/websocketsearchmaillist.ts
+++ b/src/app/websocketsearch/websocketsearchmaillist.ts
@@ -82,7 +82,6 @@ export class WebSocketSearchMailList extends MessageDisplay {
                 sortColumn: null,
                 name: 'Size',
                 rowWrapModeHidden: true,
-                textAlign: 1,
                 getValue: (rowIndex: number): number => this.getRow(rowIndex).size,
                 getFormattedValue: MessageTableRowTool.formatBytes,
             }

--- a/src/app/xapian/searchmessagedisplay.ts
+++ b/src/app/xapian/searchmessagedisplay.ts
@@ -153,6 +153,17 @@ export class SearchMessageDisplay extends MessageDisplay {
             'This message is marked for deletion by an IMAP client' : null
         });
 
+        if (app.displayFolderColumn) {
+          columns.push({
+            sortColumn: null,
+            name: 'Folder',
+            rowWrapModeHidden: true,
+            getValue: (rowIndex): string => this.searchService.getDocData(this.getRowId(rowIndex)).folder.replace(/\./g, '/'),
+            width: 200
+          });
+        }
+
+      // Attachment flag column
       columns.push({
         sortColumn: null,
         name: '',
@@ -163,6 +174,8 @@ export class SearchMessageDisplay extends MessageDisplay {
         width: 35,
         getFormattedValue: (val) => val ? '\uE226' : ''
       });
+
+      // Answered flag column
       columns.push({
         sortColumn: null,
         name: '',
@@ -173,6 +186,8 @@ export class SearchMessageDisplay extends MessageDisplay {
         width: 35,
         getFormattedValue: (val) => val ? '\uE15E' : ''
       });
+
+      // Flagged flag column
       columns.push({
         sortColumn: null,
         name: '',
@@ -183,29 +198,6 @@ export class SearchMessageDisplay extends MessageDisplay {
         width: 35,
         getFormattedValue: (val) => val ? '\uE153' : ''
       });
-
-      if (app.displayFolderColumn) {
-        columns.push({
-          sortColumn: null,
-          name: 'Folder',
-          rowWrapModeHidden: true,
-          getValue: (rowIndex): string => this.searchService.getDocData(this.getRowId(rowIndex)).folder.replace(/\./g, '/'),
-          width: 200
-        });
-      }
-
-      // Empty col enables the final col to be resized (ugh..)
-      columns.push({
-        sortColumn: null,
-        name: '',
-        textAlign: 2,
-        rowWrapModeHidden: true,
-        font: '16px \'Material Icons\'',
-        getValue: (rowIndex) => '',
-        width: 0,
-        getFormattedValue: (val) => ''
-      });
-
     }
     return columns;
   }

--- a/src/app/xapian/searchmessagedisplay.ts
+++ b/src/app/xapian/searchmessagedisplay.ts
@@ -145,7 +145,6 @@ export class SearchMessageDisplay extends MessageDisplay {
           sortColumn: 3,
           name: 'Size',
           rowWrapModeHidden: true,
-          textAlign: 1,
           getValue: (rowIndex): string => {
             return  `${this.searchService.api.getNumericValue(this.getRowId(rowIndex), 3)}`;
           },


### PR DESCRIPTION
<img src="https://i.imgur.com/xtH62VM.png" width="819">

- Changed order of the Folder column to be able to freely resize the Size column. This way the flag columns aren't getting in the way.
- Fixed the Size column alignment. Now it's aligned to the left like everything else.

Close #1126 