### PR TITLE
Checks the msg IDs given to API for certain endpoints are valid

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -621,7 +621,9 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
   public trainSpam(params) {
     const msg = params.is_spam ? 'Reporting spam' : 'Reporting not spam';
     const snackBarRef = this.snackBar.open( msg );
-    const messageIds = this.canvastable.rows.selectedMessageIds();
+    const unfilteredMessageIds = this.canvastable.rows.selectedMessageIds();
+    // ensure valid IDs
+    const messageIds = unfilteredMessageIds.filter(id => Number.isInteger(id));
 
     this.messageActionsHandler.updateMessages({
       messageIds: messageIds,

--- a/src/app/xapian/searchservice.ts
+++ b/src/app/xapian/searchservice.ts
@@ -780,25 +780,29 @@ not matching with index for current folder`);
 
     try {
       const pendingIndexVerificationsArray = Object.keys(this.pendingIndexVerifications)
-                    .map(idstring => {
-                      const msgobj = this.pendingIndexVerifications[idstring];
-                      return {
-                        id: parseInt(msgobj.id.substring(1), 10),
-                        flagged: msgobj.flagged ? 1 : 0,
-                        seen: msgobj.seen ? 1 : 0,
-                        answered: msgobj.answered ? 1 : 0,
-                        deleted: msgobj.deleted ? 1 : 0,
-                        folder: msgobj.folder
-                      };
-                    }
-        );
+        .map(idstring => {
+          const msgobj = this.pendingIndexVerifications[idstring];
+          const msgId = parseInt(msgobj.id.substring(1), 10);
+          return {
+            id: parseInt(msgobj.id.substring(1), 10),
+            flagged: msgobj.flagged ? 1 : 0,
+            seen: msgobj.seen ? 1 : 0,
+            answered: msgobj.answered ? 1 : 0,
+            deleted: msgobj.deleted ? 1 : 0,
+            folder: msgobj.folder
+          };
+        }
+      );
+      // Ensure there are no empty ID's in the array of objects
+      const filteredpendingIndexVerificationArray = pendingIndexVerificationsArray
+        .filter(msgobj => Number.isInteger(msgobj.id));
 
       this.pendingIndexVerifications = {};
 
-      if (pendingIndexVerificationsArray.length > 0) {
+      if (filteredpendingIndexVerificationArray.length > 0) {
         await this.httpclient.post('/rest/v1/searchindex/verifymessages',
             {
-              indexEntriesToVerify: pendingIndexVerificationsArray
+              indexEntriesToVerify: filteredpendingIndexVerificationArray
             }
         ).toPromise();
       }


### PR DESCRIPTION
A frontend addressing of an issue in [internal issues] 1177 and 1178, verifying via a isInteger filter that the functions which call move_messages and and verifymessages for the searchindex that message IDs given are valid integers. Number.isInteger will return true on valid integer numbers (including 0) but false on empty/NaN values, ensuring at least they are valid integers before they are given to the API. The is because it doesn't otherwise check in the arrays (or array of objects) that the message ID's are valid.
This issue has also been addressed in the backend, but this is for consistency and cutting down redundant API calls that are found already invalid.
From a npm start and reporting existing spam mail in my SC mailbox it appears to function as frontend behaves and general usage doesn't report back network errors back from the backend.