### PR TITLE
fix(identities): Always displays Other identites section

### DIFF
--- a/src/app/profiles/profiles.component.html
+++ b/src/app/profiles/profiles.component.html
@@ -41,7 +41,6 @@
         <br><br>
 
         <app-profiles-lister
-            *ngIf="profileService.otherProfiles.value.length > 0"
             [profiles]="profileService.otherProfiles.value">
             <div section-header>
                 <h2>Other identities</h2>


### PR DESCRIPTION
.. It was missing entirely if the user had no "Other" identities (including the "Add Identity" button), which made it difficult to add any!