### PR TITLE
fix(compose): Speed up drag&drop of attachments onto compose editor

### DIFF
--- a/src/app/compose/compose.component.html
+++ b/src/app/compose/compose.component.html
@@ -100,7 +100,7 @@
         <mat-form-field *ngIf="editing" floatPlaceholder="auto" id="fieldSubject">
             <input matInput placeholder="Subject" name="subject" formControlName="subject" />
         </mat-form-field>                     
-        <section *ngIf="editing" [ngClass]="{'dropzonehighlight': showDropZone, 'overdropzone': draggingOverDropZone}" (dragover)="draggingOverDropZone=true" (dragleave)="draggingOverDropZone=false" (drop)="dropFiles($event)" id="dropZone">
+        <section *ngIf="editing" [ngClass]="{'dropzonehighlight': showDropZone, 'overdropzone': draggingOverDropZone}"  id="dropZone">
             <h1 *ngIf="showDropZone" id="dropZoneText">Drop files here</h1>            
             <mat-progress-bar *ngIf="uploadprogress!=null"                               
                 mode="determinate"


### PR DESCRIPTION
The problem: Dragging & dropping files onto the compose window would pop up the "drop files here" box, then appear to do nothing for 30secs or longer, then draw the progress bar / visually upload the file.

The solution: Folks on t'internet seem many have issues with this, I pulled the most used solution, which is to have the drag/drop events processed "outside angular" (using the zone object), which seems to speed everything up.

Also added a bunch of guards, and prevented it from bubbling the event up (down?) the chain of elements, as it was trying to run the check files / upload files maaaany times.

Fixes #1070