### PR TITLE
Castaway/ci actions npm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,5 @@ jobs:
                   key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
                   restore-keys: |
                       ${{ runner.os }}-node-
-            - run: npm i -g npm
             - run: npm ci
             - run: npm run ci-tests -- ${{ matrix.phase }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v1
               with:
-                  node-version: '14.x'
+                  node-version: '16.x'
             - uses: actions/cache@v2
               with:
                   path: ~/.npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,6 @@ jobs:
                   key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
                   restore-keys: |
                       ${{ runner.os }}-node-
-            - run: npm i -g npm@latest
+            - run: npm i -g npm
             - run: npm ci
             - run: npm run ci-tests -- ${{ matrix.phase }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,6 @@ jobs:
                   key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
                   restore-keys: |
                       ${{ runner.os }}-node-
-            - run: npm install -g npm
+            - run: npm i -g npm@latest
             - run: npm ci
             - run: npm run ci-tests -- ${{ matrix.phase }}


### PR DESCRIPTION
Upgrade to Node v16 to fix npm ci issue with "timers/promises" (is in 16 no longer in 14)