### PR TITLE
fix(messaging): Delete both copys of an HTTP request if it fails

### DIFF
--- a/src/app/rmmapi/rbwebmail.ts
+++ b/src/app/rmmapi/rbwebmail.ts
@@ -265,7 +265,7 @@ export class RunboxWebmailAPI {
                             reject(response);
                         }
                     }, err => {
-                        delete this.messageContentsRequestCache[messageId];
+                        this.deleteCachedMessageContents(messageId);
                         reject(err);
                     });
                 });


### PR DESCRIPTION
We cache requests for message contents, if the request turns out to fail we should delete both copies so that it is refetched

Improves #1309