### PR TITLE
fix(canvastable): Don't show column resizing cursor while in wrap mode

### DIFF
--- a/src/app/canvastable/canvastable.ts
+++ b/src/app/canvastable/canvastable.ts
@@ -704,7 +704,7 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
       selectedColIndex = -1;
     }
 
-    if (selectedColIndex !== this.visibleColumnSeparatorIndex) {
+    if (selectedColIndex !== this.visibleColumnSeparatorIndex && !this.rowWrapMode) {
       if (selectedColIndex > 0) {
         this.canv.style.cursor = 'col-resize';
       } else {


### PR DESCRIPTION
Fixes: #795 

Now this type of cursor will only show outside of wrap mode.