### PR TITLE
Castaway/1234 incorrect flags

### DIFF
--- a/src/app/canvastable/canvastable.spec.ts
+++ b/src/app/canvastable/canvastable.spec.ts
@@ -1,5 +1,5 @@
 // --------- BEGIN RUNBOX LICENSE ---------
-// Copyright (C) 2016-2018 Runbox Solutions AS (runbox.com).
+// Copyright (C) 2016-2022 Runbox Solutions AS (runbox.com).
 // 
 // This file is part of Runbox 7.
 // 
@@ -40,12 +40,14 @@ describe('canvastable', () => {
         fixture.componentInstance.canvastable.columns = [
             {
                 name: 'Column1',
+                cacheKey: 'col1',
                 sortColumn: null,
                 getValue: (row) => row.col1,
                 width: 200
             },
             {
                 name: 'Column2',
+                cacheKey: 'col2',
                 sortColumn: null,
                 getValue: (row) => row.col2,
                 width: 200,

--- a/src/app/canvastable/canvastable.ts
+++ b/src/app/canvastable/canvastable.ts
@@ -68,16 +68,6 @@ export class FloatingTooltip {
   }
 }
 
-export class CanvasTableColumnSection {
-  constructor(
-    public columnSectionName: string,
-    public width: number,
-    public leftPos: number,
-    public backgroundColor: string) {
-
-  }
-}
-
 export namespace CanvasTable {
   export enum RowSelect {
     Visible = 'visible',
@@ -175,8 +165,6 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
     if (this._columns !== columns) {
       this.calculateColumnWidths(columns);
       this._columns = columns;
-      this.recalculateColumnSections();
-      this.calculateColumnFooterSums();
       this.hasSortColumns = columns.filter(col => col.sortColumn !== null).length > 0;
       this.hasChanges = true;    }
   }
@@ -217,8 +205,6 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
   public hasChanges: boolean;
 
   private formattedValueCache: { [key: string]: string; } = {};
-
-  public columnSections: CanvasTableColumnSection[] = [];
 
   public scrollLimitHit: BehaviorSubject<number> = new BehaviorSubject(0);
 
@@ -819,7 +805,6 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
       }
     }
 
-    this.recalculateColumnSections();
     this.hasChanges = true;
   }
 
@@ -847,7 +832,6 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
   public set rows(rows: MessageDisplay) {
     if (this._rows !== rows) {
       this._rows = rows;
-      this.calculateColumnFooterSums();
 
       this.hasChanges = true;
     }
@@ -865,39 +849,6 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
 
   public set showContentTextPreview(showContentTextPreview: boolean) {
     this._showContentTextPreview = showContentTextPreview;
-    this.hasChanges = true;
-  }
-
-  public calculateColumnFooterSums(): void {
-    this.columns.forEach((col) => {
-      if (col.footerSumReduce) {
-        col.footerText = col.getFormattedValue(
-          // FIXME: message display class
-          this.rows.rows.reduce((prev, row) => col.footerSumReduce(prev, col.getValue(row)), 0)
-        );
-      }
-    });
-  }
-
-  public recalculateColumnSections(): void {
-    let leftX = 0;
-    this.columnSections = this.columns.reduce((accumulated, current) => {
-      let ret;
-      if (accumulated.length === 0 ||
-        accumulated[accumulated.length - 1].columnSectionName !== current.columnSectionName) {
-
-        ret = accumulated.concat([
-          new CanvasTableColumnSection(current.columnSectionName,
-            current.width,
-            leftX,
-            current.backgroundColor)]);
-      } else if (accumulated.length > 0 && accumulated[accumulated.length - 1].columnSectionName === current.columnSectionName) {
-        accumulated[accumulated.length - 1].width += current.width;
-        ret = accumulated;
-      }
-      leftX += current.width;
-      return ret;
-    }, []);
     this.hasChanges = true;
   }
 

--- a/src/app/canvastable/canvastable.ts
+++ b/src/app/canvastable/canvastable.ts
@@ -1074,6 +1074,7 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
             this.formattedValueCache[formattedValueCacheKey] = formattedVal;
           } else {
             formattedVal = '' + val;
+            this.formattedValueCache[formattedValueCacheKey] = formattedVal;
           }
           if (this.rowWrapMode && col.rowWrapModeHidden) {
             continue;

--- a/src/app/canvastable/canvastable.ts
+++ b/src/app/canvastable/canvastable.ts
@@ -1,5 +1,5 @@
 // --------- BEGIN RUNBOX LICENSE ---------
-// Copyright (C) 2016-2018 Runbox Solutions AS (runbox.com).
+// Copyright (C) 2016-2022 Runbox Solutions AS (runbox.com).
 // 
 // This file is part of Runbox 7.
 // 
@@ -1066,7 +1066,7 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
             val = '';
           }
           let formattedVal: string;
-          const formattedValueCacheKey: string = colindex + ':' + val;
+          const formattedValueCacheKey: string = col.cacheKey + ':' + val;
           if (this.formattedValueCache[formattedValueCacheKey]) {
             formattedVal = this.formattedValueCache[formattedValueCacheKey];
           } else if (('' + val).length > 0 && col.getFormattedValue) {

--- a/src/app/canvastable/canvastablecolumn.ts
+++ b/src/app/canvastable/canvastablecolumn.ts
@@ -1,5 +1,5 @@
 // --------- BEGIN RUNBOX LICENSE ---------
-// Copyright (C) 2016-2020 Runbox Solutions AS (runbox.com).
+// Copyright (C) 2016-2022 Runbox Solutions AS (runbox.com).
 // 
 // This file is part of Runbox 7.
 // 
@@ -23,6 +23,8 @@
 
 export interface CanvasTableColumn {
   name: string;
+  cacheKey: string;
+
   footerText?: string;
 
   width?: number;

--- a/src/app/canvastable/canvastablecolumn.ts
+++ b/src/app/canvastable/canvastablecolumn.ts
@@ -23,7 +23,6 @@
 
 export interface CanvasTableColumn {
   name: string;
-  columnSectionName?: string;
   footerText?: string;
 
   width?: number;
@@ -33,7 +32,6 @@ export interface CanvasTableColumn {
   tooltipText?: string | ((rowobj: any) => string);
   draggable?: boolean;
   sortColumn: number;
-  excelCellAttributes?: any;
   rowWrapModeHidden?: boolean;
   rowWrapModeMuted?: boolean;
   rowWrapModeChipCounter?: boolean; // E.g. for displaying number of messages in conversation in a "chip"/"badge"
@@ -41,11 +39,8 @@ export interface CanvasTableColumn {
   textAlign?: number; // default = left, 1 = right, 2 = center
   getContentPreviewText?: (rowobj: any) => string;
 
-  compareValue?: (a: any, b: any) => number;
-  setValue?: (rowobj: any, val: any) => void;
   getValue(rowobj: any): any;
 
-  footerSumReduce?(prev: number, curr: number): number;
   getFormattedValue?(val: any): string;
 }
 

--- a/src/app/common/messagelist.ts
+++ b/src/app/common/messagelist.ts
@@ -86,7 +86,8 @@ export class MessageList extends MessageDisplay {
         cacheKey: 'date',
         sortColumn: null,
         rowWrapModeMuted: true,
-        getValue: (rowIndex: number): string => MessageTableRowTool.formatTimestamp(this.getRow(rowIndex).messageDate.toJSON()),
+        getValue: (rowIndex: number): string => this.getRow(rowIndex).messageDate.toJSON(),
+        getFormattedValue: (datestring) => MessageTableRowTool.formatTimestamp(datestring)
       },
       {
         name: app.selectedFolder === 'Sent' ? 'To' : 'From',

--- a/src/app/common/messagelist.ts
+++ b/src/app/common/messagelist.ts
@@ -1,5 +1,5 @@
 // --------- BEGIN RUNBOX LICENSE ---------
-// Copyright (C) 2016-2020 Runbox Solutions AS (runbox.com).
+// Copyright (C) 2016-2022 Runbox Solutions AS (runbox.com).
 // 
 // This file is part of Runbox 7.
 // 
@@ -75,6 +75,7 @@ export class MessageList extends MessageDisplay {
       {
         sortColumn: null,
         name: '',
+        cacheKey: 'selectbox',
         rowWrapModeHidden: false,
         getValue: (rowIndex: number): any => this.isSelectedRow(rowIndex),
         checkbox: true,
@@ -82,12 +83,14 @@ export class MessageList extends MessageDisplay {
       },
       {
         name: 'Date',
+        cacheKey: 'date',
         sortColumn: null,
         rowWrapModeMuted: true,
         getValue: (rowIndex: number): string => MessageTableRowTool.formatTimestamp(this.getRow(rowIndex).messageDate.toJSON()),
       },
       {
         name: app.selectedFolder === 'Sent' ? 'To' : 'From',
+        cacheKey: 'from',
         sortColumn: null,
         getValue: (rowIndex: number): any => app.selectedFolder === 'Sent'
           ? this.getToColumnValueForRow(rowIndex)
@@ -95,6 +98,7 @@ export class MessageList extends MessageDisplay {
       },
       {
         name: 'Subject',
+        cacheKey: 'subject',
         sortColumn: null,
         getValue: (rowIndex: number): string => this.getRow(rowIndex).subject,
         draggable: true,
@@ -107,6 +111,7 @@ export class MessageList extends MessageDisplay {
       {
         sortColumn: null,
         name: 'Size',
+        cacheKey: 'size',
         rowWrapModeHidden: true,
         getValue: (rowIndex: number): number => this.getRow(rowIndex).size,
         getFormattedValue: MessageTableRowTool.formatBytes,
@@ -114,29 +119,35 @@ export class MessageList extends MessageDisplay {
       {
         sortColumn: null,
         name: '',
+        cacheKey: 'attachment',
         textAlign: 2,
         rowWrapModeHidden: true,
         font: '16px \'Material Icons\'',
         getValue: (rowIndex: number): boolean => this.getRow(rowIndex).attachment,
-        getFormattedValue: (val) => val ? '\uE226' : ''
+        getFormattedValue: (val) => val ? '\uE226' : '',
+        tooltipText: 'Attachment'
       },
       {
         sortColumn: null,
         name: '',
+        cacheKey: 'answered',
         textAlign: 2,
         rowWrapModeHidden: true,
         font: '16px \'Material Icons\'',
         getValue: (rowIndex: number): boolean => this.getRow(rowIndex).answeredFlag,
-        getFormattedValue: (val) => val ? '\uE15E' : ''
+        getFormattedValue: (val) => val ? '\uE15E' : '',
+        tooltipText: 'Answered'
       },
       {
         sortColumn: null,
         name: '',
+        cacheKey: 'flagged',
         textAlign: 2,
         rowWrapModeHidden: true,
         font: '16px \'Material Icons\'',
         getValue: (rowIndex: number): boolean => this.getRow(rowIndex).flaggedFlag,
-        getFormattedValue: (val) => val ? '\uE153' : ''
+        getFormattedValue: (val) => val ? '\uE153' : '',
+        tooltipText: 'Flagged'
       }
     ];
 

--- a/src/app/websocketsearch/websocketsearchmaillist.ts
+++ b/src/app/websocketsearch/websocketsearchmaillist.ts
@@ -56,23 +56,27 @@ export class WebSocketSearchMailList extends MessageDisplay {
             {
                 sortColumn: null,
                 name: '',
+                cacheKey: 'selectbox',
                 rowWrapModeHidden: true,
-              getValue: (rowIndex: number): any => this.isSelectedRow(rowIndex),
+                getValue: (rowIndex: number): any => this.isSelectedRow(rowIndex),
                 checkbox: true,
             },
             {
                 name: 'Date',
+                cacheKey: 'date',
                 sortColumn: null,
                 rowWrapModeMuted: true,
-              getValue: (rowIndex: number): string => this.getRow(rowIndex).dateTime,
+                getValue: (rowIndex: number): string => this.getRow(rowIndex).dateTime,
             },
             {
                 name: 'From',
+                cacheKey: 'from',
                 sortColumn: null,
                 getValue: (rowIndex: number): string => this.getRow(rowIndex).fromName,
             },
             {
                 name: 'Subject',
+                cacheKey: 'subject',
                 sortColumn: null,
                 getValue: (rowIndex: number): string => this.getRow(rowIndex).subject,
                 draggable: true
@@ -81,6 +85,7 @@ export class WebSocketSearchMailList extends MessageDisplay {
             {
                 sortColumn: null,
                 name: 'Size',
+                cacheKey: 'size',
                 rowWrapModeHidden: true,
                 getValue: (rowIndex: number): number => this.getRow(rowIndex).size,
                 getFormattedValue: MessageTableRowTool.formatBytes,

--- a/src/app/xapian/searchmessagedisplay.ts
+++ b/src/app/xapian/searchmessagedisplay.ts
@@ -1,5 +1,5 @@
 // --------- BEGIN RUNBOX LICENSE ---------
-// Copyright (C) 2016-2020 Runbox Solutions AS (runbox.com).
+// Copyright (C) 2016-2022 Runbox Solutions AS (runbox.com).
 // 
 // This file is part of Runbox 7.
 // 
@@ -61,12 +61,14 @@ export class SearchMessageDisplay extends MessageDisplay {
       {
         sortColumn: null,
         name: '',
+        cacheKey: 'selectbox',
         rowWrapModeHidden: false,
         getValue: (rowIndex): any => this.isSelectedRow(rowIndex),
         checkbox: true,
       },
       {
         name: 'Date',
+        cacheKey: 'date',
         sortColumn: 2,
         rowWrapModeMuted : true,
         getValue: (rowIndex): string => {
@@ -76,11 +78,13 @@ export class SearchMessageDisplay extends MessageDisplay {
       },
       (app.selectedFolder.indexOf('Sent') === 0 && !app.displayFolderColumn) ? {
         name: 'To',
+        cacheKey: 'from',
         sortColumn: null,
         getValue: (rowIndex): string => this.searchService.getDocData(this.getRowId(rowIndex)).recipients.join(', '),
       } :
         {
           name: 'From',
+          cacheKey: 'from',
           sortColumn: 0,
           getValue: (rowIndex): string => {
             return this.searchService.getDocData(this.getRowId(rowIndex)).from;
@@ -88,6 +92,7 @@ export class SearchMessageDisplay extends MessageDisplay {
         },
       {
           name: 'Subject',
+          cacheKey: 'subject',
           sortColumn: 1,
           getValue: (rowIndex): string => {
             return this.searchService.getDocData(this.getRowId(rowIndex)).subject;
@@ -124,6 +129,7 @@ export class SearchMessageDisplay extends MessageDisplay {
       columns.push(
         {
           name: 'Count',
+          cacheKey: 'count',
           sortColumn: null,
           rowWrapModeChipCounter: true,
           getValue: (rowIndex): string => {
@@ -144,6 +150,7 @@ export class SearchMessageDisplay extends MessageDisplay {
         {
           sortColumn: 3,
           name: 'Size',
+          cacheKey: 'size',
           rowWrapModeHidden: true,
           getValue: (rowIndex): string => {
             return  `${this.searchService.api.getNumericValue(this.getRowId(rowIndex), 3)}`;
@@ -157,6 +164,7 @@ export class SearchMessageDisplay extends MessageDisplay {
           columns.push({
             sortColumn: null,
             name: 'Folder',
+            cacheKey: 'folder',
             rowWrapModeHidden: true,
             getValue: (rowIndex): string => this.searchService.getDocData(this.getRowId(rowIndex)).folder.replace(/\./g, '/'),
             width: 200
@@ -167,6 +175,7 @@ export class SearchMessageDisplay extends MessageDisplay {
       columns.push({
         sortColumn: null,
         name: '',
+        cacheKey: 'attachment',
         textAlign: 2,
         rowWrapModeHidden: true,
         font: '16px \'Material Icons\'',
@@ -179,6 +188,7 @@ export class SearchMessageDisplay extends MessageDisplay {
       columns.push({
         sortColumn: null,
         name: '',
+        cacheKey: 'answered',
         textAlign: 2,
         rowWrapModeHidden: true,
         font: '16px \'Material Icons\'',
@@ -191,6 +201,7 @@ export class SearchMessageDisplay extends MessageDisplay {
       columns.push({
         sortColumn: null,
         name: '',
+        cacheKey: 'flagged',
         textAlign: 2,
         rowWrapModeHidden: true,
         font: '16px \'Material Icons\'',

--- a/src/app/xapian/searchmessagedisplay.ts
+++ b/src/app/xapian/searchmessagedisplay.ts
@@ -64,17 +64,15 @@ export class SearchMessageDisplay extends MessageDisplay {
         cacheKey: 'selectbox',
         rowWrapModeHidden: false,
         getValue: (rowIndex): any => this.isSelectedRow(rowIndex),
-        checkbox: true,
+        checkbox: true
       },
       {
         name: 'Date',
         cacheKey: 'date',
         sortColumn: 2,
         rowWrapModeMuted : true,
-        getValue: (rowIndex): string => {
-          const datestring = this.searchService.api.getStringValue(this.getRowId(rowIndex), 2);
-          return MessageTableRowTool.formatTimestampFromStringWithoutSeparators(datestring);
-        },
+        getValue: (rowIndex): string => this.searchService.api.getStringValue(this.getRowId(rowIndex), 2),
+        getFormattedValue: (datestring) => MessageTableRowTool.formatTimestampFromStringWithoutSeparators(datestring)
       },
       (app.selectedFolder.indexOf('Sent') === 0 && !app.displayFolderColumn) ? {
         name: 'To',
@@ -166,7 +164,7 @@ export class SearchMessageDisplay extends MessageDisplay {
             name: 'Folder',
             cacheKey: 'folder',
             rowWrapModeHidden: true,
-            getValue: (rowIndex): string => this.searchService.getDocData(this.getRowId(rowIndex)).folder.replace(/\./g, '/'),
+            getValue: (rowIndex): string => this.searchService.getDocData(this.getRowId(rowIndex)).folder,
             width: 200
           });
         }


### PR DESCRIPTION
Fixed issue with answered/flagged flag display being incorrect (moving the folder column earlier made the indexes change, and we were caching values based on the col index) - now has a dedicated cacheKey per column type. As a bonus this means all from/to values are cached together.

Tidied up some code too, canvas columns had some bits we were not using at all.

Also added caching for values as well as formatted values (as the values also are result of effort/calculations, often)