### PR TITLE
feat(a11y): Remove underline on anchor hover

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -840,11 +840,22 @@ h3.sideNavHeader {
     padding-left: 20px;
 }
 
+a {
+    color: mat.get-color-from-palette($rmm-default-primary);
+}
+
+a:hover {
+    text-decoration: none;
+}
+
 .mat-nav-list a.textLink {
     color: mat.get-color-from-palette($rmm-default-primary);
     text-decoration: underline;
 }
 
+.mat-nav-list a.textLink:hover {
+    text-decoration: none;
+}
 
 /*** Welcome Desk ***/
 


### PR DESCRIPTION
Make default link color the same as link theme color and not browser default.