### PR TITLE
Castaway/1348 keep worker alive

### DIFF
--- a/src/app/xapian/index.worker.ts
+++ b/src/app/xapian/index.worker.ts
@@ -982,9 +982,9 @@ ctx.addEventListener('message', ({ data }) => {
       );
     };
   } else if (data['action'] === PostMessageAction.updateIndexWithNewChanges) {
-    clearTimeout(searchIndexService.indexUpdateIntervalId);
-  } else if (data['action'] === PostMessageAction.stopIndexUpdates) {
     searchIndexService.updateIndexWithNewChanges(data['args']);
+  } else if (data['action'] === PostMessageAction.stopIndexUpdates) {
+    clearTimeout(searchIndexService.indexUpdateIntervalId);
   } else if (data['action'] === PostMessageAction.deleteLocalIndex) {
     // console.log('Worker: deleting local index...');
     searchIndexService.deleteLocalIndex().subscribe(() => {


### PR DESCRIPTION
I'd left in a stupid error - user actions resulted in "stop index updates" (!) this should revert to the intended effect - user actions cause a quicker index update to sync the user changes