### PR TITLE
Castaway/compose images

### DIFF
--- a/src/app/compose/compose.component.ts
+++ b/src/app/compose/compose.component.ts
@@ -486,7 +486,12 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
                             ? this.formGroup.value.msg_body.replace(/\n/g, '<br />\n')
                             :  ''
                     );
-                }
+                },
+                image_list: (cb) => cb(this.model.attachments ? this.model.attachments.map(att => ({
+                    title: this.displayWithoutRBWUL(att.file),
+                    value: '/ajax/download_draft_attachment?filename=' + att.file
+                })) : []),
+
             };
             this.tinymce_plugin.create(options);
         } else {

--- a/src/app/rmm/plugin/tinymce.plugin.ts
+++ b/src/app/rmm/plugin/tinymce.plugin.ts
@@ -37,10 +37,10 @@ export class TinyMCEPlugin {
                     'visualblocks visualchars fullscreen image link template codesample ' +
                     'table charmap hr pagebreak ' +
                     'nonbreaking anchor toc insertdatetime advlist lists wordcount imagetools ' +
-                    'textpattern help code'),
+                    'textpattern help code paste'),
                 toolbar: (options.toolbar || 'formatselect | bold italic strikethrough forecolor backcolor codesample | ' +
                         'link image | alignleft aligncenter alignright alignjustify  | ' +
-                        'numlist bullist outdent indent | removeformat | addcomment | code'),
+                        'numlist bullist outdent indent | removeformat | addcomment | code | paste'),
                 codesample_languages: (options.codesample_languages || [
                             {text: 'HTML/XML', value: 'markup'},
                             {text: 'JavaScript', value: 'javascript'},
@@ -54,6 +54,7 @@ export class TinyMCEPlugin {
                             {text: 'C++', value: 'cpp'}
                         ]),
                 contextmenu: false,
+                paste_data_images: true,
                 image_list: (options.image_list || []),
                 menubar: (options.menubar || false),
                 setup: (options.setup),


### PR DESCRIPTION
1. Allow pasting, or drag&drop of images directly into HTML compose window
2. Insert/Edit dialog box lists attached images to insert into HTML compose window