### PR TITLE
feature(mailviewer): Store "show html images" per sender

### DIFF
--- a/src/app/contacts-app/contact.spec.ts
+++ b/src/app/contacts-app/contact.spec.ts
@@ -301,4 +301,14 @@ END:VCARD`);
         sut = Contact.fromVcard(null, sut.vcard());
         expect(sut.photo).toBe(uri);
     });
+
+    it('can create a SETTINGSONLY contact', () => {
+        const sut = new Contact({});
+        sut.kind = ContactKind.SETTINGSONLY;
+        sut.show_external_html = true;
+        expect(() => sut.vcard()).not.toThrow();
+
+        expect(sut.vcard()).toContain('X-SHOWEXTERNALHTML:true');
+        expect(sut.vcard()).toContain('settingsonly');
+    });
 });

--- a/src/app/contacts-app/contact.ts
+++ b/src/app/contacts-app/contact.ts
@@ -71,6 +71,7 @@ export enum ContactKind {
     GROUP      = 'group',
     ORG        = 'org',
     LOCATION   = 'location',
+    SETTINGSONLY = 'settingsonly',
 }
 
 // this hack allows us to pretend to have methods for enums
@@ -82,6 +83,7 @@ export namespace ContactKind {
             'group':    ContactKind.GROUP,
             'org':      ContactKind.ORG,
             'location': ContactKind.LOCATION,
+            'settingsonly': ContactKind.SETTINGSONLY,
         };
         return mapping[lowerName] || ContactKind.INVIDIDUAL;
     }
@@ -501,6 +503,18 @@ export class Contact {
         }
     }
 
+    get show_external_html(): boolean {
+        if (this.component.hasProperty('x-showexternalhtml')) {
+            return this.component.getFirstPropertyValue('x-showexternalhtml') === 'true';
+        }
+        return false;
+    }
+
+    set show_external_html(value: boolean) {
+        this.setPropertyValue('x-showexternalhtml', value.toString());
+    }
+
+
     toDict(): any {
         return {
             full_name:  this.full_name,
@@ -519,6 +533,7 @@ export class Contact {
             related:    this.related,
             members:    this.members.map(m => m.prop.toJSON()),
             photo:      this.photo,
+            'x-showexternalhtml': this.show_external_html,
         };
     }
 

--- a/src/app/contacts-app/contacts-app.component.ts
+++ b/src/app/contacts-app/contacts-app.component.ts
@@ -206,7 +206,8 @@ export class ContactsAppComponent {
 
     filterContacts(): void {
         this.shownContacts = this.contacts.filter(c => {
-            if (c.kind === ContactKind.GROUP) {
+            if (c.kind === ContactKind.GROUP
+              || c.kind === ContactKind.SETTINGSONLY) {
                 return false;
             }
 

--- a/src/app/contacts-app/contacts.service.ts
+++ b/src/app/contacts-app/contacts.service.ts
@@ -249,9 +249,16 @@ export class ContactsService implements OnDestroy {
         });
     }
 
-  saveContact(contact: Contact, syncNow: boolean = true): Promise<string> {
+  async saveContact(contact: Contact, syncNow: boolean = true): Promise<string> {
         this.activities.begin(Activity.SavingContact);
 
+        // In case we're editing a hidden contact (settings only)
+        const existing = await this.lookupContact(contact.primary_email());
+        if (existing) {
+            contact.id = existing.id;
+            contact.url = existing.url;
+            contact.show_external_html = existing.show_external_html;
+        }
         const promise = new Promise<string>((resolve, reject) => {
             if (contact.url) {
                 console.log('Modifying contact', contact.id);

--- a/src/app/mailviewer/singlemailviewer.component.html
+++ b/src/app/mailviewer/singlemailviewer.component.html
@@ -286,13 +286,16 @@
           >
           HTML
         </mat-checkbox>
-        <mat-checkbox *ngIf="showHTML" color="warn"
-          (click)="toggleImages($event)"
-          [checked]="showImages"
-          matTooltip="Toggle HTML Images"
+        <mat-checkbox *ngIf="showHTML && !showImages" color="warn"
+          [(ngModel)]="showImagesThisSender"
+          matTooltip="Always show external images for this sender"
           >
-          Show Images
+          Always for this sender
         </mat-checkbox>
+        <button *ngIf="showHTML && !showImages" mat-icon-button color="warn" (click)="showExternalImages($event)"
+          matTooltip="Show External Images" style="margin-right: 5px">
+          <mat-icon svgIcon="image"></mat-icon>
+        </button>
         <button mat-icon-button color="warn" (click)="showHTMLWarningDialog()"
           matTooltip="Only show HTML from trusted senders" style="margin-right: 5px">
           <mat-icon color="warn" svgIcon="alert"></mat-icon>

--- a/src/app/mailviewer/singlemailviewer.component.spec.ts
+++ b/src/app/mailviewer/singlemailviewer.component.spec.ts
@@ -44,12 +44,40 @@ import { MobileQueryService } from '../mobile-query.service';
 import { ProgressService } from '../http/progress.service';
 import { StorageService } from '../storage.service';
 import { RouterTestingModule } from '@angular/router/testing';
+import { Contact, ContactKind } from '../contacts-app/contact';
 import { ContactCardComponent } from './contactcard.component';
 import { MessageActions } from './messageactions';
 import { Observable, of } from 'rxjs';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MessageListService } from '../rmmapi/messagelist.service';
 import { AvatarBarComponent } from './avatar-bar.component';
+
+export class ContactsServiceMock {
+    public contactsSubject = of([
+        new Contact({
+            id: 5,
+            nick: 'test',
+            first_name: 'firstname',
+            last_name: 'lastname',
+            email: 'test@example.com'
+        }),
+        new Contact({
+            id: 6,
+            nick: 'fred@bloggs.com',
+            show_external_html: true,
+            kind: ContactKind.SETTINGSONLY,
+            emails: [{ types: ['home'], value: 'fred@bloggs.com' }]
+        })
+    ]);
+
+    lookupAvatar(_email: string) {
+        return Promise.resolve(null);
+    }
+
+    lookupContact(_email: string) {
+        return Promise.resolve(null);
+    }
+}
 
 describe('SingleMailViewerComponent', () => {
   let component: SingleMailViewerComponent;
@@ -117,14 +145,7 @@ describe('SingleMailViewerComponent', () => {
             }));
           }
         } },
-        { provide: ContactsService, useValue: {
-            lookupAvatar(_email: string) {
-              return Promise.resolve(null);
-            },
-            lookupContact(_email: string) {
-              return Promise.resolve(null);
-            }
-        } },
+        { provide: ContactsService, useClass: ContactsServiceMock },
         { provide: ProgressService, useValue: {} }
       ]
     })


### PR DESCRIPTION
The recent new feature to only show external images (et al) when
requested, implemented to speed up HTML display, is annoying some users.

This improvement allows users to save the "show external html images"
per sender (stored as a separate contact type in the dav contacts).

A new contact is only created if they do not already exist.

If/when the user later creates a contact with the same email as the
hidden type, we re-use the same contact and change it to the
"individual" type so that it will be displayed in Contacts.

Fixes #1249