### PR TITLE
feature(mailviewer): Do not load external HTML images unless asked

### DIFF
--- a/src/app/mailviewer/singlemailviewer.component.html
+++ b/src/app/mailviewer/singlemailviewer.component.html
@@ -276,7 +276,7 @@
       On {{mailObj.date | date:'yyyy-MM-dd HH:mm'}}, {{mailObj.from[0].name}} &lt;{{mailObj.from[0].address}}&gt; wrote:
     </span>
 
-    <div class="htmlButtons" *ngIf="mailContentHTML && showHTMLDecision!=='alwaysshowhtml'">
+    <div class="htmlButtons" *ngIf="mailContentHTML">
       <span style="flex-grow: 1"></span>
       <span>
         <mat-checkbox color="warn"
@@ -285,6 +285,13 @@
           matTooltip="Toggle HTML view"
           >
           HTML
+        </mat-checkbox>
+        <mat-checkbox *ngIf="showHTML" color="warn"
+          (click)="toggleImages($event)"
+          [checked]="showImages"
+          matTooltip="Toggle HTML Images"
+          >
+          Show Images
         </mat-checkbox>
         <button mat-icon-button color="warn" (click)="showHTMLWarningDialog()"
           matTooltip="Only show HTML from trusted senders" style="margin-right: 5px">

--- a/src/app/mailviewer/singlemailviewer.component.ts
+++ b/src/app/mailviewer/singlemailviewer.component.ts
@@ -46,6 +46,7 @@ import { loadLocalMailParser } from './mailparser';
 import { RunboxContactSupportSnackBar } from '../common/contact-support-snackbar.service';
 
 const showHtmlDecisionKey = 'rmm7showhtmldecision';
+const showImagesDecisionKey = 'rmm7showimagesdecision';
 const resizerHeightKey = 'rmm7resizerheight';
 const resizerPercentageKey = 'rmm7resizerpercentage';
 
@@ -112,10 +113,14 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
   public err: any;
 
   public mailContentHTML: string = null;
+  public mailContentHTMLWithImages: string = null;
+  public mailContentHTMLWithoutImages: string = null;
   public fullMailDownloaded = false;
 
   public showHTMLDecision = 'dontask';
   public showHTML = false;
+  public showImagesDecision = 'never';
+  public showImages = false;
   public showAllHeaders = false;
 
   public SUPPORTS_IFRAME_SANDBOX = 'sandbox' in document.createElement('iframe');
@@ -184,6 +189,7 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
   public ngOnInit() {
     this.messageActionsHandler.mailViewerComponent = this;
     this.showHTMLDecision = localStorage.getItem(showHtmlDecisionKey);
+    this.showImagesDecision = localStorage.getItem(showImagesDecisionKey);
     // Update 2020-12, now preferring resizerPercentageKey
     this.previousHeight = parseInt(localStorage.getItem(resizerHeightKey), 10);
     const storedHeightPercentage  = parseInt(localStorage.getItem(resizerPercentageKey), 10);
@@ -303,6 +309,19 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
     }
   }
 
+  public toggleImages(event) {
+    event.preventDefault();
+
+    this.showImages = !this.showImages;
+    if (this.showImages) {
+      this.mailContentHTMLWithoutImages = this.mailContentHTML;
+      this.mailContentHTML = this.mailContentHTMLWithImages;
+    } else {
+      this.mailContentHTMLWithImages = this.mailContentHTML;
+      this.mailContentHTML = this.mailContentHTMLWithoutImages;
+    }
+  }
+
   public fetchMessageJSON() {
     // ProgressDialog.open(this.dialog);
 
@@ -339,6 +358,7 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
         res.date.setMinutes(res.date.getMinutes() - res.date.getTimezoneOffset());
 
         res.sanitized_html = this.generateAttachmentURLs(res.attachments, res.sanitized_html);
+        res.sanitized_html_with_images = this.generateAttachmentURLs(res.attachments, res.sanitized_html_with_images);
         res.visible_attachment_count = res.attachments.filter((att) => !att.internal).length;
 
 
@@ -347,8 +367,8 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
         if (res.text.html) {
           // Pre-sanitized, however we need to escape ampersands and
           // quotes for srcdoc, let angular do it:
-//          res.html = this.domSanitizer.sanitize(SecurityContext.SCRIPT, res.sanitized_html);
           res.html = this.domSanitizer.bypassSecurityTrustHtml(DOMPurify.sanitize(res.sanitized_html));
+          res.html_with_images = this.domSanitizer.bypassSecurityTrustHtml(DOMPurify.sanitize(res.sanitized_html_with_images));
         } else {
           res.html = null;
         }
@@ -401,6 +421,8 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
       .subscribe((res) => {
         if (res.html) {
           this.mailContentHTML = res.html;
+          this.mailContentHTMLWithoutImages = res.html;
+          this.mailContentHTMLWithImages = res.html_with_images;
           if (
             // res.has_sent_mail_to === '1' || // We have sent mail to this sender before, so let's trust the HTML and show it by default
             // SingleMailViewerComponent.rememberHTMLChosenForMessagesIds[this.messageId] ||
@@ -622,6 +644,7 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
       this.fullMailDownloaded = false;
       this._messageId = id;
       this.showHTML = false;
+      this.showImages = false;
       this.mailContentHTML = null;
 
       if (!id) {

--- a/src/app/rmmapi/messagecache.ts
+++ b/src/app/rmmapi/messagecache.ts
@@ -24,7 +24,7 @@ import { MessageContents } from './rbwebmail';
 @Injectable()
 export class MessageCache {
     db: Dexie;
-    message_version = 4;
+    message_version = 5;
 
     constructor() {
         try {


### PR DESCRIPTION
Not loading external image src URLs means the HTML mail view loads
faster, and we also do not load "tracking" images embedded in emails.

Currently this displays a "show images" checkbox (next to the HTML one), which defaults to off and cannot be set to "always". Ideas on defaults/implementation welcome. (Personally am tempted to make it an "always allow for this sender" rather than global on/off)

Fixes #31