### PR TITLE
Update TinyMCE to v6, enable drag&drop of images into compose

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -40,6 +40,11 @@
               },
               {
                 "glob": "**/*",
+                "input": "node_modules/tinymce/models",
+                "output": "/tinymce/models/"
+              },
+              {
+                "glob": "**/*",
                 "input": "node_modules/@mdi/angular-material",
                 "output": "/assets/"
               },

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "runbox-searchindex": "https://registry.npmjs.org/@runboxcom/runbox-searchindex/-/runbox-searchindex-0.2.0.tgz",
         "rxjs": "^7.8.0",
         "rxjs-compat": "^6.6.7",
-        "tinymce": "^5.10.7",
+        "tinymce": "^6.8.3",
         "ts-md5": "^1.3.1",
         "zone.js": "^0.12.0"
       },
@@ -21020,9 +21020,9 @@
       "dev": true
     },
     "node_modules/tinymce": {
-      "version": "5.10.7",
-      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-5.10.7.tgz",
-      "integrity": "sha512-9UUjaO0R7FxcFo0oxnd1lMs7H+D0Eh+dDVo5hKbVe1a+VB0nit97vOqlinj+YwgoBDt6/DSCUoWqAYlLI8BLYA=="
+      "version": "6.8.3",
+      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-6.8.3.tgz",
+      "integrity": "sha512-3fCHKAeqT+xNwBVESf6iDbDV0VNwZNmfrkx9c/6Gz5iB8piMfaO6s7FvoiTrj1hf1gVbfyLTnz1DooI6DhgINQ=="
     },
     "node_modules/tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "runbox-searchindex": "https://registry.npmjs.org/@runboxcom/runbox-searchindex/-/runbox-searchindex-0.2.0.tgz",
     "rxjs": "^7.8.0",
     "rxjs-compat": "^6.6.7",
-    "tinymce": "^5.10.7",
+    "tinymce": "^6.8.3",
     "ts-md5": "^1.3.1",
     "zone.js": "^0.12.0"
   },

--- a/src/app/compose/compose.component.html
+++ b/src/app/compose/compose.component.html
@@ -102,20 +102,22 @@
             <input matInput placeholder="Subject" name="subject" formControlName="subject" />
         </mat-form-field>                     
         <section *ngIf="editing" [ngClass]="{'dropzonehighlight': showDropZone, 'overdropzone': draggingOverDropZone}" (dragover)="draggingOverDropZone=true" (dragleave)="draggingOverDropZone=false" (drop)="dropFiles($event)" id="dropZone">
-            <h1 *ngIf="showDropZone" id="dropZoneText">Drop files here</h1>            
-            <mat-progress-bar *ngIf="uploadprogress!=null"                               
+          <h1 *ngIf="showDropZone" id="dropZoneText">Drop files here</h1>
+          <ng-container *ngIf="uploadProgress | async as uprogress">
+            <mat-progress-bar *ngIf="uprogress > -1"
                 mode="determinate"
-                [value]="uploadprogress"
+                [value]="uprogress"
                >
             </mat-progress-bar>
-            <button mat-button *ngIf="uploadprogress !== null" (click)="cancelAttachmentUpload()">
+            <button mat-button *ngIf="uprogress > -1" (click)="cancelAttachmentUpload()">
                 <mat-icon svgIcon="close"></mat-icon> Cancel attachment upload
             </button>
-            <mat-card-content *ngIf="uploadprogress!=null">
-                <div *ngFor="let file of uploadingFiles">
-                    <p>{{file.name}}, {{formatBytes(file.size)}}</p>
-                </div>
+            <mat-card-content *ngIf="uprogress > -1">
+              <div *ngFor="let file of uploadingFiles">
+                <p>{{file.name}}, {{formatBytes(file.size)}}</p>
+              </div>
             </mat-card-content>
+          </ng-container>
         </section>
         <section *ngIf="editing && model.attachments && model.attachments.length>0" id="attachments">
 	  Attachments:&nbsp;

--- a/src/app/compose/compose.component.ts
+++ b/src/app/compose/compose.component.ts
@@ -24,7 +24,7 @@ import { Location } from '@angular/common';
 import { Router } from '@angular/router';
 
 import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
-import { Observable, Subscription } from 'rxjs';
+import { Observable, Subscription, AsyncSubject, BehaviorSubject } from 'rxjs';
 import { MatLegacySnackBar as MatSnackBar } from '@angular/material/legacy-snack-bar';
 import { DraftDeskService, DraftFormModel } from './draftdesk.service';
 import { HttpClient, HttpEventType, HttpHeaders, HttpRequest } from '@angular/common/http';
@@ -71,11 +71,13 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
     public editing = false;
     public isUnsaved = false;
     public savingInProgress = false;
-    public uploadprogress: number = null;
-    public uploadingFiles: FileList = null;
+    // public uploadprogress: number = null;
+    public uploadingFiles: File[] = [];
     public uploadRequest: Subscription = null;
     public saved: Date = null;
     public tinymce_plugin: TinyMCEPlugin;
+    finishImageUpload: AsyncSubject<any> = null;
+    uploadProgress: BehaviorSubject<number> = new BehaviorSubject(-1);
     has_pasted_signature: boolean;
     signature: string;
     selector: string;
@@ -331,7 +333,7 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
     }
 
     public onFilesSelected(event) {
-        this.uploadFiles(event.target.files);
+        this.uploadFiles([...event.target.files]);
         this.attachmentFileUploadInput.nativeElement.value = '';
     }
 
@@ -346,8 +348,8 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
     public dropFiles(event: DragEvent) {
         event.preventDefault();
         event.stopImmediatePropagation();
-        if (!this.uploadingFiles) {
-            this.uploadFiles(event.dataTransfer.files);
+        if (this.uploadingFiles.length === 0) {
+            this.uploadFiles(Array.from(event.dataTransfer.files));
             this.hideDropZone();
         }
     }
@@ -358,8 +360,8 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
         this.submit();
     }
 
-    public uploadFiles(files: FileList) {
-        this.uploadprogress = 0;
+    public uploadFiles(files: File[]) {
+        this.uploadProgress.next(0);
         this.uploadingFiles = files;
         const formdata: FormData = new FormData();
         for (let i = 0; i < files.length; i++) {
@@ -386,7 +388,7 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
         )).subscribe((event) => {
             if (event.type === HttpEventType.UploadProgress) {
                 const progress = event.loaded * 100 / event.total;
-                this.uploadprogress = progress === 100 ? null : progress;
+                this.uploadProgress.next(progress);
             } else if (event.type === HttpEventType.Response) {
                 if (!this.model.attachments) {
                     this.model.attachments = [];
@@ -398,21 +400,57 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
                         this.model.attachments.push(att);
                     });
 
-                this.uploadprogress = null;
-                this.uploadingFiles = null;
+                this.uploadProgress.next(-1);
+                this.uploadingFiles = [];
+                if(this.finishImageUpload) {
+                    // We were submitting a dropped image attachment
+                    this.finishImageUpload.next((event.body as any).result.attachments[0].filename);
+                    this.finishImageUpload.complete();
+                    this.finishImageUpload = null;
+                }
                 this.submit();
             }
         }, error => {
-            this.uploadprogress = null;
-            this.uploadingFiles = null;
+            this.uploadProgress.next(-1);
+            this.uploadingFiles = [];
+            if(this.finishImageUpload) {
+                // We were submitting a dropped image attachment
+                this.finishImageUpload.next('');
+                this.finishImageUpload.complete();
+                this.finishImageUpload = null;
+            }
             this.snackBar.open(`Error uploading attachments: ${error.statusText}`, 'OK');
+        });
+    }
+
+    public tinyMCEUpload(blobInfo, progress) {
+        return new Promise((resolve, reject) => {
+            if(!this.finishImageUpload) {
+                this.finishImageUpload = new AsyncSubject();
+            }
+            this.uploadProgress.subscribe((res) => {
+                if(res > -1) {progress(res);}
+            });
+            this.finishImageUpload.subscribe((res) => {
+                if(res.length > 0) {
+                    resolve('/ajax/download_draft_attachment?filename=' + res);
+                } else {
+                    reject({ message: 'Error storing image',
+                             remove: true });
+                }
+            });
+            this.uploadFiles([blobInfo.blob()]);
         });
     }
 
     public cancelAttachmentUpload() {
         this.uploadRequest.unsubscribe();
-        this.uploadprogress = null;
-        this.uploadingFiles = null;
+        this.uploadProgress.next(-1);
+        if (this.finishImageUpload) {
+            this.finishImageUpload.next('');
+            this.finishImageUpload.complete();
+        }
+        this.uploadingFiles = [];
     }
 
     public loadDraft(msgObj) {
@@ -521,7 +559,13 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
                     title: this.displayWithoutRBWUL(att.file),
                     value: '/ajax/download_draft_attachment?filename=' + att.file
                 })) : []),
-
+                paste_data_images: true,
+                automatic_uploads: true,
+                images_upload_credentials: true,
+                images_upload_handler: (blobInfo, progress) => {
+                    return this.tinyMCEUpload(blobInfo, progress);
+                },
+                // upload_url: this.router.createUrlTree(['/rest/v1/attachment/upload/single']).toString(),
             };
             this.tinymce_plugin.create(options);
             this.preferenceService .set(DefaultPrefGroups.Global, LOCAL_STORAGE_DEFAULT_HTML_COMPOSE, 'true');

--- a/src/app/compose/compose.component.ts
+++ b/src/app/compose/compose.component.ts
@@ -359,7 +359,7 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
     public removeAttachment(attachmentIndex: number) {
         const toRemove = this.model.attachments[attachmentIndex];
         const escapedUrl = DOWNLOAD_DRAFT_URL.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-        const attUrlRegex = new RegExp('<img\\ssrc="[^"]*' + escapedUrl + toRemove.filename + '"[^>]+>');
+        const attUrlRegex = new RegExp('<img\\ssrc="[^"]*' + escapedUrl + toRemove.filename + '"[^>]*>');
         this.model.html = this.model.html.replace(attUrlRegex, '');
         this.editor.setContent(this.model.html);
         this.model.attachments.splice(attachmentIndex, 1);

--- a/src/app/mailviewer/singlemailviewer.component.ts
+++ b/src/app/mailviewer/singlemailviewer.component.ts
@@ -550,7 +550,7 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
           if (isImage) {
             att.thumbnailURL = '/rest/v1/email/' + this.messageId + '/attachmentimagethumbnail/' + ndx;
             if (html) {
-              const newHtml = html.replace(new RegExp('src="cid:' + att.cid), 'src="' + att.downloadURL);
+              const newHtml = html.replace(new RegExp('src="cid:' + att.cid, 'g'), 'src="' + att.downloadURL);
               if (newHtml !== html) {
                 att.internal = true;
                 html = newHtml;

--- a/src/app/rmm/plugin/tinymce.plugin.ts
+++ b/src/app/rmm/plugin/tinymce.plugin.ts
@@ -33,14 +33,18 @@ export class TinyMCEPlugin {
             tinymce.init({
                 selector: options.selector, // '#' + this.editorRef.nativeElement.id,
                 browser_spellcheck: true,
-                plugins: (options.plugins || 'preview searchreplace autolink directionality ' +
+                plugins: (options.plugins ||
+                    'preview searchreplace autolink directionality ' +
                     'visualblocks visualchars fullscreen image link template codesample ' +
-                    'table charmap pagebreak ' +
+                    'table charmap pagebreak paste ' +
                     'nonbreaking anchor insertdatetime advlist lists wordcount ' +
                     'help code'),
-                toolbar: (options.toolbar || 'formatselect | fontselect fontsizeselect bold italic strikethrough forecolor backcolor codesample | ' +
-                        'link image | alignleft aligncenter alignright alignjustify  | ' +
-                        'numlist bullist outdent indent | removeformat | addcomment | code'),
+                toolbar: (options.toolbar
+                    || 'formatselect | fontselect fontsizeselect bold italic ' +
+                    'strikethrough forecolor backcolor codesample | ' +
+                    'link image paste pastetext | alignleft aligncenter ' +
+                    'alignright alignjustify  | ' +
+                    'numlist bullist outdent indent | removeformat | addcomment | code'),
                 codesample_languages: (options.codesample_languages || [
                             {text: 'HTML/XML', value: 'markup'},
                             {text: 'JavaScript', value: 'javascript'},
@@ -55,7 +59,11 @@ export class TinyMCEPlugin {
                         ]),
                 contextmenu: false,
                 relative_urls: false,
-                remove_script_host : false,
+                remove_script_host: false,
+                block_unsupported_drop: false,
+                paste_data_images: true,
+                paste_block_drop: false,
+                smart_paste: true,
                 font_formats: 'Arial=arial,helvetica,sans-serif;Courier New=courier new,courier;Georgia=georgia,palatino;Times New Roman=times new roman,times;Trebuchet MS=trebuchet ms,geneva;Verdana=verdana,geneva',
                 image_list: (options.image_list || []),
                 menubar: (options.menubar || false),

--- a/src/app/rmm/plugin/tinymce.plugin.ts
+++ b/src/app/rmm/plugin/tinymce.plugin.ts
@@ -36,7 +36,7 @@ export class TinyMCEPlugin {
                 plugins: (options.plugins ||
                     'preview searchreplace autolink directionality ' +
                     'visualblocks visualchars fullscreen image link template codesample ' +
-                    'table charmap pagebreak paste ' +
+                    'table charmap pagebreak ' +
                     'nonbreaking anchor insertdatetime advlist lists wordcount ' +
                     'help code'),
                 toolbar: (options.toolbar
@@ -60,8 +60,12 @@ export class TinyMCEPlugin {
                 contextmenu: false,
                 relative_urls: false,
                 remove_script_host: false,
-                block_unsupported_drop: false,
-                paste_data_images: true,
+                block_unsupported_drop: true,
+                automatic_uploads: ( options.automatic_uploads || false ),
+                paste_data_images: ( options.paste_data_images || false ),
+                images_upload_credentials: ( options.images_upload_credentials || false ),
+                images_upload_url: options.upload_url || '',
+                images_upload_handler: options.images_upload_handler,
                 paste_block_drop: false,
                 smart_paste: true,
                 font_formats: 'Arial=arial,helvetica,sans-serif;Courier New=courier new,courier;Georgia=georgia,palatino;Times New Roman=times new roman,times;Trebuchet MS=trebuchet ms,geneva;Verdana=verdana,geneva',

--- a/src/app/rmm/plugin/tinymce.plugin.ts
+++ b/src/app/rmm/plugin/tinymce.plugin.ts
@@ -33,11 +33,11 @@ export class TinyMCEPlugin {
             tinymce.init({
                 selector: options.selector, // '#' + this.editorRef.nativeElement.id,
                 browser_spellcheck: true,
-                plugins: (options.plugins || 'print preview searchreplace autolink directionality ' +
+                plugins: (options.plugins || 'preview searchreplace autolink directionality ' +
                     'visualblocks visualchars fullscreen image link template codesample ' +
-                    'table charmap hr pagebreak ' +
-                    'nonbreaking anchor toc insertdatetime advlist lists wordcount imagetools ' +
-                    'textpattern help code'),
+                    'table charmap pagebreak ' +
+                    'nonbreaking anchor insertdatetime advlist lists wordcount ' +
+                    'help code'),
                 toolbar: (options.toolbar || 'formatselect | fontselect fontsizeselect bold italic strikethrough forecolor backcolor codesample | ' +
                         'link image | alignleft aligncenter alignright alignjustify  | ' +
                         'numlist bullist outdent indent | removeformat | addcomment | code'),


### PR DESCRIPTION
Drag&drop images uploads the image as an attachment, then updates the img src attribute to load the image using the attachment url. Sending then replaces it with a cid: id linking to the attached image.