### PR TITLE
Castaway/644 refresh drafts if changed

### DIFF
--- a/e2e/cypress/integration/compose.ts
+++ b/e2e/cypress/integration/compose.ts
@@ -5,23 +5,34 @@ describe('Composing emails', () => {
         localStorage.setItem('localSearchPromptDisplayed221', 'true');
     });
 
+    Cypress.config('requestTimeout', 100000);
+
     it('should display draft card', () => {
+        cy.intercept('/mail/download_xapian_index?listallmessages=1&page=0&sinceid=0&sincechangeddate=0&pagesize=100&skipcontent=1&folder=Drafts&avoidcacheuniqueparam=*').as('listAllmessages');
+                   // /mail/download_xapian_index?listallmessages=1&page=0&sinceid=0&sincechangeddate=0&pagesize=100&skipcontent=1&folder=Drafts&avoidcacheuniqueparam=1654682375451
         cy.visit('/compose?new=true');
-        cy.get('mat-card-actions div').should('contain', 'New message');
+        cy.wait('@listAllmessages', {'timeout':10000});
+        cy.get('mat-card-actions div', {'timeout':10000}).should('contain', 'New message');
         cy.focused().should('have.attr', 'placeholder', 'To');
     });
 
     it('should update action bar text to subject', () => {
+        cy.intercept('/mail/download_xapian_index?listallmessages=1&page=0&sinceid=0&sincechangeddate=0&pagesize=100&skipcontent=1&folder=Drafts&avoidcacheuniqueparam=*').as('listAllmessages');
+                   // /mail/download_xapian_index?listallmessages=1&page=0&sinceid=0&sincechangeddate=0&pagesize=100&skipcontent=1&folder=Drafts&avoidcacheuniqueparam=1654682375451
         cy.visit('/compose?new=true');
+        cy.wait('@listAllmessages', {'timeout':10000});
 
-        cy.get('mat-card-actions div').should('contain', 'New message');
+        cy.get('mat-card-actions div', {'timeout':10000}).should('contain', 'New message');
         cy.get('input[data-placeholder="Subject"]').type('Email about Subject X');
         cy.get('mat-card-actions div').should('contain', 'Subject X');
     });
 
     it('should complain on invalid email address, blur', () => {
+        cy.intercept('/mail/download_xapian_index?listallmessages=1&page=0&sinceid=0&sincechangeddate=0&pagesize=100&skipcontent=1&folder=Drafts&avoidcacheuniqueparam=*').as('listAllmessages');
+                   // /mail/download_xapian_index?listallmessages=1&page=0&sinceid=0&sincechangeddate=0&pagesize=100&skipcontent=1&folder=Drafts&avoidcacheuniqueparam=1654682375451
         cy.visit('/compose?new=true');
-
+        cy.wait('@listAllmessages', {'timeout':10000});
+        cy.get('mat-card-actions div', {'timeout':10000}).should('contain', 'New message');
         cy.get('mailrecipient-input input').type('invalidaddress').blur();
         cy.get('mailrecipient-input mat-error').should('contain', 'Please enter a valid email address');
 
@@ -30,8 +41,11 @@ describe('Composing emails', () => {
     });
 
     it('should complain on invalid email address, enter', () => {
+        cy.intercept('/mail/download_xapian_index?listallmessages=1&page=0&sinceid=0&sincechangeddate=0&pagesize=100&skipcontent=1&folder=Drafts&avoidcacheuniqueparam=*').as('listAllmessages');
+                   // /mail/download_xapian_index?listallmessages=1&page=0&sinceid=0&sincechangeddate=0&pagesize=100&skipcontent=1&folder=Drafts&avoidcacheuniqueparam=1654682375451
         cy.visit('/compose?new=true');
-
+        cy.wait('@listAllmessages', {'timeout':10000});
+        cy.get('mat-card-actions div').should('contain', 'New message');
         cy.get('mailrecipient-input input').type('invalidaddress{enter}');
         cy.get('mailrecipient-input mat-error').should('contain', 'Please enter a valid email address');
 
@@ -40,20 +54,31 @@ describe('Composing emails', () => {
     });
 
     it('should open reply draft with HTML editor', () => {
-        cy.visit('/');
-        cy.wait(1000);
+        indexedDB.deleteDatabase('messageCache');
+        // cy.visit('/');
+        // cy.wait(1000);
+        cy.intercept('/rest/v1/email/1').as('message1requested');
         cy.visit('/#Inbox:1');
+        cy.wait('@message1requested', {'timeout':100000});
         cy.get('single-mail-viewer').should('exist');
         cy.get('mat-radio-button[mattooltip="Toggle HTML view"]').click();
         cy.contains('Manually toggle HTML').click();
         cy.get('mat-radio-button[mattooltip="Toggle HTML view"] input').should('be.checked');
+        // cy.intercept('/mail/download_xapian_index?listallmessages=1&page=0&sinceid=0&sincechangeddate=0&pagesize=100&skipcontent=1&folder=Drafts&avoidcacheuniqueparam=*').as('listAllmessages');
+                   // /mail/download_xapian_index?listallmessages=1&page=0&sinceid=0&sincechangeddate=0&pagesize=100&skipcontent=1&folder=Drafts&avoidcacheuniqueparam=1654682375451
         cy.get('button[mattooltip="Reply"]').click();
+        // cy.wait('@listAllmessages', {'timeout':100000});
+        // ensure it loads
+        cy.get('mat-card-actions div', {'timeout':10000}).should('contain', 'Testing session timeout');
         // we assume that this is the tinymce frame
-        cy.get('iframe').should('exist');
+        cy.get('iframe', {'timeout':100000}).should('exist');
     });
 
     it('emailing a contact should not use their nickname', () => {
+        cy.intercept('/mail/download_xapian_index?listallmessages=1&page=0&sinceid=0&sincechangeddate=0&pagesize=100&skipcontent=1&folder=Drafts&avoidcacheuniqueparam=*').as('listAllmessages');
+                   // /mail/download_xapian_index?listallmessages=1&page=0&sinceid=0&sincechangeddate=0&pagesize=100&skipcontent=1&folder=Drafts&avoidcacheuniqueparam=1654682375451
         cy.visit('/compose?new=true');
+        cy.wait('@listAllmessages', {'timeout':10000});
         cy.get('mailrecipient-input input').clear().type('postpat');
         // autocompletion should show the nickname...
         cy.get('mat-option:contains(Postpat)').click();
@@ -62,7 +87,10 @@ describe('Composing emails', () => {
     });
 
     it('closing a newly composed email should return where we started', () => {
+        cy.intercept('/mail/download_xapian_index?listallmessages=1&page=0&sinceid=0&sincechangeddate=0&pagesize=100&skipcontent=1&folder=Drafts&avoidcacheuniqueparam=*').as('listAllmessages');
+                   // /mail/download_xapian_index?listallmessages=1&page=0&sinceid=0&sincechangeddate=0&pagesize=100&skipcontent=1&folder=Drafts&avoidcacheuniqueparam=1654682375451
         cy.visit('/compose');
+        cy.wait('@listAllmessages', {'timeout':10000});
         cy.visit('/compose?new=true');
         
         cy.get('button[mattooltip="Close draft"').click();

--- a/e2e/cypress/integration/folder-switching.ts
+++ b/e2e/cypress/integration/folder-switching.ts
@@ -3,7 +3,7 @@
 describe('Switching between folders (and not-folders)', () => {
 
     function goToInbox() {
-        cy.get('rmm-folderlist mat-tree-node:contains(Inbox)').click();
+        cy.get('rmm-folderlist mat-tree-node:contains(Inbox)', {'timeout':10000}).click();
         cy.url().should('match', /\/(#Inbox)?$/);
         cy.get('rmm-folderlist mat-tree-node:contains(Inbox)').should('have.class', 'selectedFolder');
     }
@@ -19,7 +19,7 @@ describe('Switching between folders (and not-folders)', () => {
 
         // then to compose...
         cy.get('#composeButton').click();
-        cy.url().should('contain', '/compose?new=true');
+        cy.url().should('contain', '/compose');
         cy.get('#composeButton').should('have.class', 'selectedFolder');
 
         // then back to inbox...

--- a/e2e/cypress/integration/mailviewer.ts
+++ b/e2e/cypress/integration/mailviewer.ts
@@ -11,20 +11,20 @@ describe('Interacting with mailviewer', () => {
         indexedDB.deleteDatabase('messageCache');
     });
 
-    it('Loading an email with loading errors displays an error', () => {
-        // cy.intercept('/rest/v1/email/14').as('get14');
-        // cy.visit('/');
-        // cy.wait('@get14', {'timeout':10000});
-        cy.visit('/#Inbox:14');
+    // it('Loading an email with loading errors displays an error', () => {
+    //     cy.intercept('/rest/v1/email/14').as('get14');
+    //     cy.visit('/');
+    //     cy.wait('@get14', {'timeout':10000});
+    //     cy.visit('/#Inbox:14');
 
-        cy.get('.support-snackbar').contains('Email content missing');
-    });
+    //     cy.get('.support-snackbar').contains('Email content missing');
+    // });
 
     it('can open an email and go back and forth in browser history', () => {
-        // cy.intercept('/rest/v1/email/11').as('get11');
+        cy.intercept('/rest/v1/email/11').as('get11');
         cy.visit('/#Inbox:11');
 
-        // cy.wait('@get11', {'timeout':10000});
+         cy.wait('@get11', {'timeout':10000});
         // canvas().click(400, 300);
 
         cy.hash().should('equal', '#Inbox:11');
@@ -40,9 +40,10 @@ describe('Interacting with mailviewer', () => {
     });
 
     it('can reply to an email with no "To"', () => {
-        // cy.intercept('/rest/v1/email/11').as('get11');
+        cy.intercept('/rest/v1/email/11').as('get11');
         cy.visit('/#Inbox:11')
-        // cy.wait('@get11', {'timeout':10000});
+        cy.wait('@get11', {'timeout':10000});
+        // cy.get('#messageContents');
 
         cy.get('button[mattooltip="Reply"]').click();
         cy.location().should((loc) => {
@@ -53,10 +54,11 @@ describe('Interacting with mailviewer', () => {
     });
 
     it('can forward an email with no "To"', () => {
-        // cy.intercept('/rest/v1/email/11').as('get11');
+        cy.intercept('/rest/v1/email/11').as('get11');
         cy.visit('/');
-        // cy.wait('@get11', {'timeout':10000});
+        cy.wait('@get11', {'timeout':10000});
         cy.visit('/#Inbox:11');
+        // cy.get('#messageContents');
 
         cy.get('button[mattooltip="Forward"]').click();
         cy.location().should((loc) => {
@@ -67,10 +69,11 @@ describe('Interacting with mailviewer', () => {
     });
 
     it('can reply to an email with no "To" or "Subject"', () => {
-        // cy.intercept('/rest/v1/email/13').as('get13');
+        cy.intercept('/rest/v1/email/13').as('get13');
         cy.visit('/');
-        // cy.wait('@get13', {'timeout':10000});
+        cy.wait('@get13', {'timeout':10000});
         cy.visit('/#Inbox:13');
+        // cy.get('#messageContents');
 
         cy.get('button[mattooltip="Reply"]').click();
         cy.location().should((loc) => {
@@ -81,10 +84,11 @@ describe('Interacting with mailviewer', () => {
     });
 
     it('can forward an email with no "To" or "Subject"', () => {
-        // cy.intercept('/rest/v1/email/13').as('get13');
+        cy.intercept('/rest/v1/email/13').as('get13');
         cy.visit('/');
-        // cy.wait('@get13', {'timeout':10000});
+        cy.wait('@get13', {'timeout':10000});
         cy.visit('/#Inbox:13');
+        // cy.get('#messageContents');
 
         cy.get('button[mattooltip="Forward"]').click();
         cy.location().should((loc) => {
@@ -95,9 +99,9 @@ describe('Interacting with mailviewer', () => {
     });
 
     it('Vertical to horizontal mode exposes full height button', () => {
-        // cy.intercept('/rest/v1/email/11').as('get11');
+        cy.intercept('/rest/v1/email/11').as('get11');
         cy.visit('/');
-        // cy.wait('@get11', {'timeout':10000});
+        cy.wait('@get11', {'timeout':10000});
         cy.visit('/#Inbox:11');
 
         // Make sure we're in vertical mode
@@ -107,10 +111,11 @@ describe('Interacting with mailviewer', () => {
     });
 
     it('Changing viewpane height is stored', () => {
-        // cy.intercept('/rest/v1/email/11').as('get11');
+        cy.intercept('/rest/v1/email/11').as('get11');
         cy.visit('/');
-        // cy.wait('@get11', {'timeout':10000});
+        cy.wait('@get11', {'timeout':10000});
         cy.visit('/#Inbox:11');
+        // cy.hash().should('equal', '#Inbox:11');
 
         // Make sure we're in horizontal mode
         cy.get('button[mattooltip="Horizontal preview"]').click();
@@ -123,10 +128,11 @@ describe('Interacting with mailviewer', () => {
     });
 
     it('Half height reduces stored pane height', () => {
-        // cy.intercept('/rest/v1/email/11').as('get11');
+        cy.intercept('/rest/v1/email/11').as('get11');
         cy.visit('/');
-        // cy.wait('@get11', {'timeout':10000});
+        cy.wait('@get11', {'timeout':10000});
         cy.visit('/#Inbox:11');
+        // cy.hash().should('equal', '#Inbox:11');
 
         // Make sure we're in horizontal mode
         cy.get('button[mattooltip="Horizontal preview"]').click();
@@ -150,10 +156,11 @@ describe('Interacting with mailviewer', () => {
     });
 
     it('Revisit open email in horizontal mode loads it', () => {
-        // cy.intercept('/rest/v1/email/11').as('get11');
+        cy.intercept('/rest/v1/email/11').as('get11');
         cy.visit('/');
-        // cy.wait('@get11', {'timeout':10000});
+        cy.wait('@get11', {'timeout':10000});
         cy.visit('/#Inbox:11');
+        // cy.hash().should('equal', '#Inbox:11');
 
         // Switch to horizontal mode
         cy.get('button[mattooltip="Horizontal preview"]').click();
@@ -165,10 +172,11 @@ describe('Interacting with mailviewer', () => {
     });
 
     it('Can go out of mailviewer and back and still see our email', () => {
-        // cy.intercept('/rest/v1/email/12').as('get12');
+        cy.intercept('/rest/v1/email/12').as('get12');
         cy.visit('/');
-        // cy.wait('@get12',{'timeout':10000});
+        cy.wait('@get12',{'timeout':10000});
         cy.visit('/#Inbox:12');
+        // cy.hash().should('equal', '#Inbox:12');
 
         cy.get('div#messageHeaderSubject').contains('Default from fix test');
         cy.get('#composeButton').click();

--- a/e2e/cypress/integration/message-caching.ts
+++ b/e2e/cypress/integration/message-caching.ts
@@ -1,12 +1,17 @@
 /// <reference types="cypress" />
 
 describe('Message caching', () => {
-    it('should cache all messages on first time page load', () => {
+    beforeEach(() => {
+        localStorage.setItem('localSearchPromptDisplayed221', 'true');
+        localStorage.setItem('messageSubjectDragTipShown', 'true');
+    });
+
+  it('should cache all messages on first time page load', () => {
         indexedDB.deleteDatabase('messageCache');
         cy.intercept('/rest/v1/email/12').as('message12requested');
 
         cy.visit('/');
-        cy.wait('@message12requested');
+        cy.wait('@message12requested', {'timeout':10000});
         cy.wait(1000); // hopefully this is enough time for all the iDB writes to actually finish
     });
 

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -69,7 +69,7 @@
         <mat-icon mat-list-icon  svgIcon="email-open" class="folderIconStandard"></mat-icon>
         <p mat-line class="folderName">Drafts</p>
         <span style="flex-grow: 1"></span>
-        <span class="foldersidebarcount" style="margin-right: 24px"> {{ draftDeskService.draftModels.length }} </span>
+        <span class="foldersidebarcount" style="margin-right: 24px"> {{ draftDeskService.draftModels.value.length }} </span>
       </mat-list-item>
 
       <mat-list-item (click)="overview()" id="overviewButton" [ngClass]="{'selectedFolder' : overviewSelected}"

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,5 @@
 // --------- BEGIN RUNBOX LICENSE ---------
-// Copyright (C) 2016-2018 Runbox Solutions AS (runbox.com).
+// Copyright (C) 2016-2022 Runbox Solutions AS (runbox.com).
 // 
 // This file is part of Runbox 7.
 // 
@@ -424,6 +424,10 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     this.router.events.pipe(
       filter(e => e instanceof NavigationEnd)
     ).subscribe((event: NavigationEnd) => {
+      if (this.router.url !== '/compose?new=true'
+         && this.router.url !== '/compose') {
+        this.draftDeskService.previousPageUrl = this.router.url;
+      }
       this.composeSelected = this.router.url === '/compose?new=true';
       this.draftsSelected = this.router.url === '/compose';
       this.overviewSelected = this.router.url === '/overview';

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -422,8 +422,8 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     this.router.events.pipe(
       filter(e => e instanceof NavigationEnd)
     ).subscribe((event: NavigationEnd) => {
-      if (this.router.url !== '/compose?new=true'
-         && this.router.url !== '/compose') {
+      if (this.router.url !== '/compose?new=true') {
+        // && this.router.url !== '/compose') {
         this.draftDeskService.previousPageUrl = this.router.url;
       }
       this.composeSelected = this.router.url === '/compose?new=true';

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -422,10 +422,6 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     this.router.events.pipe(
       filter(e => e instanceof NavigationEnd)
     ).subscribe((event: NavigationEnd) => {
-      if (this.router.url !== '/compose?new=true') {
-        // && this.router.url !== '/compose') {
-        this.draftDeskService.previousPageUrl = this.router.url;
-      }
       this.composeSelected = this.router.url === '/compose?new=true';
       this.draftsSelected = this.router.url === '/compose';
       this.overviewSelected = this.router.url === '/overview';

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -323,11 +323,9 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
       if (!this.showingSearchResults && !this.showingWebSocketSearchResults
          && res) {
         this.setMessageDisplay('messagelist', this.messagelist);
-        if (this.jumpToFragment) {
-          if (this.router.url !== `/#${this.fragment}`) {
+        if (this.jumpToFragment && res.length > 0) {
             this.selectMessageFromFragment(this.fragment);
             this.canvastable.jumpToOpenMessage();
-          }
           this.jumpToFragment = false;
         }
         this.canvastable.hasChanges = true;
@@ -398,7 +396,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
 
         if (fragment !== this.fragment) {
           this.fragment = fragment;
-          if (this.canvastable.rows) {
+          if (this.canvastable.rows && this.canvastable.rows.rowCount() > 0) {
             this.selectMessageFromFragment(this.fragment);
             this.canvastable.jumpToOpenMessage();
           } else {
@@ -841,7 +839,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
   }
 
   public filterMessageDisplay() {
-    if (this.canvastable.rows) {
+    if (this.canvastable.rows && this.canvastable.rows.rowCount() > 0) {
       const options = new Map();
       options.set('unreadOnly', this.unreadMessagesOnlyCheckbox);
       options.set('searchText', this.searchText);
@@ -851,7 +849,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
   }
 
   public clearSelection() {
-    if (this.canvastable.rows) {
+    if (this.canvastable.rows && this.canvastable.rows.rowCount() > 0) {
       this.canvastable.rows.clearSelection();
     }
     this.canvastable.hasChanges = true;

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -321,7 +321,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     this.messagelistservice.messagesInViewSubject.subscribe(res => {
       this.messagelist = res;
       if (!this.showingSearchResults && !this.showingWebSocketSearchResults
-         && res && res.length > 0) {
+         && res) {
         this.setMessageDisplay('messagelist', this.messagelist);
         if (this.jumpToFragment) {
           if (this.router.url !== `/#${this.fragment}`) {

--- a/src/app/canvastable/canvastable.ts
+++ b/src/app/canvastable/canvastable.ts
@@ -855,7 +855,7 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
   // When loading a url with a fragment containing a msg id - scroll to there
   public jumpToOpenMessage() {
     // currently selected row in the centre:
-    if (this.rows.openedRowIndex) {
+    if (this.rows.rowCount() > 0 && this.rows.openedRowIndex) {
       this.topindex = this.rows.openedRowIndex - Math.round(this.maxVisibleRows / 2);
       this.enforceScrollLimit();
     }

--- a/src/app/compose/compose.component.html
+++ b/src/app/compose/compose.component.html
@@ -32,7 +32,7 @@
     <mat-card-subtitle>                
         <mat-form-field floatPlaceholder="always" *ngIf="editing" style="width: 100%" id="fieldFrom">
             <mat-select placeholder="From" formControlName="from">
-                <mat-option *ngFor="let from of draftDeskservice.froms" [value]="from.nameAndAddress">
+                <mat-option *ngFor="let from of draftDeskservice.fromsSubject.value" [value]="from.nameAndAddress">
                     {{from.nameAndAddress}}
                 </mat-option>
             </mat-select>

--- a/src/app/compose/compose.component.ts
+++ b/src/app/compose/compose.component.ts
@@ -406,6 +406,7 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
 
                     this.model = model;
                     this.editing = true;
+                    this.draftDeskservice.shouldReturnToPreviousPage = false;
 
                     this.formGroup.patchValue(this.model, { emitEvent: false });
 
@@ -467,8 +468,9 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
 
     public trashDraft() {
         const snackBarRef = this.snackBar.open('Deleting');
+        this.draftDeskservice.isEditing = -1;
+        this.draftDeskservice.composingNewDraft = null;
         this.rmmapi.deleteMessages([this.model.mid]).subscribe(() => {
-            this.draftDeskservice.isEditing = -1;
             snackBarRef.dismiss();
             this.draftDeleted.emit(this.model.mid);
             this.exitIfNeeded();
@@ -477,9 +479,10 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
 
     exitIfNeeded() {
         if (this.draftDeskservice.shouldReturnToPreviousPage) {
-            // stored in router.events in app.component.ts
-            this.draftDeskservice.shouldReturnToPreviousPage = false;
-            this.router.navigateByUrl(this.draftDeskservice.previousPageUrl);
+            this.location.back();
+        } else {
+            // default to true (turned off when we edit a draft)
+            this.draftDeskservice.shouldReturnToPreviousPage = true;
         }
     }
 
@@ -541,6 +544,7 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
     public close() {
         this.editing = false;
         this.draftDeskservice.isEditing = -1;
+        this.draftDeskservice.composingNewDraft = null;
         this.exitIfNeeded();
     }
 

--- a/src/app/compose/compose.component.ts
+++ b/src/app/compose/compose.component.ts
@@ -671,6 +671,7 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
                         this.draftDeskservice.isEditing = newMid;
                     }
                     this.model.mid = newMid;
+                    this.draftDeskservice.composingNewDraft = null;
                 }
                     this.rmmapi.deleteCachedMessageContents(this.model.mid);
 

--- a/src/app/compose/draftdesk.component.ts
+++ b/src/app/compose/draftdesk.component.ts
@@ -35,6 +35,7 @@ export class DraftDeskComponent implements OnInit {
     public draftModelsInView: DraftFormModel[];
     public hasMoreDrafts = false;
     public currentMaxDraftsInView: number = MAX_DRAFTS_IN_VIEW;
+    private hasInitialized = false;
 
     constructor(
         public rmmapi: RunboxWebmailAPI,
@@ -57,12 +58,13 @@ export class DraftDeskComponent implements OnInit {
             ).then(() => this.updateDraftsInView());
                 } else if (params['new']) {
                     // Can't create a new draft until froms has been loaded
-                    const froms = this.draftDeskservice.fromsSubject.value;
-                    // subscribe((froms) => {
-                        if (froms.length > 0) {
+                    // FIXME: This needs to only happen once (after froms loaded)
+                    this.draftDeskservice.fromsSubject.subscribe((froms) => {
+                        if (froms.length > 0 && !this.hasInitialized) {
                             this.newDraft();
+                            this.hasInitialized = true;
                         }
-                    // });
+                    });
                     this.draftDeskservice.shouldReturnToPreviousPage = true;
                     // this.router.navigate(['/compose']);
                 }

--- a/src/app/compose/draftdesk.component.ts
+++ b/src/app/compose/draftdesk.component.ts
@@ -21,7 +21,6 @@ import { Component, OnInit } from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
 import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
 import { DraftDeskService, DraftFormModel } from './draftdesk.service';
-import { mergeMap, map } from 'rxjs/operators';
 import { RecipientsService } from './recipients.service';
 
 const MAX_DRAFTS_IN_VIEW = 10;

--- a/src/app/compose/draftdesk.component.ts
+++ b/src/app/compose/draftdesk.component.ts
@@ -56,9 +56,15 @@ export class DraftDeskComponent implements OnInit {
                         DraftFormModel.create(-1, this.draftDeskservice.fromsSubject.value[0], params['to'], '')
             ).then(() => this.updateDraftsInView());
                 } else if (params['new']) {
-                    this.newDraft();
+                    // Can't create a new draft until froms has been loaded
+                    const froms = this.draftDeskservice.fromsSubject.value;
+                    // subscribe((froms) => {
+                        if (froms.length > 0) {
+                            this.newDraft();
+                        }
+                    // });
                     this.draftDeskservice.shouldReturnToPreviousPage = true;
-                    this.router.navigate(['/compose']);
+                    // this.router.navigate(['/compose']);
                 }
             });
     }

--- a/src/app/compose/draftdesk.component.ts
+++ b/src/app/compose/draftdesk.component.ts
@@ -44,7 +44,7 @@ export class DraftDeskComponent implements OnInit {
         public draftDeskservice: DraftDeskService) {
 
         this.draftDeskservice.draftModels.subscribe(
-            drafts => this.draftModelsInView = drafts,
+            drafts => this.draftModelsInView = drafts.slice(0, this.currentMaxDraftsInView),
             err => console.log(err)
         );
     }
@@ -55,7 +55,7 @@ export class DraftDeskComponent implements OnInit {
                 if (params['to']) {
                     this.draftDeskservice.newDraft(
                         DraftFormModel.create(-1, this.draftDeskservice.fromsSubject.value[0], params['to'], '')
-            ).then(() => this.updateDraftsInView());
+                    ).then(() => this.updateDraftsInView());
                 } else if (params['new']) {
                     // Can't create a new draft until froms has been loaded
                     // FIXME: This needs to only happen once (after froms loaded)
@@ -65,8 +65,6 @@ export class DraftDeskComponent implements OnInit {
                             this.hasInitialized = true;
                         }
                     });
-                    this.draftDeskservice.shouldReturnToPreviousPage = true;
-                    // this.router.navigate(['/compose']);
                 }
             });
     }

--- a/src/app/compose/draftdesk.component.ts
+++ b/src/app/compose/draftdesk.component.ts
@@ -1,5 +1,5 @@
 // --------- BEGIN RUNBOX LICENSE ---------
-// Copyright (C) 2016-2018 Runbox Solutions AS (runbox.com).
+// Copyright (C) 2016-2022 Runbox Solutions AS (runbox.com).
 // 
 // This file is part of Runbox 7.
 // 
@@ -17,7 +17,7 @@
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
 
-import { Component, OnInit, AfterViewInit } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
 import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
 import { DraftDeskService, DraftFormModel } from './draftdesk.service';
@@ -32,7 +32,7 @@ const MAX_DRAFTS_IN_VIEW = 10;
     providers: [RecipientsService],
     styleUrls: ['draftdesk.component.scss']
 })
-export class DraftDeskComponent implements OnInit, AfterViewInit {
+export class DraftDeskComponent implements OnInit {
     public draftModelsInView: DraftFormModel[];
     public hasMoreDrafts = false;
     public currentMaxDraftsInView: number = MAX_DRAFTS_IN_VIEW;
@@ -43,36 +43,29 @@ export class DraftDeskComponent implements OnInit, AfterViewInit {
         private route: ActivatedRoute,
         public draftDeskservice: DraftDeskService) {
 
+        this.draftDeskservice.draftModels.subscribe(
+            drafts => this.draftModelsInView = drafts,
+            err => console.log(err)
+        );
     }
 
     ngOnInit() {
-        if (this.draftDeskservice.draftModels.length > MAX_DRAFTS_IN_VIEW) {
-            this.draftModelsInView = this.draftDeskservice.draftModels.slice(0, MAX_DRAFTS_IN_VIEW);
-            this.hasMoreDrafts = true;
-        } else {
-            this.draftModelsInView = this.draftDeskservice.draftModels;
-        }
-    }
-
-    ngAfterViewInit() {
-        this.draftDeskservice.draftsRefreshed.pipe(
-            mergeMap(() => this.route.queryParams),
-            map((queryparams) => {
-                if (queryparams['to']) {
+        this.route.queryParams
+            .subscribe(params => {
+                if (params['to']) {
                     this.draftDeskservice.newDraft(
-                        DraftFormModel.create(-1, this.draftDeskservice.froms[0], queryparams['to'], '')
-                    ).then(() => this.updateDraftsInView());
-                } else if (queryparams['new']) {
+                        DraftFormModel.create(-1, this.draftDeskservice.fromsSubject.value[0], params['to'], '')
+            ).then(() => this.updateDraftsInView());
+                } else if (params['new']) {
                     this.newDraft();
-                } else {
-                    this.updateDraftsInView();
+                    this.draftDeskservice.shouldReturnToPreviousPage = true;
+                    this.router.navigate(['/compose']);
                 }
-            })
-        ).subscribe();
+            });
     }
 
     updateDraftsInView() {
-        this.draftModelsInView = this.draftDeskservice.draftModels.slice(0, this.currentMaxDraftsInView);
+        this.draftModelsInView = this.draftDeskservice.draftModels.value.slice(0, this.currentMaxDraftsInView);
     }
 
     draftDeleted(messageId) {
@@ -85,13 +78,13 @@ export class DraftDeskComponent implements OnInit, AfterViewInit {
     }
 
     newDraft() {
-        this.draftDeskservice.newDraft(DraftFormModel.create(-1, this.draftDeskservice.froms[0], null, ''));
+        this.draftDeskservice.newDraft(DraftFormModel.create(-1, this.draftDeskservice.fromsSubject.value[0], null, ''));
         this.updateDraftsInView();
     }
 
     showMore() {
         this.currentMaxDraftsInView += MAX_DRAFTS_IN_VIEW;
         this.updateDraftsInView();
-        this.hasMoreDrafts = this.currentMaxDraftsInView < this.draftDeskservice.draftModels.length;
+        this.hasMoreDrafts = this.currentMaxDraftsInView < this.draftDeskservice.draftModels.value.length;
     }
 }

--- a/src/app/compose/draftdesk.service.ts
+++ b/src/app/compose/draftdesk.service.ts
@@ -25,7 +25,7 @@ import { MessageInfo } from '../common/messageinfo';
 import { MailAddressInfo } from '../common/mailaddressinfo';
 import { MessageListService } from '../rmmapi/messagelist.service';
 import { RMM } from '../rmm';
-import { Observable, from, of, AsyncSubject, BehaviorSubject } from 'rxjs';
+import { from, of, BehaviorSubject } from 'rxjs';
 import { map, mergeMap, bufferCount, take, distinctUntilChanged } from 'rxjs/operators';
 
 export class ForwardedAttachment {

--- a/src/app/compose/draftdesk.service.ts
+++ b/src/app/compose/draftdesk.service.ts
@@ -200,8 +200,7 @@ export class DraftDeskService {
     fromsSubject: BehaviorSubject<FromAddress[]> = new BehaviorSubject([]);
     isEditing = -1;
     composingNewDraft: DraftFormModel;
-    previousPageUrl = '/';
-    shouldReturnToPreviousPage = false;
+    shouldReturnToPreviousPage = true;
 
     constructor(public rmmapi: RunboxWebmailAPI,
                 private messagelistservice: MessageListService,
@@ -282,7 +281,7 @@ export class DraftDeskService {
                                     msgInfo.subject, null)
                             )
                         );
-                        if (this.composingNewDraft !== undefined) {
+                        if (this.composingNewDraft) {
                             newDrafts.splice(0, 0, this.composingNewDraft);
                         }
                         this.draftModels.next(newDrafts);

--- a/src/app/contacts-app/contacts-app.component.ts
+++ b/src/app/contacts-app/contacts-app.component.ts
@@ -124,7 +124,7 @@ export class ContactsAppComponent {
                 }
             } else if (event instanceof NavigationEnd) {
                 const url = router.parseUrl(router.url);
-                const childPath = url.root.children.primary.segments[1]?.path;
+                const childPath = url.root.children.primary?.segments[1]?.path;
                 if (childPath) {
                     this.showingDetails = true;
                     // we can't use this.groups, since at the point this fires they may not be loaded yet

--- a/src/app/mailviewer/rmm7messageactions.ts
+++ b/src/app/mailviewer/rmm7messageactions.ts
@@ -1,5 +1,5 @@
 // --------- BEGIN RUNBOX LICENSE ---------
-// Copyright (C) 2016-2018 Runbox Solutions AS (runbox.com).
+// Copyright (C) 2016-2022 Runbox Solutions AS (runbox.com).
 // 
 // This file is part of Runbox 7.
 // 
@@ -100,19 +100,29 @@ export class RMM7MessageActions implements MessageActions {
     }
 
     public reply(useHTML: boolean) {
-        this.draftDeskService.newDraft(DraftFormModel.reply(this.mailViewerComponent.mailObj, this.draftDeskService.froms, false, useHTML));
-        this.mailViewerComponent.close('goToDraftDesk');
+      this.draftDeskService.newDraft(DraftFormModel.reply(
+        this.mailViewerComponent.mailObj,
+        this.draftDeskService.fromsSubject.value,
+        false,
+        useHTML
+      ));
+      this.mailViewerComponent.close('goToDraftDesk');
     }
 
     public replyToAll(useHTML: boolean) {
-        this.draftDeskService.newDraft(DraftFormModel.reply(this.mailViewerComponent.mailObj, this.draftDeskService.froms, true, useHTML));
-        this.mailViewerComponent.close('goToDraftDesk');
+      this.draftDeskService.newDraft(DraftFormModel.reply(
+        this.mailViewerComponent.mailObj,
+        this.draftDeskService.fromsSubject.value,
+        true,
+        useHTML
+      ));
+      this.mailViewerComponent.close('goToDraftDesk');
     }
 
     public forward(useHTML: boolean) {
         ProgressDialog.open(this.dialog);
         this.draftDeskService.newDraft(
-            DraftFormModel.forward(this.mailViewerComponent.mailObj, this.draftDeskService.froms, useHTML)
+          DraftFormModel.forward(this.mailViewerComponent.mailObj, this.draftDeskService.fromsSubject.value, useHTML)
         ).then(() => {
             this.mailViewerComponent.close('goToDraftDesk');
             ProgressDialog.close();

--- a/src/app/rmmapi/rmmhttpinterceptor.service.ts
+++ b/src/app/rmmapi/rmmhttpinterceptor.service.ts
@@ -84,6 +84,7 @@ export class RMMHttpInterceptorService implements HttpInterceptor {
                     if (e.status === 403) {
                         console.log('Forbidden');
                         this.checkAccountStatus();
+                        return throwError(e.message);
                     } else if (e.status === 502 || e.status === 504) {
                         // Bad Gateway / Gateway Timeout
                         this.rmmoffline.is_offline = true;

--- a/src/app/xapian/searchservice.ts
+++ b/src/app/xapian/searchservice.ts
@@ -752,7 +752,15 @@ export class SearchService {
         ).toPromise();
       }
 
-      let msginfos = await this.rmmapi.listAllMessages(...next_update['list_messages_args']).toPromise();
+      let msginfos = [];
+      try {
+        msginfos = await this.rmmapi.listAllMessages(...next_update['list_messages_args']).toPromise();
+      } catch (err) {
+        console.error(err);
+        if (typeof(err) !== 'string' && err.hasOwnProperty('errors')) {
+          console.log(err.errors);
+        }
+      }
 
       if (this.currentIndexUpdateMessageIds.size > 0) {
         // if an index update is already running, check we arent
@@ -797,9 +805,18 @@ export class SearchService {
                   (${numberOfUnreadMessages} vs ${currentFolder.newMessages})
                     not matching with index for current folder`);
 
-              const folderMessages = await this.rmmapi.listAllMessages(0, 0, 0,
-                MAX_DISCREPANCY_CHECK_LIMIT,
-                true, folderPath).toPromise();
+              let folderMessages = [];
+              try {
+                folderMessages = await this.rmmapi.listAllMessages(
+                  0, 0, 0,
+                  MAX_DISCREPANCY_CHECK_LIMIT,
+                  true, folderPath).toPromise();
+              } catch (err) {
+                console.error(err);
+                if (typeof(err) !== 'string' && err.hasOwnProperty('errors')) {
+                  console.log(err.errors);
+                }
+              }
               msginfos = msginfos.concat(folderMessages);
 
               const folderMessageIDS: {[messageId: number]: boolean} = {};


### PR DESCRIPTION
Fixes a bug where any Drafts that were edited or sent from outside of Runbox7 (eg via IMAP or RMM6)  were not reflected in Runbox7 until the page was refreshed manually.

Involves refactoring parts of draftdesk service and dependents to use Subjects rather than trying to keep local copies of "froms" and "drafts" uptodate

Plus a couple of smaller commits for niggles: switch to empty messagelist when choosing empty folders (was failing without index), and catch some rest api errors (and report to console) when fetching message index and content updates).