### PR TITLE
fix(search): Cope with no index, use websocket and message fetch

### DIFF
--- a/src/app/xapian/searchservice.ts
+++ b/src/app/xapian/searchservice.ts
@@ -481,10 +481,11 @@ export class SearchService {
         mergeMap(() => this.checkIfDownloadableIndexExists()),
         mergeMap((res) => new Observable<boolean>( (observer) => {
         if (!res) {
-          this.api.initXapianIndexReadOnly(XAPIAN_GLASS_WR);
-          this.localSearchActivated = true;
+          this.localSearchActivated = false;
           this.indexLastUpdateTime = 0;
-          observer.next(true);
+          // restart updates
+          this.indexWorker.postMessage({'action': PostMessageAction.updateIndexWithNewChanges });
+          observer.next(false);
           return;
         }
 


### PR DESCRIPTION
Fixes #1485

When no search index exists, then we should not attempt to fetch partitions, and we should restart the message list update mechanism. We should definitely not try and twiddle a setting on the xapian index that didn't load (!)
