### PR TITLE
fix(folders): Ensure creating a new folder does not show above Inbox

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -513,7 +513,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
 
   createFolder(newFolder: CreateFolderEvent) {
     this.rmmapi.createFolder(
-      newFolder.parentId, newFolder.name
+      newFolder.parentId, newFolder.name, newFolder.order
     ).subscribe(() => {
       this.messagelistservice.refreshFolderList();
     });

--- a/src/app/rmmapi/rbwebmail.ts
+++ b/src/app/rmmapi/rbwebmail.ts
@@ -364,10 +364,11 @@ export class RunboxWebmailAPI {
         }
     }
 
-    createFolder(parentFolderId: number, newFolderName: string): Observable<boolean> {
+    createFolder(parentFolderId: number, newFolderName: string, order: number[]): Observable<boolean> {
         const req = this.http.post('/rest/v1/email_folder/create', {
             'new_folder': newFolderName,
-            'to_folder': parentFolderId
+            'to_folder': parentFolderId,
+            'ordered_ids': order
         }).pipe(share());
         this.subscribeShowBackendErrors(req);
         return req.pipe(map((res: any) => res.status === 'success'));


### PR DESCRIPTION
Always use "priority" for sorting folders, instead of only when "move"
sorts them. Create sends a priorities order into which the newly
created folder can be inserted.

Sorting via priorities (or alphabetically) is now handled on the
backend inside the "list" endpoint. This ensures that new folders
created using RMM6 also do not appear above Inbox.

Fixes #1099