### PR TITLE
fix(messagecache): Load message contents whenever we encounter them

### DIFF
--- a/src/app/xapian/searchservice.ts
+++ b/src/app/xapian/searchservice.ts
@@ -811,15 +811,7 @@ export class SearchService {
           if (this.messageTextCache.has(rmmMessageId)) {
               this.currentDocData.textcontent = this.messageTextCache.get(rmmMessageId);
           }
-          this.rmmapi.getCachedMessageContents(rmmMessageId).then(content => {
-              if (content && content.text) {
-                  // this.currentDocData.textcontent = content.text.text;
-                  this.messageTextCache.set(rmmMessageId, content.text.text);
-              } else {
-                console.error("messangeContent has no text");
-                console.error(content);
-              }
-          });
+          this.updateMessageText(rmmMessageId);
 
           try {
             this.api.documentXTermList(docid);


### PR DESCRIPTION
There are many sentry-errors resulting from the message list drawing code attempting to fetch the message contents from the cache, when the cache hasnt been created or updated yet (that happens after the canvas has been painted with the message list)

This fills the cache as we look for the data (using promises so without interrupting the canvas drawing)