### PR TITLE
Castaway/1070 compose drag

### DIFF
--- a/src/app/compose/compose.component.html
+++ b/src/app/compose/compose.component.html
@@ -100,7 +100,7 @@
         <mat-form-field *ngIf="editing" floatPlaceholder="auto" id="fieldSubject">
             <input matInput placeholder="Subject" name="subject" formControlName="subject" />
         </mat-form-field>                     
-        <section *ngIf="editing" [ngClass]="{'dropzonehighlight': showDropZone, 'overdropzone': draggingOverDropZone}"  id="dropZone">
+        <section *ngIf="editing" [ngClass]="{'dropzonehighlight': showDropZone, 'overdropzone': draggingOverDropZone}" (dragover)="draggingOverDropZone=true" (dragleave)="draggingOverDropZone=false" (drop)="dropFiles($event)" id="dropZone">
             <h1 *ngIf="showDropZone" id="dropZoneText">Drop files here</h1>            
             <mat-progress-bar *ngIf="uploadprogress!=null"                               
                 mode="determinate"
@@ -123,7 +123,7 @@
               <a [href]="'/rest/v1/email/'+model.mid+'/viewdraft/'+i+'/?filename='+attachment.file+'&origfilename='+displayWithoutRBWUL(attachment.file)">{{displayWithoutRBWUL(attachment.file)}} ({{attachment.size}})</a>
               <button mat-icon-button id="deleteAttachment" (click)="removeAttachment(i)"><mat-icon svgIcon="delete"></mat-icon></button>
             </ng-container>
-          </div>      
+          </div>
         </section>      
         <span [hidden]="editing">
             {{this.model.preview}}

--- a/src/app/compose/compose.component.ts
+++ b/src/app/compose/compose.component.ts
@@ -390,6 +390,7 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
     public loadDraft(msgObj) {
         const model = new DraftFormModel();
         model.mid = typeof msgObj.mid === 'string' ? parseInt(msgObj.mid, 10) : msgObj.mid;
+        this.draftDeskservice.isEditing = model.mid;
         model.attachments = msgObj.attachments.map((att) => Object.assign({
             file_url: att.filename,
             file: att.filename

--- a/src/app/compose/compose.component.ts
+++ b/src/app/compose/compose.component.ts
@@ -221,17 +221,8 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
 
         this._ngZone.runOutsideAngular(() => {
             window.addEventListener(
-                'drop', this.dropFiles.bind(this)
-            );
-            // window.addEventListener(
-            //     'dragend', this._onDragEnd.bind(this)
-            // );
-            window.addEventListener(
                 'dragover', this.onDragOver.bind(this)
             );
-            // window.addEventListener(
-            //     'dragenter', this._onDragEnter.bind(this)
-            // );
             window.addEventListener(
                 'dragleave', this.onDragLeave.bind(this)
             );
@@ -245,7 +236,8 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
     }
 
     onDragLeave(event: DragEvent) {
-        event.preventDefault();
+        // only do this once on any event in the window, else the whole thing
+        // flickers
         event.stopImmediatePropagation();
         if (!this.dragLeaveTimeout) {
             // Drag leave events are fired all the time - so add some throttling on them
@@ -256,32 +248,29 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
         return false;
     }
 
+    // on Drag over - entire window, if contains files, show the drop zone
     onDragOver(event: DragEvent) {
-        event.stopImmediatePropagation();
-        if (!this.draggingOverDropZone && !this.showDropZone) {
-            this.draggingOverDropZone = true;
-            if (this.showDropZone) {
-                event.preventDefault();
-                return false;
+        if (this.showDropZone) {
+            event.preventDefault();
+            return false;
+        }
+        const dt = event.dataTransfer;
+        if (dt.types) {
+            let foundFilesType = false;
+            for (let n = 0; n < dt.types.length; n++) {
+                if (dt.types[n] === 'Files' || dt.types[n] === 'application/x-moz-file') {
+                    foundFilesType = true;
+                    break;
+                }
             }
-            const dt = event.dataTransfer;
-            if (dt.types && !this.showDropZone) {
-                let foundFilesType = false;
-                for (let n = 0; n < dt.types.length; n++) {
-                    if (dt.types[n] === 'Files' || dt.types[n] === 'application/x-moz-file') {
-                        foundFilesType = true;
-                        break;
-                    }
+            if (foundFilesType) {
+                event.stopImmediatePropagation();
+                event.preventDefault();
+                if (this.dragLeaveTimeout) {
+                    clearTimeout(this.dragLeaveTimeout);
+                    this.dragLeaveTimeout = null;
                 }
-                if (foundFilesType) {
-                    event.preventDefault();
-                    if (this.dragLeaveTimeout) {
-                        clearTimeout(this.dragLeaveTimeout);
-                        this.dragLeaveTimeout = null;
-                    }
-                    this.showDropZone = true;
-                    this.draggingOverDropZone = false;
-                }
+                this.showDropZone = true;
             }
         }
     }
@@ -301,10 +290,8 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
     }
 
     public hideDropZone() {
-        if (this.showDropZone) {
-            this.draggingOverDropZone = false;
-            this.showDropZone = false;
-        }
+      this.draggingOverDropZone = false;
+      this.showDropZone = false;
     }
 
     addRecipientFromSuggestions(recipient: MailAddressInfo) {


### PR DESCRIPTION
This *should* display the compose dropZone consistently, AND have the file upload visuals not take ages...

Also fixed: Ensure edited draft is re-opened after a drafts refresh.