### PR TITLE
feat(identities): Change of runbox domains for all identities

### DIFF
--- a/src/app/profiles/profiles.editor.modal.html
+++ b/src/app/profiles/profiles.editor.modal.html
@@ -31,7 +31,7 @@
             </mat-form-field>
 
             <mat-form-field class="form-field form-item"
-                *ngIf="identity.type === 'aliases' && identity.preferred_runbox_domain && profileService.global_domains ; else other_content">
+                *ngIf="(identity.type === 'aliases' || identity.type === 'main' ) && identity.preferred_runbox_domain && profileService.global_domains ; else other_content">
                 <mat-label>Email</mat-label>
                 <mat-select [(ngModel)]="identity.preferred_runbox_domain"
                     [(value)]="identity.preferred_runbox_domain"


### PR DESCRIPTION
Allows users to change their preferred "runbox domain" (eg from runbox.com to runbox.uk) for any Identities not using virtual domains, without requiring new validation. For username identities this is a drop-down to choose the new domain (localpart may not be changed), for other identities the entire email may be changed, we only require validation if a non-runbox domain is used.