### PR TITLE
fix(index): Restart index updates after syncing index

### DIFF
--- a/src/app/xapian/searchservice.ts
+++ b/src/app/xapian/searchservice.ts
@@ -568,6 +568,7 @@ export class SearchService {
             this.localSearchActivated = true;
             this.messagelistservice.refreshFolderList();
 
+            this.indexWorker.postMessage({'action': PostMessageAction.updateIndexWithNewChanges });
             this.updateIndexLastUpdateTime();
 
             this.downloadProgress = null;


### PR DESCRIPTION
At some point we lost this - it does restart itself eventually (after user actions) - better to restart explicitly though