### PR TITLE
fix(compose): URLs in messages and signatures should not be relative

### DIFF
--- a/src/app/compose/compose.component.ts
+++ b/src/app/compose/compose.component.ts
@@ -498,6 +498,11 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
                         this.formGroup.controls['msg_body'].setValue(editor.getContent({ format: 'text' }));
                         this.model.html = editor.getContent();
                     });
+                    editor.on('remove', () => {
+                        if(editor.queryCommandState('ToggleToolbarDrawer')) {
+                            editor.execCommand('ToggleToolbarDrawer');
+                        }
+                    });
                 },
                 init_instance_callback: (editor) => {
                     editor.setContent(

--- a/src/app/profiles/profiles.editor.modal.ts
+++ b/src/app/profiles/profiles.editor.modal.ts
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
-import { Component, Input, Inject } from '@angular/core';
+import { Component, Input, Inject, OnDestroy } from '@angular/core';
 
 import { MatLegacyDialogRef as MatDialogRef, MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA } from '@angular/material/legacy-dialog';
 import { MatLegacySnackBar as MatSnackBar } from '@angular/material/legacy-snack-bar';
@@ -32,7 +32,7 @@ import { TinyMCEPlugin } from '../rmm/plugin/tinymce.plugin';
     templateUrl: 'profiles.editor.modal.html',
 })
 
-export class ProfilesEditorModalComponent {
+export class ProfilesEditorModalComponent implements OnDestroy {
     @Input() value: any[];
     field_errors: Identity;
     allowed_domains = [];
@@ -240,6 +240,11 @@ export class ProfilesEditorModalComponent {
                 editor.on('Change', () => {
                     this.identity.signature = editor.getContent();
                 });
+                editor.on('remove', () => {
+                    if(editor.queryCommandState('ToggleToolbarDrawer')) {
+                        editor.execCommand('ToggleToolbarDrawer');
+                    }
+                });
             },
             init_instance_callback: (editor) => {
                 editor.setContent(
@@ -253,5 +258,11 @@ export class ProfilesEditorModalComponent {
     }
     resend_validate_email(id) {
         this.profileService.reValidate(id);
+    }
+
+    ngOnDestroy() {
+        if (this.editor) {
+            this.tinymce_plugin.remove(this.editor);
+        }
     }
 }

--- a/src/app/rmm/plugin/tinymce.plugin.ts
+++ b/src/app/rmm/plugin/tinymce.plugin.ts
@@ -54,6 +54,8 @@ export class TinyMCEPlugin {
                             {text: 'C++', value: 'cpp'}
                         ]),
                 contextmenu: false,
+                relative_urls: false,
+                remove_script_host : false,
                 font_formats: 'Arial=arial,helvetica,sans-serif;Courier New=courier new,courier;Georgia=georgia,palatino;Times New Roman=times new roman,times;Trebuchet MS=trebuchet ms,geneva;Verdana=verdana,geneva',
                 image_list: (options.image_list || []),
                 menubar: (options.menubar || false),


### PR DESCRIPTION
If emails containing runbox.com urls are written, they should not be changed to be ../. This fixes this issue for general urls entered in compose, as well as saved signatures edited on the identities page.

Also fixed: Remove the floating toolbar, if still present when the tiny mce editor is closed.