### PR TITLE
feature(mailviewer): More control on how html/image settings are stored

### DIFF
--- a/e2e/cypress/integration/compose.ts
+++ b/e2e/cypress/integration/compose.ts
@@ -44,9 +44,9 @@ describe('Composing emails', () => {
         cy.wait(1000);
         cy.visit('/#Inbox:1');
         cy.get('single-mail-viewer').should('exist');
-        cy.get('mat-checkbox[mattooltip="Toggle HTML view"]').click();
+        cy.get('mat-radio-button[mattooltip="Toggle HTML view"]').click();
         cy.contains('Manually toggle HTML').click();
-        cy.get('mat-checkbox[mattooltip="Toggle HTML view"] input').should('be.checked');
+        cy.get('mat-radio-button[mattooltip="Toggle HTML view"] input').should('be.checked');
         cy.get('button[mattooltip="Reply"]').click();
         // we assume that this is the tinymce frame
         cy.get('iframe').should('exist');

--- a/src/app/contacts-app/contact.ts
+++ b/src/app/contacts-app/contact.ts
@@ -503,6 +503,7 @@ export class Contact {
         }
     }
 
+    // Flag for "always show external links/images from this sender
     get show_external_html(): boolean {
         if (this.component.hasProperty('x-showexternalhtml')) {
             return this.component.getFirstPropertyValue('x-showexternalhtml') === 'true';
@@ -514,6 +515,17 @@ export class Contact {
         this.setPropertyValue('x-showexternalhtml', value.toString());
     }
 
+    // Flag for "always show html content from this sender
+    get show_html(): boolean {
+        if (this.component.hasProperty('x-showhtml')) {
+            return this.component.getFirstPropertyValue('x-showhtml') === 'true';
+        }
+        return false;
+    }
+
+    set show_html(value: boolean) {
+        this.setPropertyValue('x-showhtml', value.toString());
+    }
 
     toDict(): any {
         return {

--- a/src/app/contacts-app/contacts.service.ts
+++ b/src/app/contacts-app/contacts.service.ts
@@ -310,6 +310,20 @@ export class ContactsService implements OnDestroy {
         ).then(() => this.reload());
     }
 
+    async findOrUpdateContact(email, newKind, properties: any) {
+        let contact = await this.lookupContact(email);
+        if (!contact) {
+            contact = new Contact({ email: email });
+            contact.kind = newKind;
+        }
+        for (const key in properties) {
+            if (properties[key] !== null && properties[key] !== '') {
+                contact[key] = properties[key];
+            }
+        }
+        this.saveContact(contact);
+    }
+
     // returns an URL or null if no avatar is available
     async lookupAvatar(email: string): Promise<string> {
         if (this.settingsService.settings.avatars === AppSettings.AvatarSource.NONE) {

--- a/src/app/dialog/htmlconfirm.dialog.ts
+++ b/src/app/dialog/htmlconfirm.dialog.ts
@@ -1,0 +1,41 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2022 Runbox Solutions AS (runbox.com).
+// 
+// This file is part of Runbox 7.
+// 
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+// 
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { Component } from '@angular/core';
+import { MatDialogRef } from '@angular/material/dialog';
+
+@Component({
+  template: `
+      <h3 mat-dialog-title>Really show HTML version?</h3>
+      <mat-dialog-content>
+          <p>Showing HTML formatted messages may send tracking information to the sender,
+          and may also expose you to security threats.
+	  You should only show the HTML version if you trust the sender.</p>
+
+          <p><button mat-raised-button (click)="dialogRef.close('dontask')">Manually toggle HTML</button></p>
+          <p><button mat-raised-button (click)="dialogRef.close('alwaysshowhtml')">Always show HTML if available</button></p>
+
+      </mat-dialog-content>
+  `
+})
+export class ShowHTMLDialogComponent {
+  constructor(public dialogRef: MatDialogRef<ShowHTMLDialogComponent>) {
+
+  }
+}

--- a/src/app/mailviewer/mailviewer.module.ts
+++ b/src/app/mailviewer/mailviewer.module.ts
@@ -33,7 +33,9 @@ import { MatRadioModule } from '@angular/material/radio';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { FormsModule } from '@angular/forms';
-import { SingleMailViewerComponent, ShowHTMLDialogComponent } from './singlemailviewer.component';
+import { SingleMailViewerComponent } from './singlemailviewer.component';
+import { ShowHTMLDialogComponent } from '../dialog/htmlconfirm.dialog';
+// import { ShowImagesDialogComponent } from '../dialog/imagesconfirm.dialog';
 import { ResizerModule } from '../directives/resizer.module';
 import { AvatarBarComponent } from './avatar-bar.component';
 import { ContactCardComponent } from './contactcard.component';
@@ -68,7 +70,8 @@ export { SingleMailViewerComponent } from './singlemailviewer.component';
         ShowHTMLDialogComponent
     ],
     entryComponents: [
-        ShowHTMLDialogComponent
+        ShowHTMLDialogComponent,
+//        ShowImagesDialogComponent,
     ]
 })
 export class MailViewerModule {

--- a/src/app/mailviewer/singlemailviewer.component.html
+++ b/src/app/mailviewer/singlemailviewer.component.html
@@ -79,11 +79,29 @@
           <mat-radio-group
             style="display: inline-flex; flex-direction: column"
             [(ngModel)]="showHTMLDecision" (change)="saveShowHTMLDecision()">
-              <mat-radio-button class="menuradiobutton" value="dontask">
+            <mat-radio-button
+              class="menuradiobutton"
+              value="dontask"
+              matTooltip="Toggle Plain Text view"
+              >
                 Toggle HTML
               </mat-radio-button>
-              <mat-radio-button class="menuradiobutton" value="alwaysshowhtml">
+            <mat-radio-button
+              class="menuradiobutton"
+              value="alwaysshowhtml"
+              matTooltip="Toggle HTML view"
+              >
                 Always show HTML
+              </mat-radio-button>
+          </mat-radio-group>
+          <mat-radio-group
+            style="display: inline-flex; flex-direction: column"
+            [(ngModel)]="showImagesDecision" (change)="saveShowImagesDecision()">
+              <mat-radio-button class="menuradiobutton" value="dontask">
+                Toggle Images
+              </mat-radio-button>
+              <mat-radio-button class="menuradiobutton" value="alwaysshowimages">
+                Always show Images
               </mat-radio-button>
           </mat-radio-group>
       </mat-menu>
@@ -279,27 +297,40 @@
     <div class="htmlButtons" *ngIf="mailContentHTML">
       <span style="flex-grow: 1"></span>
       <span>
-        <mat-checkbox color="warn"
+        <mat-radio-group
+          aria-label="Toggle Plain/HTML view"
+          matTooltip="Toggle Plain/HTML view"
+          [value]="showHTML ? 'HTML' : 'Plain'"
+          >
+        <mat-radio-button
           (click)="toggleHtml($event)"
-          [checked]="showHTML"
-          matTooltip="Toggle HTML view"
+          value="Plain"
+          >
+          Plain
+        </mat-radio-button>
+        <mat-radio-button
+          (click)="toggleHtml($event)"
+          value="HTML"
           >
           HTML
-        </mat-checkbox>
-        <mat-checkbox *ngIf="showHTML && !showImages" color="warn"
-          [(ngModel)]="showImagesThisSender"
-          matTooltip="Always show external images for this sender"
+        </mat-radio-button>
+        </mat-radio-group>
+        <mat-checkbox *ngIf="showHTML"
+          (click)="showExternalImages($event)"
+          [checked]="showImages"
+          matTooltip="Show external images"
           >
-          Always for this sender
+          With Images
         </mat-checkbox>
-        <button *ngIf="showHTML && !showImages" mat-icon-button color="warn" (click)="showExternalImages($event)"
-          matTooltip="Show External Images" style="margin-right: 5px">
-          <mat-icon svgIcon="image"></mat-icon>
+        <button *ngIf="showHTML" mat-stroked-button
+          (click)="saveDecisionGlobal($event)">
+          Always
         </button>
-        <button mat-icon-button color="warn" (click)="showHTMLWarningDialog()"
-          matTooltip="Only show HTML from trusted senders" style="margin-right: 5px">
-          <mat-icon color="warn" svgIcon="alert"></mat-icon>
+        <button *ngIf="showHTML" mat-stroked-button
+          (click)="saveDecisionForThisSender($event)">
+          For This Sender
         </button>
+        <mat-icon color="warn" svgIcon="alert"></mat-icon>
       </span>
     </div>
 


### PR DESCRIPTION
Attempt #2: Allow choice of storing HTML Always/Per sender/with/without images

Fixes #1249