### PR TITLE
Castaway/compose improvements

### DIFF
--- a/src/app/compose/compose.component.ts
+++ b/src/app/compose/compose.component.ts
@@ -66,6 +66,7 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
     public draggingOverDropZone = false;
     public editing = false;
     public isUnsaved = false;
+    public savingInProgress = false;
     public uploadprogress: number = null;
     public uploadingFiles: FileList = null;
     public uploadRequest: Subscription = null;
@@ -581,6 +582,10 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
     }
 
     public submit(send: boolean = false) {
+        if (this.savingInProgress) {
+            return;
+        }
+        this.savingInProgress = true;
         if (send) {
             let validemails = false;
             validemails = isValidEmailArray(this.model.to);
@@ -656,6 +661,7 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
                     this.draftDeskservice.isEditing = -1;
                     this.draftDeleted.emit(this.model.mid);
 
+                    this.savingInProgress = false;
                     this.dialogService.closeProgressDialog();
                     this.exitToTable();
                 }, (err) => {
@@ -669,6 +675,7 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
                         `Error sending: ${msg}`,
                         'Dismiss'
                     );
+                    this.savingInProgress = false;
                     this.dialogService.closeProgressDialog();
                 });
         } else {
@@ -715,6 +722,7 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
                     this.saved = new Date();
                     this.saveErrorMessage = null;
 
+                    this.savingInProgress = false;
                     if (send) {
                         this.draftDeleted.emit(this.model.mid);
                         this.snackBar.open(res.status_msg, null, { duration: 3000 });
@@ -726,6 +734,7 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
                                 .map(fieldname =>
                                     `field ${fieldname}: ${err.field_errors[fieldname][0]}`);
                     }
+                    this.savingInProgress = false;
                     this.saveErrorMessage = `Error saving draft: ${msg}`;
                 });
         }

--- a/src/app/compose/compose.component.ts
+++ b/src/app/compose/compose.component.ts
@@ -306,6 +306,7 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
 
     public onFilesSelected(event) {
         this.uploadFiles(event.target.files);
+        this.attachmentFileUploadInput.nativeElement.value = '';
     }
 
     public displayWithoutRBWUL(filename: string): string {

--- a/src/app/compose/draftdesk.service.ts
+++ b/src/app/compose/draftdesk.service.ts
@@ -50,7 +50,7 @@ export class DraftFormModel {
     reply_to: string = null;
     subject: string = null;
     msg_body = '';
-    html: string;
+    html = '';
     preview: string;
     in_reply_to: string;
     reply_to_id: string = null;


### PR DESCRIPTION
Making an assumption that multiple drafts appearing is because of multiple save-runs happening at the same time, especially during the first save, which would send the "new draft" mid (a negative value) multiple times, and thus create multiple drafts. Fixed by only letting it happen once per draft.

Fixed a save issue where an initial save when in HTML mode wouldn't save until there was some content in the email body.

Clear attachment inputs after use (otherwise wouldnt trigger on attaching same file twice)