### PR TITLE
fix(folderlist): Check current folder counts for all folder types

### DIFF
--- a/src/app/rmmapi/rbwebmail.ts
+++ b/src/app/rmmapi/rbwebmail.ts
@@ -67,6 +67,12 @@ export class FolderListEntry {
     }
 }
 
+export class FolderStatsEntry {
+    total: number;
+    total_unseen: number;
+    total_seen: number;
+}
+
 export class Alias {
     constructor(
         public id: number,
@@ -388,6 +394,24 @@ export class RunboxWebmailAPI {
         }).pipe(share());
         this.subscribeShowBackendErrors(req);
         return req.pipe(map((res: any) => res.status === 'success'));
+    }
+
+    folderStats(folderName: string): Observable<FolderStatsEntry> {
+        const req = this.http.get('/rest/v1/email_folder/stats/' + folderName).pipe(share());
+        this.subscribeShowBackendErrors(req);
+        return req.pipe(
+            map((response: any) => {
+                const fse = new FolderStatsEntry();
+                fse.total = response.result.stats.total;
+                fse.total_unseen = response.result.stats.total_unseen;
+                fse.total_seen = response.result.stats.total_seen;
+                return fse;
+            })
+        );
+    }
+
+    updateFolderCounts(folderName: string): Observable<any> {
+        return this.http.post('/rest/v1/email_folder/stats/' + folderName, {});
     }
 
     moveFolder(folderId: number, newParentFolderId: number, ordered_ids?: number[]): Observable<boolean> {

--- a/src/app/xapian/searchservice.spec.ts
+++ b/src/app/xapian/searchservice.spec.ts
@@ -258,7 +258,7 @@ describe('SearchService', () => {
         req.flush(testMessageId + '\t' +  testMessageTime + '\t' + testMessageTime + '\tInbox\t1\t0\t0\t' +
             'Cloud Web Services <cloud-marketing-email-replies@cloudsuperhosting.com>\ttest@example.com	Analyse Data at Scale\ty');
 
-        await new Promise(resolve => setTimeout(resolve, 100));
+        await new Promise(resolve => setTimeout(resolve, 1000));
 
         const sincechangeddate = new Date(indexLastUpdateTime - new Date().getTimezoneOffset() * 60 * 1000);
         const datestring = sincechangeddate.toJSON().replace('T', ' ').substr(0, 'yyyy-MM-dd HH:mm:ss'.length);
@@ -268,7 +268,7 @@ describe('SearchService', () => {
             message_ids: []
         });
 
-        await new Promise(resolve => setTimeout(resolve, 100));
+        await new Promise(resolve => setTimeout(resolve, 1000));
 
         expect(searchService.api.sortedXapianQuery('flag:missingbodytext', 0, 0, 0, 10, -1).length).toBe(1);
 


### PR DESCRIPTION
This enhances previous code that only checked the index counts against
the rest api counts. Now we also check non-indexed folders (Spam/Trash)
stored folder count values against actual counts.

Needs a rest api update

Fixes #1182