### PR TITLE
fix(dist): Disable output file hash

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -69,7 +69,7 @@
           "configurations": {
             "production": {
               "optimization": true,
-              "outputHashing": "all",
+              "outputHashing": "none",
               "aot": true,
               "extractLicenses": true,
               "vendorChunk": false,
@@ -177,7 +177,7 @@
           "configurations": {
             "production": {
               "optimization": true,
-              "outputHashing": "all",
+              "outputHashing": "none",
               "namedChunks": false,
               "aot": true,
               "extractLicenses": true,


### PR DESCRIPTION
Fix issues with the nginx serving index.html when file is not found because of file miss.

This is a potential solution that moves away from the hash filename cache busting strategy.

This solution will require correct setup of etag to prevent index.html and other files that must update on change.

Another solution is to keep files of previous build around. This is what most angular projects tend to use.

Fixes: #1617 

- [ ] Consider a migration strategy to prevent issues on new release.