### PR TITLE
Castaway/1122 drag and drop loses one

### DIFF
--- a/src/app/common/messagedisplay.ts
+++ b/src/app/common/messagedisplay.ts
@@ -116,7 +116,7 @@ export abstract class MessageDisplay {
     // Drag&Drop, if we click to drag, we don't want to change the state of
     // the selection.
     // UNLESS: no messages are selected, then we select+drag one.
-    if (columnIndex == -1) {
+    if (columnIndex === -1) {
       if (this.isSelectedRow(rowIndex)) {
         return;
       }

--- a/src/app/common/messagedisplay.ts
+++ b/src/app/common/messagedisplay.ts
@@ -113,6 +113,15 @@ export abstract class MessageDisplay {
     //    const selectedRowId = this.getRowId(rowIndex);
     const selectedRowId = rowIndex;
 
+    // Drag&Drop, if we click to drag, we don't want to change the state of
+    // the selection.
+    // UNLESS: no messages are selected, then we select+drag one.
+    if (columnIndex == -1) {
+      if (this.isSelectedRow(rowIndex)) {
+        return;
+      }
+    }
+
     // multiSelect just means do these, nothing else:
     // multiSelect is true if we're applying rowSelect in a loop
     this.selectedRowId = selectedRowId;

--- a/src/app/common/messagelist.ts
+++ b/src/app/common/messagelist.ts
@@ -87,7 +87,8 @@ export class MessageList extends MessageDisplay {
         sortColumn: null,
         rowWrapModeMuted: true,
         getValue: (rowIndex: number): string => this.getRow(rowIndex).messageDate.toJSON(),
-        getFormattedValue: (datestring) => MessageTableRowTool.formatTimestamp(datestring)
+        getFormattedValue: (datestring) => MessageTableRowTool.formatTimestamp(datestring),
+        draggable: true
       },
       {
         name: app.selectedFolder === 'Sent' ? 'To' : 'From',
@@ -96,6 +97,7 @@ export class MessageList extends MessageDisplay {
         getValue: (rowIndex: number): any => app.selectedFolder === 'Sent'
           ? this.getToColumnValueForRow(rowIndex)
           : this.getFromColumnValueForRow(rowIndex),
+        draggable: true
       },
       {
         name: 'Subject',
@@ -116,6 +118,7 @@ export class MessageList extends MessageDisplay {
         rowWrapModeHidden: true,
         getValue: (rowIndex: number): number => this.getRow(rowIndex).size,
         getFormattedValue: MessageTableRowTool.formatBytes,
+        draggable: true
       },
       {
         sortColumn: null,

--- a/src/app/websocketsearch/websocketsearchmaillist.ts
+++ b/src/app/websocketsearch/websocketsearchmaillist.ts
@@ -63,6 +63,7 @@ export class WebSocketSearchMailList extends MessageDisplay {
             },
             {
                 name: 'Date',
+                draggable: true,
                 cacheKey: 'date',
                 sortColumn: null,
                 rowWrapModeMuted: true,
@@ -70,6 +71,7 @@ export class WebSocketSearchMailList extends MessageDisplay {
             },
             {
                 name: 'From',
+                draggable: true,
                 cacheKey: 'from',
                 sortColumn: null,
                 getValue: (rowIndex: number): string => this.getRow(rowIndex).fromName,
@@ -84,6 +86,7 @@ export class WebSocketSearchMailList extends MessageDisplay {
             },
             {
                 sortColumn: null,
+                draggable: true,
                 name: 'Size',
                 cacheKey: 'size',
                 rowWrapModeHidden: true,

--- a/src/app/xapian/searchmessagedisplay.ts
+++ b/src/app/xapian/searchmessagedisplay.ts
@@ -68,6 +68,7 @@ export class SearchMessageDisplay extends MessageDisplay {
       },
       {
         name: 'Date',
+        draggable: true,
         cacheKey: 'date',
         sortColumn: 2,
         rowWrapModeMuted : true,
@@ -76,12 +77,14 @@ export class SearchMessageDisplay extends MessageDisplay {
       },
       (app.selectedFolder.indexOf('Sent') === 0 && !app.displayFolderColumn) ? {
         name: 'To',
+        draggable: true,
         cacheKey: 'from',
         sortColumn: null,
         getValue: (rowIndex): string => this.searchService.getDocData(this.getRowId(rowIndex)).recipients.join(', '),
       } :
         {
           name: 'From',
+          draggable: true,
           cacheKey: 'from',
           sortColumn: 0,
           getValue: (rowIndex): string => {
@@ -127,6 +130,7 @@ export class SearchMessageDisplay extends MessageDisplay {
       columns.push(
         {
           name: 'Count',
+          draggable: true,
           cacheKey: 'count',
           sortColumn: null,
           rowWrapModeChipCounter: true,
@@ -147,6 +151,7 @@ export class SearchMessageDisplay extends MessageDisplay {
       columns.push(
         {
           sortColumn: 3,
+          draggable: true,
           name: 'Size',
           cacheKey: 'size',
           rowWrapModeHidden: true,


### PR DESCRIPTION
When click & dragging: 
If message clicked on is already selected, do nothing and continue with drag
If message is not yet selected, select message and continue with drag

(Existing logic was somewhat convoluted)

Also added: We can now drag messages from Date, From/To, Subject and Size columns (instead of just Subject)