### PR TITLE
fix(account): Ensure upgrade/downgrade works when returning to page

### DIFF
--- a/src/app/account-app/account-product.component.html
+++ b/src/app/account-app/account-product.component.html
@@ -4,7 +4,7 @@
       {{ p.name }}
     </mat-card-title>
     <mat-card-subtitle [ngClass]="{'themePaletteDarkGray': (p.type !== 'addon' && over_quota.length > 0)}">
-      <h4><span *ngIf="p.pid === me.subscription"> Your current {{ p.type }} </span><br /></h4>
+      <h4><span *ngIf="is_current_subscription"> Your current {{ p.type }} </span><br /></h4>
       {{ p.description }}.
     </mat-card-subtitle>
     <mat-card-content>

--- a/src/app/account-app/account-product.component.ts
+++ b/src/app/account-app/account-product.component.ts
@@ -35,8 +35,7 @@ export class ProductComponent implements OnInit {
     @Input() active_sub: boolean;
     @Input() usage: DataUsageInterface;
     @Input() current_sub: Product;
-
-    me: RunboxMe = new RunboxMe();
+    @Input() me: RunboxMe;
 
     allow_multiple = false;
     quantity = 1;
@@ -46,6 +45,7 @@ export class ProductComponent implements OnInit {
     addon_usages = [];
     is_upgrade = false;
     is_downgrade = false;
+    is_current_subscription: boolean = false;
 
     constructor(
         private cart: CartService,
@@ -60,11 +60,8 @@ export class ProductComponent implements OnInit {
         this.allow_multiple = this.p.type === 'addon';
         this.over_quota = this.check_over_quota();
         this.addon_usages = this.get_addon_usages();
+        this.is_current_subscription = this.me && this.p.pid === this.me.subscription;
         this.check_up_down_grade();
-
-        this.rmmapi.me.subscribe(me => {
-            this.me = me;
-        });
     }
 
     // More or less disk space than the existing subscription?

--- a/src/app/account-app/account-upgrades.component.html
+++ b/src/app/account-app/account-upgrades.component.html
@@ -67,7 +67,7 @@
     -->
 
       <div class="productGrid" *ngIf="subs_regular | async as subs_regular; else productsLoading">
-        <app-account-product *ngFor="let p of subs_regular" [ngClass]="'productCard'" [p]="p" [currency]="me.currency" [active_sub]="me.subscription === p.pid" [usage]="q_usage" [current_sub]="current_sub">
+        <app-account-product *ngFor="let p of subs_regular" [ngClass]="'productCard'" [p]="p" [currency]="me.currency" [active_sub]="me.subscription === p.pid" [usage]="q_usage" [current_sub]="current_sub" [me] = "me">
           <ul>
             <li *ngFor="let detail of p.details"> {{ detail }}
           </ul>

--- a/src/app/account-app/account-upgrades.component.ts
+++ b/src/app/account-app/account-upgrades.component.ts
@@ -37,7 +37,7 @@ import { RunboxSidenavService } from '../runbox-components/runbox-sidenav.servic
 })
 export class AccountUpgradesComponent implements OnInit {
     @ViewChild(RunboxTimerComponent) runboxtimer: RunboxTimerComponent;
-    me: RunboxMe = new RunboxMe();
+    me: RunboxMe;
 
     subaccounts    = new AsyncSubject<Product[]>();
     emailaddons    = new AsyncSubject<Product[]>();
@@ -50,7 +50,6 @@ export class AccountUpgradesComponent implements OnInit {
 
     limitedTimeOffer = false;
     limited_time_offer_age = 24 * 60 * 60 * 1000; // 24hours in microseconds
-
 
     constructor(
         public  cart:            CartService,
@@ -70,9 +69,6 @@ export class AccountUpgradesComponent implements OnInit {
         });
 
         this.paymentsservice.products.subscribe(products => {
-            // User's current subscription product:
-            this.current_sub = products.find(p => p.pid == this.me.subscription);
-
             const subs_all = products.filter(p => p.type === 'subscription');
             this.subscriptions.next(subs_all);
             this.subscriptions.complete();
@@ -104,12 +100,17 @@ export class AccountUpgradesComponent implements OnInit {
                     this.snackbar.open('You can only buy one main account subscription at a time.', 'OK');
                 }
             });
+
+            this.rmmapi.me.subscribe(me => {
+                this.me = me;
+                // User's current subscription product:
+                if (this.subscriptions) {
+                    this.current_sub = products.find(p => p.pid === this.me.subscription);
+                }
+                this.limitedTimeOffer = !me.newerThan(this.limited_time_offer_age);
+            });
         });
 
-        this.rmmapi.me.subscribe(me => {
-            this.me = me;
-            this.limitedTimeOffer = !me.newerThan(this.limited_time_offer_age);
-        });
     }
 
     runboxTimerFinished(): void {


### PR DESCRIPTION
The subscribe to the "me" object sometimes finishes after the "products", so current_sub, used to set the is_upgrade/is_downgrade flags isnt always set when needed. Ensure that the me.subscription is run after the products, then set the current_sub