### PR TITLE
fix(index): Ensure deleting index and resyncing doesnt stop updates

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -73,7 +73,7 @@
       </mat-list-item>
 
       <mat-list-item (click)="overview()" id="overviewButton" [ngClass]="{'selectedFolder' : overviewSelected}"
-        *ngIf="dataReady"
+        *ngIf="searchService.localSearchActivated"
       >
         <mat-icon mat-list-icon svgIcon="blur" class="folderIconStandard"></mat-icon>
         <p mat-line class="folderName">Overview</p>
@@ -86,7 +86,7 @@
         [ngStyle]="{ 'display': settingsService.settings.showPopularRecipients ? 'block' : 'none' }"
         (recipientClicked)="searchFor($event)"
     >
-        <mat-list-item *ngIf="!dataReady" (click)="downloadIndexFromServer()">
+        <mat-list-item *ngIf="!searchService.localSearchActivated" (click)="downloadIndexFromServer()">
             Synchronize index in order to use this feature
         </mat-list-item>
     </app-popular-recipients>
@@ -113,7 +113,7 @@
 
     <mat-divider></mat-divider>
 
-    <mat-nav-list *ngIf="dataReady">
+    <mat-nav-list *ngIf="searchService.localSearchActivated">
       <mat-list-item
         (click)="deleteLocalIndex()"
         matTooltip="Stop synchronization and remove index stored on your device">
@@ -122,7 +122,7 @@
       </mat-list-item>
     </mat-nav-list>
 
-    <mat-nav-list *ngIf="(xapianLoaded | async) && !dataReady && searchService.downloadProgress===null">
+    <mat-nav-list *ngIf="(xapianLoaded | async) && !searchService.localSearchActivated && searchService.downloadProgress===null">
       <mat-list-item (click)="downloadIndexFromServer()" matTooltip="Synchronize index with your device">
         <mat-icon  svgIcon="sync" mat-list-icon></mat-icon>
         <p mat-line>Synchronize index</p>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -769,24 +769,27 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
   }
 
   public deleteLocalIndex() {
-    this.usewebsocketsearch = true;
-    this.canvastable.topindex = 0;
-    this.canvastable.rows = null;
-    this.viewmode = 'messages';
-    this.dataReady = false;
-    this.showingSearchResults = false;
-    this.searchText = '';
+    if (this.searchService.localSearchActivated || this.dataReady) {
+      this.usewebsocketsearch = true;
+      this.canvastable.topindex = 0;
+      this.canvastable.rows = null;
+      this.viewmode = 'messages';
+      this.dataReady = false;
+      this.showingSearchResults = false;
+      this.searchText = '';
 
-    this.resetColumns();
+      this.resetColumns();
 
-    this.usage.report('local-index-deleted');
+      this.usage.report('local-index-deleted');
 
-    this.searchService.deleteLocalIndex().subscribe(() => {
-      this.messagelistservice.fetchFolderMessages();
+      this.searchService.deleteLocalIndex().subscribe(() => {
+        // this.messagelistservice.fetchFolderMessages();
+        this.setMessageDisplay('messagelist', this.messagelist);
 
-      this.updateTooltips();
-      this.snackBar.open('The index has been deleted from your device', 'Dismiss');
-    });
+        this.updateTooltips();
+        this.snackBar.open('The index has been deleted from your device', 'Dismiss');
+      });
+    }
   }
 
   public setMessageDisplay(displayType: string, ...args) {

--- a/src/app/xapian/searchservice.ts
+++ b/src/app/xapian/searchservice.ts
@@ -366,6 +366,10 @@ export class SearchService {
   }
 
   public deleteLocalIndex(): Observable<any> {
+    if (!this.localSearchActivated) {
+      console.log('Tried to delete local index when it is not present');
+      return;
+    }
     this.localSearchActivated = false;
 
     return new Observable((observer) => {
@@ -1046,6 +1050,15 @@ export class SearchService {
       }
     } catch (err) {
       console.error('Failed updating with new changes (will retry in 10 secs)', err);
+      if (this.messageProcessingInProgressSubject &&
+        this.messageProcessingInProgressSubject.isStopped) {
+        // stopped/errored because localSearchActivated changed
+        // during processing, reset
+        this.messageProcessingInProgressSubject = null;
+        this.pendingMessagesToProcess = null;
+        this.processMessageHistoryProgress = null;
+        this.processMessageIndex = 0;
+      }
     }
     this.currentIndexUpdateMessageIds.clear();
     this.notifyOnNewMessages = true;


### PR DESCRIPTION
Fixes: #1190

This *should* get rid of an issue where deleting the index while its syncing prevents its use again until a page refresh is done (while the user has no idea there is an issue).

It also changes how various parts of the app decide whether the index is present or not (we had 2 ways, trying to switch to only one) - so we should do some manual testing on this one.