### PR TITLE
fix(accounts): Subscriptions links on account expiry

### DIFF
--- a/src/app/rmmapi/rmmhttpinterceptor.service.ts
+++ b/src/app/rmmapi/rmmhttpinterceptor.service.ts
@@ -29,7 +29,6 @@ import { RMMOfflineService } from './rmmoffline.service';
 export class RMMHttpInterceptorService implements HttpInterceptor {
 
     httpRequestCount = 0;
-    currentMe;
 
     constructor(
         private httpClient: HttpClient,
@@ -76,19 +75,6 @@ export class RMMHttpInterceptorService implements HttpInterceptor {
                             // but we don't have any indicator for that now
                             this.checkAccountStatus();
                         }
-                    }
-                    if (req.url === '/rest/v1/me' && r.body) {
-                        this.currentMe = r.body.result;
-                        // && r.body.result.account_status === 'expired') {
-                        // this.authguardservice.redirectToSubscriptions();
-                    }
-                    // If expired may login but only visit account/subscriptions
-                    if (this.currentMe && this.currentMe.account_status === 'expired'
-                        && !(req.url.startsWith('/rest/v1/account_product')
-                            || req.url.startsWith('/rest/v1/me')
-                            || req.url.startsWith('/rest/v1/payments')
-                            || req.url.startsWith('/rest/v1/last_on')) ) {
-                        this.authguardservice.redirectToSubscriptions();
                     }
                 }
                 return evt;


### PR DESCRIPTION
Expired accounts should only be able to visit account/subscriptions, attempting to view anything else should return them to account/subscriptions