### PR TITLE
fix(identities): Re-enable editing of preferred domain for aliases

### DIFF
--- a/src/app/compose/recipients.service.spec.ts
+++ b/src/app/compose/recipients.service.spec.ts
@@ -127,6 +127,7 @@ export class ContactsServiceMock {
 export class RunboxWebMailAPIMock {
     public me = of({ uid: 33 });
     public getProfiles = () => of([{ 'email':'testuser@runbox.com'}]);
+    public getRunboxDomains = () => of([{ 'id': 1, name: 'runbox.com'}]);
 }
 
 describe('RecipientsService', () => {

--- a/src/app/mailviewer/singlemailviewer.component.spec.ts
+++ b/src/app/mailviewer/singlemailviewer.component.spec.ts
@@ -130,6 +130,7 @@ describe('SingleMailViewerComponent', () => {
         { provide: RunboxWebmailAPI, useValue: {
           me: of({ uid: 9876 }),
           getProfiles() { return of([]); },
+          getRunboxDomains: () => of([{ 'id': 1, name: 'runbox.com'}]),
           getMessageContents(messageId: number): Observable<MessageContents> {
             console.log('Get message contents for', messageId);
             return of(Object.assign(new MessageContents(), {

--- a/src/app/profiles/profile.service.spec.ts
+++ b/src/app/profiles/profile.service.spec.ts
@@ -150,7 +150,7 @@ describe('ProfileService', () => {
                         PROFILES.unshift(newprofile);
                         return of(PROFILES.length);
                     },
-                    
+                    getRunboxDomains: () => of([{ 'id': 1, name: 'runbox.com'}]),
                 } },
                 ProfileService
             ],

--- a/src/app/profiles/profile.service.ts
+++ b/src/app/profiles/profile.service.ts
@@ -69,10 +69,12 @@ export class ProfileService {
     public validProfiles: BehaviorSubject<Identity[]> = new BehaviorSubject([]);
     public composeProfile: Identity;
     public me: RunboxMe;
+    public global_domains = [];
     constructor(
         public rmmapi: RunboxWebmailAPI
     ) {
         this.refresh();
+        this.rmmapi.getRunboxDomains().subscribe(domains => this.global_domains = domains);
         this.rmmapi.me.subscribe(me => this.me = me);
     }
 

--- a/src/app/profiles/profiles.editor.modal.html
+++ b/src/app/profiles/profiles.editor.modal.html
@@ -31,13 +31,13 @@
             </mat-form-field>
 
             <mat-form-field class="form-field form-item"
-                *ngIf="is_aliases_global_domain(identity) && rmm.runbox_domain.data ; else other_content">
+                *ngIf="identity.type === 'aliases' && identity.preferred_runbox_domain && profileService.global_domains ; else other_content">
                 <mat-label>Email</mat-label>
                 <mat-select [(ngModel)]="identity.preferred_runbox_domain"
                     [(value)]="identity.preferred_runbox_domain"
                     (ngModelChange)="onchange_field('preferred_runbox_domain')" name="preferred_runbox_domain"
                     [ngModelOptions]="{standalone: true}">
-                    <mat-option *ngFor="let runbox_domain of rmm.runbox_domain.data" [value]="runbox_domain.name">
+                    <mat-option *ngFor="let runbox_domain of profileService.global_domains" [value]="runbox_domain.name">
                         {{localpart}}@{{runbox_domain.name}}
                     </mat-option>
                 </mat-select>


### PR DESCRIPTION
Broken by recent identities changes, alias identities should be allowed to change their "preferred domain", eg from runbox.com to runbox.uk