### PR TITLE
style(mail menu): Improve read and unread icons.

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -338,10 +338,10 @@
 
     <div class="contextToolButtons" *ngIf="!hasChildRouterOutlet && showSelectOperations && showSelectMarkOpMenu">
       <button mat-fab matTooltip="Mark unread" (click)="setReadStatus(false)">
-          <mat-icon svgIcon="email-open"></mat-icon>
+          <mat-icon svgIcon="email-mark-as-unread"></mat-icon>
       </button>
       <button mat-fab matTooltip="Mark read" (click)="setReadStatus(true)">
-          <mat-icon svgIcon="email-check"></mat-icon>
+          <mat-icon svgIcon="email-open"></mat-icon>
       </button>
       <button mat-fab matTooltip="Set flag" (click)="setFlaggedStatus(true)">
           <mat-icon svgIcon="flag"></mat-icon>

--- a/src/app/mailviewer/singlemailviewer.component.html
+++ b/src/app/mailviewer/singlemailviewer.component.html
@@ -35,10 +35,10 @@
       </button>
       <ng-container *ngIf="morebuttonindex>5">
         <button *ngIf="mailObj.seen_flag===1" mat-icon-button matTooltip="Mark unread" (click)="messageActionsHandler.markSeen(0)">
-        <mat-icon svgIcon="email-open"></mat-icon>
+        <mat-icon svgIcon="email-mark-as-unread"></mat-icon>
         </button>
         <button *ngIf="mailObj.seen_flag===0" mat-icon-button matTooltip="Mark read" (click)="messageActionsHandler.markSeen(1)">
-        <mat-icon svgIcon="email-check"></mat-icon>
+        <mat-icon svgIcon="email-open"></mat-icon>
         </button>
        </ng-container>
       <ng-container *ngIf="morebuttonindex>6">


### PR DESCRIPTION
Mark as read and unread, respectively:
<img width="60" alt="Mark as read unread" src="https://user-images.githubusercontent.com/1620058/236672615-fe34b38a-eddc-4b9d-a18a-720694e907e5.png">

Ref: https://community.runbox.com/t/confusing-mark-as-read-unread-icons/1937/3?u=geir