### PR TITLE
Adds a link to caldav sync guide on calendar

### DIFF
--- a/src/app/calendar-app/calendar-app.component.html
+++ b/src/app/calendar-app/calendar-app.component.html
@@ -129,6 +129,11 @@
                 <p mat-line>Settings</p>
             </mat-list-item>
 
+            <a mat-list-item target="_blank" href="https://help.runbox.com/using-a-calendar-client-with-caldav/" class="calendarMenuButton">
+                <mat-icon mat-list-icon svgIcon="sync"></mat-icon>
+                <p mat-line>CalDAV Sync Guide</p>
+            </a>
+
             <mat-divider></mat-divider>
 
             <div class="calendarsSideHeader">

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -121,11 +121,16 @@ mat-form-field {
     font-size: 15px !important;
 }
 
-mat-list-item .mat-list-item-content {
+/* The anchor tag classing is required as it doesn't inherit the styles with html level a[mat-list-item] */
+mat-list-item .mat-list-item-content,
+a[mat-list-item] .mat-list-item-content {
     min-height: 36px !important;
 }
 
-.mat-list[dense] .mat-list-item .mat-list-text, .mat-nav-list[dense] .mat-list-item .mat-list-text>*, mat-list-item .mat-list-text {
+.mat-list[dense] .mat-list-item .mat-list-text, 
+.mat-nav-list[dense] .mat-list-item .mat-list-text>*,
+mat-list-item .mat-list-text,
+a[mat-list-item] .mat-list-text {
     height: 1.3em;
     line-height: 22px;
     font-weight: 400;


### PR DESCRIPTION
Adds a link to the Caldav calendar syncing help as per #805 and appears as below in a new tab. Required some CSS tweaks as mat-list-item wasn't correctly taking certain custom styles in styles.css due to being used as an attribute to an anchor (as per angular docs specify it to be done for links).
Name of link is simply a first pass guess for "this is a guide on how to sync with Caldav" to avoid obscurity/confusion on the link purpose.
![image](https://user-images.githubusercontent.com/5954123/186733191-2fcab231-2bdb-4bf2-8982-781f6af288af.png)
