### PR TITLE
fix(maillist): Ensure we only switch to index data after its loaded

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1011,10 +1011,8 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
   public childRouteActivated(yes: boolean): void {
     this.hasChildRouterOutlet = yes;
     if (yes) {
+      // Don't highlight a folder if we're not viewing one
       this.selectedFolder = null;
-    } else {
-      // reset the default Folder
-      this.selectedFolder = 'Inbox';
     }
   }
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -107,7 +107,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
   entireHistoryInProgress = false;
 
   displayedFolders = new Observable<FolderListEntry[]>();
-  selectedFolder = 'Inbox';
+  selectedFolder = '';
   composeSelected: boolean;
   draftsSelected: boolean;
   overviewSelected: boolean;
@@ -410,7 +410,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
       fragment => {
         if (!fragment) {
           // This also runs when we load '/compose' .. but doesnt need to
-          this.messagelistservice.setCurrentFolder('Inbox');
+          this.switchToFolder('Inbox');
           if (this.singlemailviewer) {
             this.singlemailviewer.close();
           }
@@ -420,8 +420,8 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
 
         if (fragment !== this.fragment) {
           this.fragment = fragment;
+          this.selectMessageFromFragment(this.fragment);
           if (this.canvastable.rows && this.canvastable.rows.rowCount() > 0) {
-            this.selectMessageFromFragment(this.fragment);
             this.canvastable.jumpToOpenMessage();
           } else {
             this.jumpToFragment = true;
@@ -996,6 +996,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
 
     this.showingWebSocketSearchResults = false;
     this.usewebsocketsearch = false;
+    this.showingSearchResults = true;
 
     // don't scroll to top when redrawing after index updates
     if (!this.hasChildRouterOutlet) {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -370,8 +370,11 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
 
     this.messagelistservice.messagesInViewSubject.subscribe(res => {
       this.messagelist = res;
-      if (!this.showingSearchResults && !this.showingWebSocketSearchResults
-         && res) {
+      if (
+        (
+          (!this.showingSearchResults && !this.showingWebSocketSearchResults)
+            || this.messagelistservice.unindexedFolders.includes(this.selectedFolder)
+        ) && res) {
         this.setMessageDisplay('messagelist', this.messagelist);
         if (this.jumpToFragment && res.length > 0) {
             this.selectMessageFromFragment(this.fragment);

--- a/src/app/rmmapi/messagelist.service.ts
+++ b/src/app/rmmapi/messagelist.service.ts
@@ -447,8 +447,11 @@ export class MessageListService {
         folders.forEach((f) => this.staleFolders[f] = true);
         // check if current visible folder has updates
         // refresh if localsearch not activated (aka setCurrentFolder)
-        if (this.staleFolders[this.currentFolder]) {
+        this.searchservice.pipe(take(1)).subscribe(searchservice => {
+          if (!searchservice.localSearchActivated &&
+            this.staleFolders[this.currentFolder]) {
             this.fetchFolderMessages();
-        }
+          }
+        });
     }
 }

--- a/src/app/xapian/index.worker.ts
+++ b/src/app/xapian/index.worker.ts
@@ -204,8 +204,8 @@ class SearchIndexService {
             FS.syncfs(true, async () => {
               // console.log('Worker: Loading partitions');
               this.openStoredPartitions();
-              await this.updateIndexWithNewChanges();
               ctx.postMessage({'action': PostMessageAction.indexUpdated});
+              await this.updateIndexWithNewChanges();
             });
 
 
@@ -1022,7 +1022,8 @@ ctx.addEventListener('message', ({ data }) => {
       if (searchIndexDocumentUpdates.length > 0 && searchIndexService.localSearchActivated) {
         searchIndexService.postMessagesToXapianWorker(searchIndexDocumentUpdates);
       }
-    } else if (data['action'] === PostMessageAction.addTermToDocument && searchIndexService.localSearchActivated) {
+    } else if (data['action'] === PostMessageAction.addTermToDocument) {
+      if (searchIndexService.localSearchActivated) {
       searchIndexService.postMessagesToXapianWorker([
         new SearchIndexDocumentUpdate(data['messageId'], async () => {
           try {
@@ -1032,7 +1033,9 @@ ctx.addEventListener('message', ({ data }) => {
             console.error(e);
           }
         }) ]);
-    } else if (data['action'] === PostMessageAction.removeTermFromDocument && searchIndexService.localSearchActivated) {
+      }
+    } else if (data['action'] === PostMessageAction.removeTermFromDocument) {
+      if (searchIndexService.localSearchActivated) {
       searchIndexService.postMessagesToXapianWorker([
         new SearchIndexDocumentUpdate(data['messageId'], async () => {
           try {
@@ -1044,6 +1047,7 @@ ctx.addEventListener('message', ({ data }) => {
             console.error(e);
           }
         }) ]);
+      }
     } else if (data['action'] === PostMessageAction.setCurrentFolder) {
       searchIndexService.currentFolder = data['folder'];
     }


### PR DESCRIPTION
Only switch to index data after its actually loaded, don't accidentally switch back to the API messagelist., or redo folder counts until user actions are finished.

Also fix an issue where switching from non-folders (Compose/Drafts/Overview) to a folder (by clicking on the Folder name), would display the contents of Inbox, regardless of which folder was selected.

Seems the issue was childRouteActivated - runs when the non-folder router outlet (aka compose, drafts et al) deactivates, and was setting selectedFolder to Inbox, generally *after* switchToFolder et al had switched the folder (so we switched it to chosen folder, then back to Inbox after the deactivation)

Fixes: #1622 

Fixes: #1564