### PR TITLE
fix(payment): Show products correctly in the receipt.

### DIFF
--- a/src/app/account-app/account-receipt.component.html
+++ b/src/app/account-app/account-receipt.component.html
@@ -42,25 +42,30 @@
     </tr>
     <tr>
       <td><strong> Product{{ receipt.products.length > 1 ? 's' : '' }}: </strong></td>
-      <td><span *ngIf="receipt.products.length === 1">
-	  {{ receipt.products[0][1] }}x {{ receipt.products[0][0] }}
-	</span>
+      <td>
 	<div *ngFor="let p of receipt.products">
           {{ p[1] }} x {{ p[0] }}
 	</div>
       </td>
     </tr>
+    <p>
+        If you need an invoice for this purchase, you can view it here:
+        <a href="/payment/payinvoice?invoice={{ receipt.tid }}">Invoice {{ receipt.tid }}</a>
+    </p>
   </table>
 
     <div *ngIf="receipt.status == 1 && receipt.method === 'offline'">
-        <p>
+        <h3>
             Please follow the instructions for your selected payment method below.
-        </p>
+        </h3>
 
-        <h4> SWIFT </h4>
+        <h4> SWIFT transfer </h4>
 
         <p>
-            Runbox Solutions accepts SWIFT and SEPA payments, but please be aware that this is an expensive payment alternative as the sender must pay the transaction cost. It may take a while for us to receive and register your payment as it cannot be automatically applied to your account. Payment should be made from a bank account in your name, otherwise delays may occur in payments being applied to your Runbox account. Please contact us upon paying to make sure your payment is registered as efficiently as possible.
+          Runbox Solutions accepts SWIFT and SEPA payments, but please be aware that this is an expensive payment alternative as the sender must pay the transaction cost. It may take a while for us to receive and register your payment as it cannot be automatically applied to your account.
+	</p>
+	<p>
+	  Payment should be made from a bank account in your name, otherwise delays may occur in payments being applied to your Runbox account. Please contact us upon paying to make sure your payment is registered as efficiently as possible.
         </p>
 
         <table>
@@ -75,14 +80,16 @@
             </tr>
         </table>
 
-        <h4> Cash </h4>
+        <h4> Cash payment </h4>
 
         <p>
             Send the cash via registered or regular mail (not recommended) to: Runbox Solutions AS, Oscars gate 27, 0352 Oslo, Norway.
         </p>
 
         <p>
-    Be advised that payments sent by regular mail may be delayed or lost, and that they require manual processing. Therefore you should send such payments well ahead (at least 3 weeks) of your trial or subscription period's expiration. You may avoid delays and service disruptions by scanning (or taking a picture of) the payment prior to sending it in the mail, and emailing it to billing@runbox.com.
+	  Be advised that payments sent by regular mail may be delayed or lost, and that they require manual processing. Therefore you should send such payments well ahead (at least 3 weeks) of your trial or subscription period's expiration.</p>
+	<p>
+	  You may avoid delays and service disruptions by scanning (or taking a picture of) the payment prior to sending it in the mail, and emailing it to billing@runbox.com.
         </p>
 
         <p>
@@ -93,11 +100,6 @@
             <strong> Your Transaction ID (TID) is: {{ receipt.tid }} </strong>
         </p>
     </div>
-
-    <p>
-        If you need an invoice for this purchase, you can view it here:
-        <a href="/payment/payinvoice?invoice={{ receipt.tid }}">Invoice {{ receipt.tid }}</a>
-    </p>
 </div>
 
 <ng-template #loading>

--- a/src/app/account-app/shopping-cart.component.html
+++ b/src/app/account-app/shopping-cart.component.html
@@ -166,11 +166,9 @@
                     </button>
                 </p>
                 <p>
-                    You can send us a SWIFT/IBAN bank transfer or mail us an envelope with cash in your preferred currency.
-        </p>
-        <p>
-                    Your products won't activate until the payment is received by Runbox.
-                </p>
+                  You can send us a SWIFT/IBAN bank transfer or mail us an envelope with cash in your preferred currency.<br />
+		  Please note that your products won't activate until the payment is received by Runbox.
+		</p>
             </div>
         </mat-expansion-panel>
     </div>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -78,7 +78,7 @@ body {
 }
 
 h1, .mat-typography h1 {
-    margin: 0 0 20px 0;
+    margin: 10px 0 20px 0;
     font-size: 30px;
     font-weight: 400;
 }


### PR DESCRIPTION
Fixes an issue where a single product would be shown twice, and improves formatting of alternative payment method instructions.

<img width="878" alt="Payment receipt" src="https://github.com/runbox/runbox7/assets/1620058/a222c6ca-b07c-489b-adb8-de750142ccef">
