### PR TITLE
fix(changelog): Ensure typos in commit entries do not break the page

### DIFF
--- a/src/build/build-changelog.js
+++ b/src/build/build-changelog.js
@@ -7,7 +7,7 @@ const lines = stdout.toString().split('\n');
 const changes = [];
 
 function find_entry(line) {
-    const m = line.match(/(\w+)\(([^)]+)\):\s(.+)/);
+    const m = line.match(/(build|ci|docs|feat|feature|fix|perf|refactor|refator|style|test)\(([^)]+)\):\s(.+)/);
     if (m) {
         return m.slice(1);
     } else {


### PR DESCRIPTION
In which we only output correctly formatted entries.

Fixes #1318 