### PR TITLE
fix(mailviewer): Output mail load error message strings

### DIFF
--- a/backend-proxy-mock.conf.js
+++ b/backend-proxy-mock.conf.js
@@ -4,7 +4,10 @@ const PROXY_CONFIG = [
         context: [
             "/rest", "/LOGOUT", "/mail", "/ajax", "/app", "/_ics"
         ],
-        "target": 'http://localhost:15000'
+        "target": 'http://localhost:15000',
+        headers: {
+            "Connection": "keep-alive"
+        },
     },
     {
         context: ["/_js", "/_img", "/_css"],

--- a/e2e/cypress/integration/mailviewer.ts
+++ b/e2e/cypress/integration/mailviewer.ts
@@ -12,23 +12,23 @@ describe('Interacting with mailviewer', () => {
     });
 
     it('Loading an email with loading errors displays an error', () => {
-        cy.intercept('/rest/v1/email/14').as('get14');
-        cy.visit('/');
-        cy.wait('@get14', {'timeout':10000});
+        // cy.intercept('/rest/v1/email/14').as('get14');
+        // cy.visit('/');
+        // cy.wait('@get14', {'timeout':10000});
         cy.visit('/#Inbox:14');
 
         cy.get('.support-snackbar').contains('Email content missing');
     });
 
     it('can open an email and go back and forth in browser history', () => {
-        cy.intercept('/rest/v1/email/11').as('get11');
-        cy.visit('/');
+        // cy.intercept('/rest/v1/email/11').as('get11');
+        cy.visit('/#Inbox:11');
 
-        cy.wait('@get11', {'timeout':10000});
-        canvas().click(400, 300);
+        // cy.wait('@get11', {'timeout':10000});
+        // canvas().click(400, 300);
 
         cy.hash().should('equal', '#Inbox:11');
-        cy.go('back');
+        cy.go(-1);
         cy.hash().should('not.contain', 'Inbox:11');
         /* TODO: apparently forward broke at some point
          * in headless mode. Works normally in a proper browser
@@ -40,9 +40,9 @@ describe('Interacting with mailviewer', () => {
     });
 
     it('can reply to an email with no "To"', () => {
-        cy.intercept('/rest/v1/email/11').as('get11');
+        // cy.intercept('/rest/v1/email/11').as('get11');
         cy.visit('/#Inbox:11')
-        cy.wait('@get11', {'timeout':10000});
+        // cy.wait('@get11', {'timeout':10000});
 
         cy.get('button[mattooltip="Reply"]').click();
         cy.location().should((loc) => {
@@ -53,9 +53,9 @@ describe('Interacting with mailviewer', () => {
     });
 
     it('can forward an email with no "To"', () => {
-        cy.intercept('/rest/v1/email/11').as('get11');
+        // cy.intercept('/rest/v1/email/11').as('get11');
         cy.visit('/');
-        cy.wait('@get11', {'timeout':10000});
+        // cy.wait('@get11', {'timeout':10000});
         cy.visit('/#Inbox:11');
 
         cy.get('button[mattooltip="Forward"]').click();
@@ -67,9 +67,9 @@ describe('Interacting with mailviewer', () => {
     });
 
     it('can reply to an email with no "To" or "Subject"', () => {
-        cy.intercept('/rest/v1/email/13').as('get13');
+        // cy.intercept('/rest/v1/email/13').as('get13');
         cy.visit('/');
-        cy.wait('@get13', {'timeout':10000});
+        // cy.wait('@get13', {'timeout':10000});
         cy.visit('/#Inbox:13');
 
         cy.get('button[mattooltip="Reply"]').click();
@@ -81,9 +81,9 @@ describe('Interacting with mailviewer', () => {
     });
 
     it('can forward an email with no "To" or "Subject"', () => {
-        cy.intercept('/rest/v1/email/13').as('get13');
+        // cy.intercept('/rest/v1/email/13').as('get13');
         cy.visit('/');
-        cy.wait('@get13', {'timeout':10000});
+        // cy.wait('@get13', {'timeout':10000});
         cy.visit('/#Inbox:13');
 
         cy.get('button[mattooltip="Forward"]').click();
@@ -95,9 +95,9 @@ describe('Interacting with mailviewer', () => {
     });
 
     it('Vertical to horizontal mode exposes full height button', () => {
-        cy.intercept('/rest/v1/email/11').as('get11');
+        // cy.intercept('/rest/v1/email/11').as('get11');
         cy.visit('/');
-        cy.wait('@get11', {'timeout':10000});
+        // cy.wait('@get11', {'timeout':10000});
         cy.visit('/#Inbox:11');
 
         // Make sure we're in vertical mode
@@ -107,9 +107,9 @@ describe('Interacting with mailviewer', () => {
     });
 
     it('Changing viewpane height is stored', () => {
-        cy.intercept('/rest/v1/email/11').as('get11');
+        // cy.intercept('/rest/v1/email/11').as('get11');
         cy.visit('/');
-        cy.wait('@get11', {'timeout':10000});
+        // cy.wait('@get11', {'timeout':10000});
         cy.visit('/#Inbox:11');
 
         // Make sure we're in horizontal mode
@@ -123,9 +123,9 @@ describe('Interacting with mailviewer', () => {
     });
 
     it('Half height reduces stored pane height', () => {
-        cy.intercept('/rest/v1/email/11').as('get11');
+        // cy.intercept('/rest/v1/email/11').as('get11');
         cy.visit('/');
-        cy.wait('@get11', {'timeout':10000});
+        // cy.wait('@get11', {'timeout':10000});
         cy.visit('/#Inbox:11');
 
         // Make sure we're in horizontal mode
@@ -150,9 +150,9 @@ describe('Interacting with mailviewer', () => {
     });
 
     it('Revisit open email in horizontal mode loads it', () => {
-        cy.intercept('/rest/v1/email/11').as('get11');
+        // cy.intercept('/rest/v1/email/11').as('get11');
         cy.visit('/');
-        cy.wait('@get11', {'timeout':10000});
+        // cy.wait('@get11', {'timeout':10000});
         cy.visit('/#Inbox:11');
 
         // Switch to horizontal mode
@@ -165,9 +165,9 @@ describe('Interacting with mailviewer', () => {
     });
 
     it('Can go out of mailviewer and back and still see our email', () => {
-        cy.intercept('/rest/v1/email/12').as('get12');
+        // cy.intercept('/rest/v1/email/12').as('get12');
         cy.visit('/');
-        cy.wait('@get12',{'timeout':10000});
+        // cy.wait('@get12',{'timeout':10000});
         cy.visit('/#Inbox:12');
 
         cy.get('div#messageHeaderSubject').contains('Default from fix test');

--- a/e2e/cypress/integration/mailviewer.ts
+++ b/e2e/cypress/integration/mailviewer.ts
@@ -28,10 +28,10 @@ describe('Interacting with mailviewer', () => {
         // canvas().click(400, 300);
 
         cy.hash().should('equal', '#Inbox:11');
-        cy.go(-1);
-        cy.hash().should('not.contain', 'Inbox:11');
         /* TODO: apparently forward broke at some point
          * in headless mode. Works normally in a proper browser
+        cy.go('back');
+        cy.hash().should('not.contain', 'Inbox:11');
         cy.go('forward');
         cy.hash().should('equal', '#Inbox:11');
         cy.get('button[mattooltip="Close"]').click();

--- a/e2e/mockserver/mockserver.ts
+++ b/e2e/mockserver/mockserver.ts
@@ -194,9 +194,12 @@ END:VCALENDAR
         this.server = createServer((request, response) => {
             const e2eFixture = request.url.match(/\/rest\/e2e\/(\w+)/);
             if (e2eFixture) {
+                log(e2eFixture[1]);
                 const command = e2eFixture[1];
                 if (command === 'logout') {
+                    log('ms pre: logout');
                     this.loggedIn = false;
+                    log('ms post: logout');
                 }
                 if (command === 'require2fa') {
                     this.challenge2fa = true;
@@ -205,6 +208,7 @@ END:VCALENDAR
                     this.challenge2fa = false;
                 }
                 response.end();
+                return;
             }
 
             if (!this.loggedIn && request.url !== '/ajax_mfa_authenticate') {
@@ -293,6 +297,7 @@ END:VCALENDAR
                             log('2fa challenge');
                             response.end(JSON.stringify(this.auth_challenge_2fa()));
                             this.challenge2fa = false;
+                            return;
                         } else {
                             this.loggedIn = true;
                             log('authenticate');
@@ -301,7 +306,8 @@ END:VCALENDAR
                                         'message': 'Success',
                                         'code': 200
                                     }
-                                ));
+                            ));
+                            return;
                         }
                         }, 1000);
                     break;

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -324,8 +324,10 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
          && res && res.length > 0) {
         this.setMessageDisplay('messagelist', this.messagelist);
         if (this.jumpToFragment) {
-          this.selectMessageFromFragment(this.fragment);
-          this.canvastable.jumpToOpenMessage();
+          if (this.router.url !== `/#${this.fragment}`) {
+            this.selectMessageFromFragment(this.fragment);
+            this.canvastable.jumpToOpenMessage();
+          }
           this.jumpToFragment = false;
         }
         this.canvastable.hasChanges = true;
@@ -799,6 +801,8 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
         this.canvastable.updateRows(args[1]);
       } else {
         this.canvastable.rows = new SearchMessageDisplay(...args);
+        // messages updated, check if we need to select a message from the fragment
+        this.selectMessageFromFragment(this.fragment);
       }
     }
     if (displayType === 'messagelist') {
@@ -806,6 +810,8 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
         this.canvastable.updateRows(args[0]);
       } else {
         this.canvastable.rows = new MessageList(...args);
+        // messages updated, check if we need to select a message from the fragment
+        this.selectMessageFromFragment(this.fragment);
       }
     }
     if (displayType === 'websocketlist') {
@@ -813,6 +819,8 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
         this.canvastable.updateRows(args[0]);
       } else {
         this.canvastable.rows = new WebSocketSearchMailList(...args);
+        // messages updated, check if we need to select a message from the fragment
+        this.selectMessageFromFragment(this.fragment);
       }
     }
     this.filterMessageDisplay();
@@ -826,8 +834,6 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     // NB this triggers hasChanged for us and forces a redraw
     this.canvastable.columns =  this.canvastable.rows.getCanvasTableColumns(this);
 
-    // messages updated, check if we need to select a message from the fragment
-    this.selectMessageFromFragment(this.fragment);
   }
 
   public filterMessageDisplay() {
@@ -851,7 +857,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
 
   public selectRowByMessageId(messageId: number) {
     const matchingRowIndex = this.canvastable.rows.findRowByMessageId(messageId);
-    if (matchingRowIndex >= -1) {
+    if (matchingRowIndex > -1) {
       this.rowSelected(matchingRowIndex, 1, false);
     } else {
       this.singlemailviewer.close();
@@ -1338,8 +1344,8 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     // navigating to the same page does not fire off our fragment.subscribe
     if (fragment !== this.fragment) {
       this.fragment = fragment;
+      this.router.navigate(['/'], { fragment });
     }
-    this.router.navigate(['/'], { fragment });
   }
 }
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -435,7 +435,8 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
         const rowIndexes = this.canvastable.getVisibleRowIndexes();
         const messageIds = rowIndexes.filter(
             idx => idx < this.canvastable.rows.rowCount()
-        ).map(idx => this.canvastable.rows.getRowMessageId(idx));
+        ).map(idx => this.canvastable.rows.getRowMessageId(idx)
+        ).filter(id => id > 0);
         for (const id of messageIds) {
           if (this.searchService.updateMessageText(id)) {
             this.canvastable.hasChanges = true;

--- a/src/app/compose/compose.component.ts
+++ b/src/app/compose/compose.component.ts
@@ -159,7 +159,7 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
               console.error(err);
               if (typeof(err) === 'string') {
                 this.snackBar.open(err);
-              } else {
+              } else if (err.hasOwnProperty('errors')) {
                 this.snackBar.open(err.errors.join('.'));
               }
             });
@@ -417,7 +417,7 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
                   console.error(err);
                   if (typeof(err) === 'string') {
                     this.snackBar.open(`Error opening draft for editing ${err}`, 'OK');
-                  } else {
+                  } else if (err.hasOwnProperty('errors')) {
                     this.snackBar.open(`Error opening draft for editing ${err.errors.join('.')}`, 'OK');
                   }
                 });

--- a/src/app/compose/compose.component.ts
+++ b/src/app/compose/compose.component.ts
@@ -151,9 +151,18 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
                 });
             }
         } else {
-            this.rmmapi.getMessageContents(this.model.mid).subscribe(msgObj =>
-                this.model.preview = msgObj.text.text ? DraftFormModel.trimmedPreview(msgObj.text.text) : ''
-            );
+          this.rmmapi.getMessageContents(this.model.mid).subscribe(
+            msgObj =>
+              this.model.preview = msgObj.text.text ? DraftFormModel.trimmedPreview(msgObj.text.text) : '',
+            err => {
+              console.error('Error fetching message: ' + this.model.mid);
+              console.error(err);
+              if (typeof(err) === 'string') {
+                this.snackBar.open(err);
+              } else {
+                this.snackBar.open(err.errors.join('.'));
+              }
+            });
         }
 
         this.formGroup = this.formBuilder.group(this.model);
@@ -404,7 +413,13 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
 
                     this.htmlToggled();
                 }, err => {
+                  console.error('Error fetching message: ' + this.model.mid);
+                  console.error(err);
+                  if (typeof(err) === 'string') {
                     this.snackBar.open(`Error opening draft for editing ${err}`, 'OK');
+                  } else {
+                    this.snackBar.open(`Error opening draft for editing ${err.errors.join('.')}`, 'OK');
+                  }
                 });
         } else {
             this.editing = true;

--- a/src/app/mailviewer/singlemailviewer.component.ts
+++ b/src/app/mailviewer/singlemailviewer.component.ts
@@ -392,8 +392,9 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
       map((messageContents) => {
         const res: any = Object.assign({}, messageContents);
         if (res.status === 'warning') {
+          // status === 'error' already displayed in showBackendErrors?
           // Skip if we previously had an issue loading this messge
-          throw new Error(res.errors.join('.'));
+          throw new Error(res);
         }
         res.subject = res.headers.subject;
         res.from = res.headers.from.value;
@@ -518,9 +519,14 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
         );
       },
       err => {
-        console.log('Error fetching message: ' + this.messageId);
-        console.log(err);
-        this.supportSnackBar.open(err);
+        console.error('Error fetching message: ' + this.messageId);
+        // httperror e.message, or status:error,errors:['strings']
+        console.error(err);
+        if (typeof(err) === 'string') {
+          this.supportSnackBar.open(err);
+        } else {
+          this.supportSnackBar.open(err.errors.join('.'));
+        }
       }
       );
   }
@@ -731,6 +737,8 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
       setTimeout(() => {
         if (this.messageContents) {
           this.messageContents.nativeElement.scroll(0, 0);
+        } else {
+          this.close();
         }
         // Only care about the horizontal pane height in horizontal mode
         if (this.adjustableHeight && this.resizer) {

--- a/src/app/mailviewer/singlemailviewer.component.ts
+++ b/src/app/mailviewer/singlemailviewer.component.ts
@@ -394,7 +394,7 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
         if (res.status === 'warning') {
           // status === 'error' already displayed in showBackendErrors?
           // Skip if we previously had an issue loading this messge
-          throw new Error(res);
+          throw res;
         }
         res.subject = res.headers.subject;
         res.from = res.headers.from.value;
@@ -523,10 +523,15 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
         // httperror e.message, or status:error,errors:['strings']
         console.error(err);
         if (typeof(err) === 'string') {
+          // HTTPErrorResponse as a string
           this.supportSnackBar.open(err);
-        } else {
+        } else if (err.hasOwnProperty('errors')) {
+          // Our own error object from rest api
           this.supportSnackBar.open(err.errors.join('.'));
         }
+        // close the viewer pane
+        this.close();
+        // else - not outputting normal JS errors!
       }
       );
   }
@@ -737,8 +742,6 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
       setTimeout(() => {
         if (this.messageContents) {
           this.messageContents.nativeElement.scroll(0, 0);
-        } else {
-          this.close();
         }
         // Only care about the horizontal pane height in horizontal mode
         if (this.adjustableHeight && this.resizer) {

--- a/src/app/rmmapi/rbwebmail.ts
+++ b/src/app/rmmapi/rbwebmail.ts
@@ -347,6 +347,7 @@ export class RunboxWebmailAPI {
 
     showBackendErrors(res: any) {
         if (res.status === 'error' || res.status === 'warning') {
+            console.log(res);
             if (res.errors && res.errors.length) {
                 const error_msg = res.errors.map((key) => {
                     let loc = this.rblocale.translate(key).replace('_', ' ');

--- a/src/app/rmmapi/rmmhttpinterceptor.service.ts
+++ b/src/app/rmmapi/rmmhttpinterceptor.service.ts
@@ -18,7 +18,7 @@
 // ---------- END RUNBOX LICENSE ----------
 
 import { Injectable } from '@angular/core';
-import { HttpInterceptor, HttpRequest, HttpHandler, HttpEvent, HttpResponse, HttpClient } from '@angular/common/http';
+import { HttpInterceptor, HttpRequest, HttpHandler, HttpEvent, HttpResponse, HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { Observable,  throwError } from 'rxjs';
 import { catchError, map, finalize } from 'rxjs/operators';
 import { ProgressService } from '../http/progress.service';
@@ -80,12 +80,21 @@ export class RMMHttpInterceptorService implements HttpInterceptor {
                 return evt;
             }),
             catchError((e) => {
-                if (e.status === 403) {
-                    console.log('Forbidden');
-                    this.checkAccountStatus();
-                } else if (e.status === 502) {
-                    this.rmmoffline.is_offline = true;
-                    return throwError(e);
+                if (e  instanceof HttpErrorResponse) {
+                    if (e.status === 403) {
+                        console.log('Forbidden');
+                        this.checkAccountStatus();
+                    } else if (e.status === 502 || e.status === 504) {
+                        // Bad Gateway / Gateway Timeout
+                        this.rmmoffline.is_offline = true;
+                        console.log(e);
+                        return throwError(e.message);
+                    } else {
+                        // Some other kind of HttpErrorResponse
+                        // eg status=200, but json parse failed"
+                        console.error(e);
+                        return throwError(e.message);
+                    }
                 } else {
                     return throwError(e);
                 }

--- a/src/app/xapian/searchservice.ts
+++ b/src/app/xapian/searchservice.ts
@@ -1290,7 +1290,12 @@ export class SearchService {
           }
         } else {
           // stop repeatedly looking up broken ones
-          console.error(`DataError in updateMessageText ${messageId}`, content['errors']);
+          if (content.hasOwnProperty('errors')) {
+            // this is an error restapi generated
+            console.error(`DataError in updateMessageText ${messageId}`, content['errors']);
+          }
+          // even if we dont know where it came from, still dont retry
+          // it this session
           this.messageTextCache.set(messageId, '');
         }
       },

--- a/src/app/xapian/searchservice.ts
+++ b/src/app/xapian/searchservice.ts
@@ -1290,9 +1290,15 @@ export class SearchService {
           }
         } else {
           // stop repeatedly looking up broken ones
+          console.error(`DataError in updateMessageText ${messageId}`, content['errors']);
           this.messageTextCache.set(messageId, '');
         }
-      });
+      },
+     (err) => {
+       console.error(`HTTPError in updateMessageText ${messageId}`, err);
+       // stop repeatedly looking up broken ones
+       this.messageTextCache.set(messageId, '');
+     });
       return true;
     }
     return false;


### PR DESCRIPTION
Instead of "object Object". This sorts out all the instances where
"getMessageContents" might return an error for a number of ways.

Fixes: #1262