### PR TITLE
fix(compose): Generate Reply/Fwd header text only when needed

### DIFF
--- a/src/app/compose/compose.component.ts
+++ b/src/app/compose/compose.component.ts
@@ -146,9 +146,9 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
             if (this.composeInHTMLByDefault) {
                 this.model.useHTML = true;
             }
-            // This.. shouldnt happen as only have content if reply/fwd
+            // above was true and we replied to a text-view email:
             if (this.model.useHTML && !this.model.html) {
-                this.model.html = this.model.msg_body;
+                this.model.html = this.model.msg_body.replace(/\n/g, '<br />\n');
                 console.log('Copied msg body to html attribute');
             }
             if (this.model.cc.length > 0) {

--- a/src/app/compose/draftdesk.service.spec.ts
+++ b/src/app/compose/draftdesk.service.spec.ts
@@ -24,15 +24,10 @@ import { MailAddressInfo } from '../common/mailaddressinfo';
 
 describe('DraftDesk', () => {
     const mailDate = new Date(2017, 6, 1);
-    const timezoneOffset: number = mailDate.getTimezoneOffset();
-    const timezoneOffsetString: string = 'GMT' + (timezoneOffset <= 0 ? '+' : '-') +
-        ('' + (100 + (Math.abs(timezoneOffset) / 60))).substr(1, 2) + ':' +
-        ('' + (100 + (Math.abs(timezoneOffset) % 60))).substr(1, 2);
 
-    it('Reply: Address with object, single reply', (done) => {
-        console.log('Reply test: Address with object, single reply');
+    it('Forward: froms, plain text', (done) => {
         // fromObj, identities, all (t/f), html (t/f)
-        const draft = DraftFormModel.reply({
+        const draft = DraftFormModel.forward({
             headers: {
                 'message-id': 'themessageid12123abcdef',
             },
@@ -43,6 +38,7 @@ describe('DraftDesk', () => {
             to: [
                 {address: 'to@runbox.com', name: 'To'}
             ],
+            attachments: [],
             date: mailDate,
             subject: 'Test subject',
             text: 'blabla\nabcde',
@@ -50,12 +46,67 @@ describe('DraftDesk', () => {
             html: '<p>blabla</p><p>abcde</p>'
         },
         [ FromAddress.fromEmailAddress('to@runbox.com')],
-        false, false);
+        false);
 
-        expect(draft.subject).toBe('Re: Test subject');
+        expect(draft.subject).toBe('Fwd: Test subject');
         expect(draft.from).toBe('to@runbox.com');
-        expect(draft.to[0].nameAndAddress).toBe('"From" <from@runbox.com>');
-        expect(draft.msg_body).toBe(`\n2017-07-01 00:00 ${timezoneOffsetString} "From" <from@runbox.com>:\n> blabla\n> abcde`);
+        // expect(draft.to[0].nameAndAddress).toBe('"From" <from@runbox.com>');
+        expect(draft.msg_body).toBe(
+            `\n\n----------------------------------------------\nForwarded message:
+From: "From" <from@runbox.com>
+Time: 2017-07-01 00:00 +00:00 GMT
+Subject: Test subject
+To: "To" <to@runbox.com>
+
+
+blabla\nabcde`);
+        expect(draft.isUnsaved()).toBe(true);
+        done();
+    });
+    it('Forward: froms, html text', (done) => {
+        // fromObj, identities, all (t/f), html (t/f)
+        const draft = DraftFormModel.forward({
+            headers: {
+                'message-id': 'themessageid12123abcdef',
+            },
+            from: [
+                {address: 'from@runbox.com', name: 'From'}
+            ]
+            ,
+            to: [
+                {address: 'to@runbox.com', name: 'To'}
+            ],
+            attachments: [],
+            date: mailDate,
+            subject: 'Test subject',
+            text: 'blabla\nabcde',
+            rawtext: 'blabla\nabcde',
+            html: '<p>blabla</p><p>abcde</p>',
+            sanitized_html: '<p>blabla</p><p>abcde</p>'
+        },
+        [ FromAddress.fromEmailAddress('to@runbox.com')],
+        true);
+
+        expect(draft.subject).toBe('Fwd: Test subject');
+        expect(draft.from).toBe('to@runbox.com');
+        // expect(draft.to[0].nameAndAddress).toBe('"From" <from@runbox.com>');
+        expect(draft.html).toBe(
+            `<br />
+<hr style="width: 100%" />
+---------- Forwarded message ----------<br />
+From: "From" &lt;from@runbox.com&gt; <br />
+Time: 2017-07-01 00:00 +00:00 GMT <br />
+Subject: Test subject <br />
+<span>To: <span>"To" &lt;to@runbox.com&gt;</span></span> <br /><br />
+<p>blabla</p><p>abcde</p>`);
+// <br />
+// <hr style="width: 100%" />
+// ---------- Forwarded message ----------<br />
+// From: "From" &lt;from@runbox.com&gt; <br/>
+// Time: 2017-07-01 00:00 <br/>
+// Subject: Test subject <br/>
+// <span>To: <span>"To" &lt;to@runbox.com&gt;</span></span> <br /><br />
+// <p>blabla</p><p>abcde</p>`);
         expect(draft.isUnsaved()).toBe(true);
         done();
     });
@@ -92,7 +143,74 @@ describe('DraftDesk', () => {
         expect(draft.subject).toBe('Re: Test subject');
         expect(draft.from).toBe('to@runbox.com');
         expect(draft.to[0].nameAndAddress).toBe('"Reply-To" <reply-to@runbox.com>');
-        expect(draft.msg_body).toBe(`\n2017-07-01 00:00 ${timezoneOffsetString} "From" <from@runbox.com>:\n> blabla\n> abcde`);
+        expect(draft.msg_body).toBe(`\nOn 2017-07-01 00:00 +00:00 GMT, "From" <from@runbox.com> wrote:\n> blabla\n> abcde`);
+        expect(draft.isUnsaved()).toBe(true);
+        done();
+    });
+    it('Reply: Address with object, single reply', (done) => {
+        console.log('Reply test: Address with object, single reply');
+        // fromObj, identities, all (t/f), html (t/f)
+        const draft = DraftFormModel.reply({
+            headers: {
+                'message-id': 'themessageid12123abcdef',
+            },
+            from: [
+                {address: 'from@runbox.com', name: 'From'}
+            ]
+            ,
+            to: [
+                {address: 'to@runbox.com', name: 'To'}
+            ],
+            date: mailDate,
+            subject: 'Test subject',
+            text: 'blabla\nabcde',
+            rawtext: 'blabla\nabcde',
+            html: '<p>blabla</p><p>abcde</p>'
+        },
+        [ FromAddress.fromEmailAddress('to@runbox.com')],
+        false, false);
+
+        expect(draft.subject).toBe('Re: Test subject');
+        expect(draft.from).toBe('to@runbox.com');
+        expect(draft.to[0].nameAndAddress).toBe('"From" <from@runbox.com>');
+        expect(draft.msg_body).toBe(`\nOn 2017-07-01 00:00 +00:00 GMT, "From" <from@runbox.com> wrote:\n> blabla\n> abcde`);
+        expect(draft.isUnsaved()).toBe(true);
+        done();
+    });
+    it('Reply: Address with object, single reply-to', (done) => {
+        console.log('Reply test: Address with object, single reply-to');
+        // fromObj, identities, all (t/f), html (t/f)
+        const draft = DraftFormModel.reply({
+            headers: {
+                'message-id': 'themessageid12123abcdef',
+                'reply-to': {
+                    'text': 'Reply-To <reply-to@runbox.com>',
+                    'value': [{
+                        'name': 'Reply-To',
+                        'address': 'reply-to@runbox.com'
+                    }]
+                }
+            },
+            from: [
+                {address: 'from@runbox.com', name: 'From'}
+            ]
+            ,
+            to: [
+                {address: 'to@runbox.com', name: 'To'}
+            ],
+            date: mailDate,
+            subject: 'Test subject',
+            text: 'blabla\nabcde',
+            rawtext: 'blabla\nabcde',
+            html: '<p>blabla</p><p>abcde</p>'
+        },
+        [ FromAddress.fromEmailAddress('to@runbox.com')],
+        false, false);
+
+        expect(draft.subject).toBe('Re: Test subject');
+        expect(draft.from).toBe('to@runbox.com');
+        expect(draft.to[0].nameAndAddress).toBe('"Reply-To" <reply-to@runbox.com>');
+        expect(draft.msg_body).toBe(`\nOn 2017-07-01 00:00 +00:00 GMT, "From" <from@runbox.com> wrote:\n> blabla\n> abcde`);
         expect(draft.isUnsaved()).toBe(true);
         done();
     });
@@ -135,7 +253,7 @@ describe('DraftDesk', () => {
         expect(draft.to[0].nameAndAddress).toBe('"Reply-To" <reply-to@runbox.com>');
         expect(draft.to[1].nameAndAddress).toBe('"To-Extra" <to-extra@runbox.com>');
         expect(draft.cc[0].nameAndAddress).toBe('"CC" <cc@runbox.com>');
-        expect(draft.msg_body).toBe(`\n2017-07-01 00:00 ${timezoneOffsetString} "From" <from@runbox.com>:\n> blabla\n> abcde`);
+        expect(draft.msg_body).toBe(`\nOn 2017-07-01 00:00 +00:00 GMT, "From" <from@runbox.com> wrote:\n> blabla\n> abcde`);
         expect(draft.isUnsaved()).toBe(true);
         done();
     });
@@ -164,7 +282,7 @@ describe('DraftDesk', () => {
         expect(draft.subject).toBe('Re: Test subject');
         expect(draft.from).toBe('to@runbox.com');
         expect(draft.to[0].nameAndAddress).toBe('"From" <from@runbox.com>');
-        expect(draft.msg_body).toBe(`\n2017-07-01 00:00 ${timezoneOffsetString} "From" <from@runbox.com>:\n> blabla\n> abcde`);
+        expect(draft.msg_body).toBe(`\nOn 2017-07-01 00:00 +00:00 GMT, "From" <from@runbox.com> wrote:\n> blabla\n> abcde`);
         expect(draft.isUnsaved()).toBe(true);
         done();
     });
@@ -192,7 +310,7 @@ describe('DraftDesk', () => {
         expect(draft.subject).toBe('Re: Test subject');
         expect(draft.from).toBe('to@runbox.com');
         expect(draft.to[0].nameAndAddress).toBe('"From" <from@runbox.com>');
-        expect(draft.msg_body).toBe(`\n2017-07-01 00:00 ${timezoneOffsetString} "From" <from@runbox.com>:\n> blabla\n> abcde`);
+        expect(draft.msg_body).toBe(`\nOn 2017-07-01 00:00 +00:00 GMT, "From" <from@runbox.com> wrote:\n> blabla\n> abcde`);
         expect(draft.isUnsaved()).toBe(true);
         done();
     });
@@ -239,9 +357,9 @@ describe('DraftDesk', () => {
         expect(replydraft.subject).toBe('Re: Test subject');
         expect(replydraft.from).toBe('from@runbox.com');
         expect(replydraft.to[0].nameAndAddress).toBe('to@runbox.com');
-        expect(replydraft.msg_body).toBe(`\n2017-07-02 00:00 ${timezoneOffsetString} to@runbox.com:\n` +
+        expect(replydraft.msg_body).toBe(`\nOn 2017-07-02 00:00 +00:00 GMT, to@runbox.com wrote:\n` +
                                          '> \n' +
-                                         `> 2017-07-01 00:00 ${timezoneOffsetString} from@runbox.com:\n` +
+          `> On 2017-07-01 00:00 +00:00 GMT, from@runbox.com wrote:\n` +
                                          '>> blabla\n>> abcde');
         expect(replydraft.isUnsaved()).toBe(true);
         done();

--- a/src/app/mailviewer/singlemailviewer.component.html
+++ b/src/app/mailviewer/singlemailviewer.component.html
@@ -266,26 +266,6 @@
     </mat-expansion-panel>
     <mat-divider></mat-divider>
 
-    <!-- Used when forwarding mail - do not delete -->
-
-    <span style="display: none" #forwardMessageHeader>
-      From: {{mailObj.from[0].name}} &lt;{{mailObj.from[0].address}}&gt; <br />
-      Time: {{mailObj.date | date:'yyyy-MM-dd HH:mm'}} <br />
-      Subject: {{mailObj.subject}} <br />
-      <span *ngIf="mailObj.to">
-        To: <span *ngFor="let to of mailObj.to">{{to.name}} &lt;{{to.address}}&gt;</span>
-      </span> <br />
-      <span *ngIf="mailObj.cc">
-        Cc: <span *ngFor="let to of mailObj.cc">{{to.name}} &lt;{{to.address}}&gt;</span>
-      </span> <br />
-    </span>
-
-    <!-- Used when replying to mail - do not delete -->
-
-    <span style="display: none" #replyMessageHeader>
-      On {{mailObj.date | date:'yyyy-MM-dd HH:mm'}}, {{mailObj.from[0].name}} &lt;{{mailObj.from[0].address}}&gt; wrote:
-    </span>
-
     <div class="htmlButtons" *ngIf="mailContentHTML">
       <span style="flex-grow: 1"></span>
       <span>

--- a/src/app/mailviewer/singlemailviewer.component.spec.ts
+++ b/src/app/mailviewer/singlemailviewer.component.spec.ts
@@ -216,7 +216,6 @@ describe('SingleMailViewerComponent', () => {
       tick(1);
       fixture.detectChanges();
 
-      expect(component.messageHeaderHTML.nativeElement.innerText).toContain('Test subject');
 
       expect(component.mailObj.attachments[0].downloadURL.indexOf('attachment/0')).toBeGreaterThan(-1);
       expect(component.mailObj.attachments[0].thumbnailURL.indexOf('attachmentimagethumbnail/0')).toBeGreaterThan(-1);

--- a/src/app/mailviewer/singlemailviewer.component.ts
+++ b/src/app/mailviewer/singlemailviewer.component.ts
@@ -236,21 +236,6 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
       }, 0);
     });
 
-    // messageHeaderHTML loads after message is loaded
-    this.messageHeaderHTMLQuery.changes.subscribe((messageHeaderHTMLList: QueryList<ElementRef>) => {
-      if (this.messageHeaderHTML) {
-        this.mailObj.origMailHeaderHTML = messageHeaderHTMLList.first.nativeElement.innerHTML;
-        this.mailObj.origMailHeaderText = messageHeaderHTMLList.first.nativeElement.innerText;
-      }
-    });
-
-    this.replyHeaderHTMLQuery.changes.subscribe((replyHeaderHTMLList: QueryList<ElementRef>) => {
-      if (this.replyHeaderHTML) {
-        this.mailObj.origReplyHeaderHTML = replyHeaderHTMLList.first.nativeElement.innerHTML;
-        this.mailObj.origReplyHeaderText = replyHeaderHTMLList.first.nativeElement.innerText;
-      }
-    });
-
     this.afterViewInit.emit(this.messageId);
     this.calculateWidthDependentElements();
   }
@@ -520,18 +505,11 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
 
         this.mailObj = res;
         this.folder = res.folder;
+
         // ProgressDialog.close();
         if (this.mailObj.seen_flag === 0) {
           this.messageActionsHandler.markSeen();
         }
-        setTimeout(() => {
-          // If forwarding HTML copy mail header from the visible mail viewer header
-          if (this.messageHeaderHTML) {
-            this.mailObj.origMailHeaderHTML = this.messageHeaderHTML.nativeElement.innerHTML;
-            this.mailObj.origMailHeaderText = this.messageHeaderHTML.nativeElement.innerText;
-          }
-        }, 0
-        );
       },
       err => {
         console.error('Error fetching message: ' + this.messageId);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "lib": [
       "es2018.promise",
       "es2017",
+      "ES2021.String",
       "dom"
     ],
     "module": "ES2020",


### PR DESCRIPTION
Fixes #234

For reasons best known to history, we were "generating" the reply/fwd headers (where header means "first line(s) of message" in the mail viewer template, then copying them out when doing a reply or fwd action. As pointed out in the #234 thread, quick actions could mean a message was opened, and the "reply" button clicked, before the reply header was generated, leading to "undefined" header strings.

I have moved the generation out of the template, and into the "create draft" code (which has the same mail object). Which means we could also now "reply" without opening a message, if we wanted to.

I also made the HTML+Text reply headers match, as one was regenerated differently!