### PR TITLE
fix(account): Only subscription/renewal pages for expired accounts

### DIFF
--- a/src/app/rmmapi/rmmauthguard.service.ts
+++ b/src/app/rmmapi/rmmauthguard.service.ts
@@ -99,4 +99,11 @@ export class RMMAuthGuardService implements CanActivate, CanActivateChild {
         console.log('Will navigate back to ', this.urlBeforeLogin);
         this.router.navigate(['login']);
     }
+
+  redirectToSubscriptions() {
+      if (this.router.url !== 'account/subscriptions') {
+        console.log('Will navigate back to account/subscriptions');
+        this.router.navigate(['account/subscriptions']);
+      }
+    }
 }

--- a/src/app/rmmapi/rmmhttpinterceptor.service.ts
+++ b/src/app/rmmapi/rmmhttpinterceptor.service.ts
@@ -29,6 +29,7 @@ import { RMMOfflineService } from './rmmoffline.service';
 export class RMMHttpInterceptorService implements HttpInterceptor {
 
     httpRequestCount = 0;
+    currentMe;
 
     constructor(
         private httpClient: HttpClient,
@@ -75,6 +76,19 @@ export class RMMHttpInterceptorService implements HttpInterceptor {
                             // but we don't have any indicator for that now
                             this.checkAccountStatus();
                         }
+                    }
+                    if (req.url === '/rest/v1/me' && r.body) {
+                        this.currentMe = r.body.result;
+                        // && r.body.result.account_status === 'expired') {
+                        // this.authguardservice.redirectToSubscriptions();
+                    }
+                    // If expired may login but only visit account/subscriptions
+                    if (this.currentMe && this.currentMe.account_status === 'expired'
+                        && !(req.url.startsWith('/rest/v1/account_product')
+                            || req.url.startsWith('/rest/v1/me')
+                            || req.url.startsWith('/rest/v1/payments')
+                            || req.url.startsWith('/rest/v1/last_on')) ) {
+                        this.authguardservice.redirectToSubscriptions();
                     }
                 }
                 return evt;

--- a/src/app/xapian/searchservice.ts
+++ b/src/app/xapian/searchservice.ts
@@ -103,6 +103,7 @@ export class SearchService {
   localdir: string;
   partitionsdir: string;
 
+  isExpired: boolean = false;
   initcalled = false;
   partitionDownloadProgress: number = null;
 
@@ -182,6 +183,7 @@ export class SearchService {
         map((me) => {
           this.localdir = 'rmmsearchservice' + me.uid;
           this.partitionsdir = '/partitions' + this.localdir;
+          this.isExpired = me.isExpired();
         }),
         mergeMap(() =>
           new Observable<any>((observer) => {
@@ -211,17 +213,21 @@ export class SearchService {
           })
         )
       ).subscribe((hasLocalIndex: boolean) => {
-        if (hasLocalIndex) {
-          this.openDBOnWorker();
-          this.init();
+        if (!this.isExpired) {
+          if (hasLocalIndex) {
+            this.openDBOnWorker();
+            this.init();
+          } else {
+            // We have no local index - but still need the polling loop here
+            this.indexLastUpdateTime = new Date().getTime(); // Set the last update time to now since we don't have a local index
+            this.indexWorker.postMessage({'action': PostMessageAction.updateIndexWithNewChanges});
+            this.noLocalIndexFoundSubject.next(true);
+            this.noLocalIndexFoundSubject.complete();
+            this.initSubject.next(false);
+            this.initSubject.complete();
+          }
         } else {
-          // We have no local index - but still need the polling loop here
-          this.indexLastUpdateTime = new Date().getTime(); // Set the last update time to now since we don't have a local index
-          this.indexWorker.postMessage({'action': PostMessageAction.updateIndexWithNewChanges});
-          this.noLocalIndexFoundSubject.next(true);
-          this.noLocalIndexFoundSubject.complete();
-          this.initSubject.next(false);
-          this.initSubject.complete();
+          console.log("Account has expired, access to /account/subscriptions only");
         }
       });
 
@@ -804,9 +810,12 @@ export class SearchService {
               this.currentDocData.textcontent = this.messageTextCache.get(rmmMessageId);
           }
           this.rmmapi.getCachedMessageContents(rmmMessageId).then(content => {
-              if (content) {
+              if (content && content.text) {
                   // this.currentDocData.textcontent = content.text.text;
                   this.messageTextCache.set(rmmMessageId, content.text.text);
+              } else {
+                console.error("messangeContent has no text");
+                console.error(content);
               }
           });
 


### PR DESCRIPTION
Expired accounts should only be able to visit account/subscriptions (and related pages) to process a renewal. This prevents starting the index updates or current message list, as these will delete the session cookie when called with an expired account, which prevents the user from visiting the subscriptions page.

Fixes #1473