### PR TITLE
Create browser-local index if server-side not found

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1020,10 +1020,10 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
       } else {
         console.log('Index download cancelled or failed');
         this.deleteLocalIndex();
-        this.searchService.indexDownloadingInProgress = false;
-        this.searchService.stopIndexDownloadingInProgress = false;
-        this.offerInitialLocalIndex = false;
       }
+      this.searchService.indexDownloadingInProgress = false;
+      this.searchService.stopIndexDownloadingInProgress = false;
+      this.offerInitialLocalIndex = false;
     });
   }
 

--- a/src/app/contacts-app/contacts.service.spec.ts
+++ b/src/app/contacts-app/contacts.service.spec.ts
@@ -73,7 +73,7 @@ describe('ContactsService', () => {
     sut = new ContactsService(rmmapi, prefService, storage);
   });
 
-  it('should allow looking up remote avatars', () => {
+  it('should allow looking up remote avatars', (done) => {
     prefService.set(prefService.prefGroup, 'avatarSource', 'remote' );
 
     prefService.preferences.pipe(take(1)).subscribe(async _ => {
@@ -87,10 +87,12 @@ describe('ContactsService', () => {
 
       avatarUrl = await sut.lookupAvatar('test+no+gravatar@runbox.com');
       expect(avatarUrl).toBeFalsy();
-    });
+
+      done();
+    },);
   });
 
-  it('should allow looking up local avatars', () => {
+  it('should allow looking up local avatars', (done) => {
     prefService.set(prefService.prefGroup, 'avatarSource', 'local');
     prefService.preferences.pipe(take(1)).subscribe(async _ => {
       let avatarUrl = await sut.lookupAvatar('test@runbox.com');
@@ -98,18 +100,22 @@ describe('ContactsService', () => {
 
       avatarUrl = await sut.lookupAvatar('test+gravatar@runbox.com');
       expect(avatarUrl).toBeFalsy();
+
+      done();
     });
   });
 
-  it('should allow looking up avatars set to none', () => {
+  it('should allow looking up avatars set to none', (done) => {
     prefService.set(prefService.prefGroup, 'avatarSource', 'none');
     prefService.preferences.pipe(take(1)).subscribe(async _ => {
       const avatarUrl = await sut.lookupAvatar('test@runbox.com');
       expect(avatarUrl).toBeFalsy();
+
+      done();
     });
   });
 
-  it('should allow resetting avatar source to remote', () => {
+  it('should allow resetting avatar source to remote', (done) => {
     // can enable it back again
     prefService.set(prefService.prefGroup, 'avatarSource', 'remote');
     prefService.preferences.pipe(take(1)).subscribe(async _ => {
@@ -117,6 +123,8 @@ describe('ContactsService', () => {
       expect(avatarUrl).toMatch(/gravatar/);
       avatarUrl = await sut.lookupAvatar('test@runbox.com');
       expect(avatarUrl).toMatch(/test.url/);
+
+      done();
     });
-    });
+  });
 });

--- a/src/app/xapian/searchservice.ts
+++ b/src/app/xapian/searchservice.ts
@@ -497,19 +497,20 @@ export class SearchService {
     // initSubject returns false if no db yet, but that's fine
     // we're downloading it here..
     return this.initSubject.pipe(
-        mergeMap(() => this.checkIfDownloadableIndexExists()),
-        mergeMap((res) => new Observable<boolean>( (observer) => {
+      mergeMap(() => this.checkIfDownloadableIndexExists()),
+      mergeMap((res) => new Observable<boolean>( (observer) => {
         if (!res) {
-          this.localSearchActivated = false;
+          // just create one
+          this.api.initXapianIndex(XAPIAN_GLASS_WR);
+          this.localSearchActivated = true;
           this.indexLastUpdateTime = 0;
-          this.indexDownloadingInProgress = false;
-          // restart updates
+          this.api.closeXapianDatabase();
+          this.api.initXapianIndexReadOnly(XAPIAN_GLASS_WR);
+          this.openDBOnWorker();
+          this.indexReloadedSubject.next(undefined);
           this.indexWorker.postMessage({'action': PostMessageAction.updateIndexWithNewChanges });
-          observer.next(false);
           return;
         }
-
-        // console.log('Download index');
 
         this.downloadProgress = 0;
         let loaded = 0;


### PR DESCRIPTION
Server-side indexes are not created instantly for new users, so if a user signs up, then accepts the offered index download prompt, it would fail. This PR catches the "fail" and creates a new index in the browser, which is then updated as usual by index updates.

The check for server side index is repeated any time the user stops the synchronisation and restarts it, if there is still no server side index, we create another local one and add any updates from scratch again.