### PR TITLE
Updates bulk messages PR, adding index working (less data passing) improvements

### DIFF
--- a/e2e/cypress/integration/mailviewer.ts
+++ b/e2e/cypress/integration/mailviewer.ts
@@ -26,7 +26,7 @@ describe('Interacting with mailviewer', () => {
     // });
 
     it('can open an email and go back and forth in browser history', () => {
-        cy.intercept('/rest/v1/email/11').as('get11');
+        cy.intercept('/rest/v1/email/download/*').as('get11');
         cy.visit('/#Inbox:11');
 
          cy.wait('@get11', {'timeout':10000});
@@ -45,7 +45,7 @@ describe('Interacting with mailviewer', () => {
     });
 
     it('can reply to an email with no "To"', () => {
-        cy.intercept('/rest/v1/email/11').as('get11');
+        cy.intercept('/rest/v1/email/download/*').as('get11');
         cy.visit('/#Inbox:11')
         cy.wait('@get11', {'timeout':10000});
         // cy.get('#messageContents');
@@ -59,7 +59,7 @@ describe('Interacting with mailviewer', () => {
     });
 
     it('can forward an email with no "To"', () => {
-        cy.intercept('/rest/v1/email/11').as('get11');
+        cy.intercept('/rest/v1/email/download/*').as('get11');
         cy.visit('/');
         cy.wait('@get11', {'timeout':10000});
         cy.visit('/#Inbox:11');
@@ -74,7 +74,7 @@ describe('Interacting with mailviewer', () => {
     });
 
     it('can reply to an email with no "To" or "Subject"', () => {
-        cy.intercept('/rest/v1/email/13').as('get13');
+        cy.intercept('/rest/v1/email/download/*').as('get13');
         cy.visit('/');
         cy.wait('@get13', {'timeout':10000});
         cy.visit('/#Inbox:13');
@@ -89,7 +89,7 @@ describe('Interacting with mailviewer', () => {
     });
 
     it('can forward an email with no "To" or "Subject"', () => {
-        cy.intercept('/rest/v1/email/13').as('get13');
+        cy.intercept('/rest/v1/email/download/*').as('get13');
         cy.visit('/');
         cy.wait('@get13', {'timeout':10000});
         cy.visit('/#Inbox:13');
@@ -104,7 +104,7 @@ describe('Interacting with mailviewer', () => {
     });
 
     it('Vertical to horizontal mode exposes full height button', () => {
-        cy.intercept('/rest/v1/email/11').as('get11');
+        cy.intercept('/rest/v1/email/download/*').as('get11');
         cy.visit('/');
         cy.wait('@get11', {'timeout':10000});
         cy.visit('/#Inbox:11');
@@ -116,7 +116,7 @@ describe('Interacting with mailviewer', () => {
     });
 
     it('Changing viewpane height is stored', () => {
-        cy.intercept('/rest/v1/email/11').as('get11');
+        cy.intercept('/rest/v1/email/download/*').as('get11');
         cy.visit('/');
         cy.wait('@get11', {'timeout':10000});
         cy.visit('/#Inbox:11');
@@ -133,7 +133,7 @@ describe('Interacting with mailviewer', () => {
     });
 
     it('Half height reduces stored pane height', () => {
-        cy.intercept('/rest/v1/email/11').as('get11');
+        cy.intercept('/rest/v1/email/download/*').as('get11');
         cy.visit('/');
         cy.wait('@get11', {'timeout':10000});
         cy.visit('/#Inbox:11');
@@ -161,7 +161,7 @@ describe('Interacting with mailviewer', () => {
     });
 
     it('Revisit open email in horizontal mode loads it', () => {
-        cy.intercept('/rest/v1/email/11').as('get11');
+        cy.intercept('/rest/v1/email/download/*').as('get11');
         cy.visit('/');
         cy.wait('@get11', {'timeout':10000});
         cy.visit('/#Inbox:11');
@@ -177,7 +177,7 @@ describe('Interacting with mailviewer', () => {
     });
 
     it('Can go out of mailviewer and back and still see our email', () => {
-        cy.intercept('/rest/v1/email/12').as('get12');
+        cy.intercept('/rest/v1/email/download/*').as('get12');
         cy.visit('/');
         cy.wait('@get12',{'timeout':10000});
         cy.visit('/#Inbox:12');

--- a/e2e/cypress/integration/message-caching.ts
+++ b/e2e/cypress/integration/message-caching.ts
@@ -9,8 +9,8 @@ describe('Message caching', () => {
 
     });
 
-  it('should cache all messages on first time page load', () => {
-        cy.intercept('/rest/v1/email/12').as('message12requested');
+    it('should cache all messages on first time page load', () => {
+        cy.intercept('/rest/v1/email/download/*').as('message12requested');
 
         cy.visit('/');
         cy.wait('@message12requested', {'timeout':10000});
@@ -27,7 +27,7 @@ describe('Message caching', () => {
         // Now don't fetch it again:
         cy.visit('/#Inbox:12');
         let called = false;
-        cy.intercept('/rest/v1/email/12', (_req) => {
+        cy.intercept('/rest/v1/email/download/*', (_req) => {
             called = true;
         });
 

--- a/e2e/cypress/integration/message-caching.ts
+++ b/e2e/cypress/integration/message-caching.ts
@@ -9,7 +9,7 @@ describe('Message caching', () => {
 
     });
 
-    it('should cache all messages on first time page load', () => {
+  it('should fetch all messages on first time page load', () => {
         cy.intercept('/rest/v1/email/download/*').as('message12requested');
 
         cy.visit('/');
@@ -18,7 +18,7 @@ describe('Message caching', () => {
     });
 
     it('should not re-request messages after a page reload', () => {
-        cy.intercept('/rest/v1/email/12').as('message12requested');
+        cy.intercept('/rest/v1/email/download/*').as('message12requested');
 
         cy.visit('/');
         cy.wait('@message12requested', {'timeout':10000});

--- a/e2e/mockserver/mockserver.ts
+++ b/e2e/mockserver/mockserver.ts
@@ -246,39 +246,26 @@ END:VCALENDAR
                 }
 
             }
+
+            const bulkemailendpiont = requesturl.match(/\/rest\/v1\/email\/download\/([0-9,]+)/);
+            if (bulkemailendpiont) {
+                const ids = bulkemailendpiont[1].split(',').map(id => parseInt(id, 10));
+
+                const messages = {};
+                for (const id of ids) {
+                    messages[id] = { json: this.getMessage(id).result };
+                }
+
+                response.end(JSON.stringify({
+                    'status': 'success',
+                    'result': messages,
+                }));
+            }
+
             const emailendpoint = requesturl.match(/\/rest\/v1\/email\/([0-9]+)/);
             if (emailendpoint) {
-                const mailid = emailendpoint[1];
-                let message_obj = mail_message_obj;
-                if (mailid === '11') {
-                    message_obj = JSON.parse(JSON.stringify(mail_message_obj));
-                    const to = message_obj.result.headers['to'];
-                    delete message_obj.result.headers['to'];
-                    message_obj.result.headers['cc'] = to;
-                    message_obj.result.headers['subject'] = "No 'To', just 'CC'";
-                }
-                if (mailid === '12') {
-                    message_obj = JSON.parse(JSON.stringify(mail_message_obj));
-                    message_obj.result.headers['to'].value[0].address = "TESTMAIL@TESTMAIL.COM";
-                    message_obj.result.headers['to'].text = "TESTMAIL@TESTMAIL.COM";
-                    message_obj.result.headers['subject'] = "Default from fix test";
-                }
-                if (mailid === '13') {
-                    message_obj = JSON.parse(JSON.stringify(mail_message_obj));
-                    const to = message_obj.result.headers['to'];
-                    delete message_obj.result.headers['to'];
-                    message_obj.result.headers['cc'] = to;
-                    message_obj.result.headers['subject'] = "";
-                }
-                // This one warns, we couldnt find it!
-                if (mailid === '14') {
-                    message_obj = {
-                        'status':'warning',
-                        'errors': [
-                            'Email content missing'
-                        ]
-                    };
-                }
+                const mailid = parseInt(emailendpoint[1], 10);
+                const message_obj = this.getMessage(mailid);
 
                 if (requesturl.endsWith('/html')) {
                     response.end(message_obj.result.text.html);
@@ -1003,5 +990,40 @@ END:VCALENDAR
                 "BEGIN:VCARD\nVERSION:3.0\nUID:ID-GROUP1-MEMBER1\nFN:Group #1 member #1\nNOTE:member 1-1 note\nEND:VCARD",
             ],
         ];
+    }
+
+    getMessage(mailid: number): any {
+        let message_obj = mail_message_obj;
+        if (mailid === 11) {
+            message_obj = JSON.parse(JSON.stringify(mail_message_obj));
+            const to = message_obj.result.headers['to'];
+            delete message_obj.result.headers['to'];
+            message_obj.result.headers['cc'] = to;
+            message_obj.result.headers['subject'] = "No 'To', just 'CC'";
+        }
+        if (mailid === 12) {
+            message_obj = JSON.parse(JSON.stringify(mail_message_obj));
+            message_obj.result.headers['to'].value[0].address = "TESTMAIL@TESTMAIL.COM";
+            message_obj.result.headers['to'].text = "TESTMAIL@TESTMAIL.COM";
+            message_obj.result.headers['subject'] = "Default from fix test";
+        }
+        if (mailid === 13) {
+            message_obj = JSON.parse(JSON.stringify(mail_message_obj));
+            const to = message_obj.result.headers['to'];
+            delete message_obj.result.headers['to'];
+            message_obj.result.headers['cc'] = to;
+            message_obj.result.headers['subject'] = "";
+        }
+        // This one warns, we couldnt find it!
+        if (mailid === '14') {
+            message_obj = {
+              'status':'warning',
+              'errors': [
+                 'Email content missing'
+              ]
+           };
+        }
+
+        return message_obj;
     }
 }

--- a/e2e/mockserver/mockserver.ts
+++ b/e2e/mockserver/mockserver.ts
@@ -260,6 +260,7 @@ END:VCALENDAR
                     'status': 'success',
                     'result': messages,
                 }));
+                return;
             }
 
             const emailendpoint = requesturl.match(/\/rest\/v1\/email\/([0-9]+)/);
@@ -994,18 +995,21 @@ END:VCALENDAR
 
     getMessage(mailid: number): any {
         let message_obj = mail_message_obj;
+        message_obj.status = 'success';
         if (mailid === 11) {
             message_obj = JSON.parse(JSON.stringify(mail_message_obj));
             const to = message_obj.result.headers['to'];
             delete message_obj.result.headers['to'];
             message_obj.result.headers['cc'] = to;
             message_obj.result.headers['subject'] = "No 'To', just 'CC'";
+            message_obj.result.mid = mailid;
         }
         if (mailid === 12) {
             message_obj = JSON.parse(JSON.stringify(mail_message_obj));
             message_obj.result.headers['to'].value[0].address = "TESTMAIL@TESTMAIL.COM";
             message_obj.result.headers['to'].text = "TESTMAIL@TESTMAIL.COM";
             message_obj.result.headers['subject'] = "Default from fix test";
+            message_obj.result.mid = mailid;
         }
         if (mailid === 13) {
             message_obj = JSON.parse(JSON.stringify(mail_message_obj));
@@ -1013,9 +1017,10 @@ END:VCALENDAR
             delete message_obj.result.headers['to'];
             message_obj.result.headers['cc'] = to;
             message_obj.result.headers['subject'] = "";
+            message_obj.result.mid = mailid;
         }
         // This one warns, we couldnt find it!
-        if (mailid === '14') {
+        if (mailid === 14) {
             message_obj = {
               'status':'warning',
               'errors': [
@@ -1023,8 +1028,6 @@ END:VCALENDAR
               ]
            };
         }
-
-        message_obj.status = 'success';
 
         return message_obj;
     }

--- a/e2e/mockserver/mockserver.ts
+++ b/e2e/mockserver/mockserver.ts
@@ -1024,6 +1024,8 @@ END:VCALENDAR
            };
         }
 
+        message_obj.status = 'success';
+
         return message_obj;
     }
 }

--- a/src/app/account-app/bitpay-payment-dialog.component.html
+++ b/src/app/account-app/bitpay-payment-dialog.component.html
@@ -25,8 +25,7 @@
           </button>
         </p>
     </span>
-    <span *ngIf="state === 'failed'">
-        There was an error creating your payment. <br>
-        Try again later, or contact Runbox Support at support@runbox.com.
-    </span>
+    <app-runbox-contact-support *ngIf="state === 'failed'">
+        There was an error creating your payment.
+    </app-runbox-contact-support>
 </div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -460,16 +460,17 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
         filter(() => !this.canvastable.isScrollInProgress()),
         throttleTime(1000)
     ).subscribe(() => {
-        const rowIndexes = this.canvastable.getVisibleRowIndexes();
-        const messageIds = rowIndexes.filter(
-            idx => idx < this.canvastable.rows.rowCount()
-        ).map(idx => this.canvastable.rows.getRowMessageId(idx)
-        ).filter(id => id > 0);
-        for (const id of messageIds) {
-          if (this.searchService.updateMessageText(id)) {
-            this.canvastable.hasChanges = true;
+      const rowIndexes = this.canvastable.getVisibleRowIndexes();
+      const messageIds = rowIndexes.filter(
+        idx => idx < this.canvastable.rows.rowCount()
+      ).map(idx => this.canvastable.rows.getRowMessageId(idx));
+      this.rmmapi.downloadMessages(messageIds).then(
+        (messages) => {
+          for (const msg messages) {
+            this.searchService.updateMessageText(parseInt(msg['id'], 10));
           }
-        }
+          this.canvastable.hasChanges = true;
+        });
     });
 
       if ('serviceWorker' in navigator) {

--- a/src/app/mailviewer/mailviewer.module.ts
+++ b/src/app/mailviewer/mailviewer.module.ts
@@ -39,11 +39,13 @@ import { ShowHTMLDialogComponent } from '../dialog/htmlconfirm.dialog';
 import { ResizerModule } from '../directives/resizer.module';
 import { AvatarBarComponent } from './avatar-bar.component';
 import { ContactCardComponent } from './contactcard.component';
+import { RunboxCommonModule } from '../common/common.module';
 export { SingleMailViewerComponent } from './singlemailviewer.component';
 
 @NgModule({
     imports: [
         CommonModule,
+        RunboxCommonModule,
         FormsModule,
         MatCheckboxModule,
         MatButtonModule,

--- a/src/app/mailviewer/singlemailviewer.component.html
+++ b/src/app/mailviewer/singlemailviewer.component.html
@@ -417,7 +417,10 @@
       </mat-card-content>
     </mat-card>
   </div>
-  <div *ngIf="err">
-    {{err}}
+  <div *ngIf="!mailObj && !err">
+    <app-runbox-loading text="Loading your message"></app-runbox-loading>
   </div>
+  <app-runbox-contact-support *ngIf="err">
+    There was an error loading your message: {{ err }}.
+  </app-runbox-contact-support>
 </div>

--- a/src/app/mailviewer/singlemailviewer.component.ts
+++ b/src/app/mailviewer/singlemailviewer.component.ts
@@ -238,7 +238,18 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
             }
           }
         }
-      });
+      }, 0);
+    });
+
+    // messageHeaderHTML loads after message is loaded
+    this.messageHeaderHTMLQuery.changes.subscribe((forwardHeader: QueryList<ElementRef>) => {
+      setTimeout(() => {
+          const nativeElement = forwardHeader.first?.nativeElement;
+          if (nativeElement) {
+            this.mailObj.origMailHeaderHTML = '<table>' + nativeElement.innerHTML + '</table>';
+            this.mailObj.origMailHeaderText = nativeElement.innerText;
+          }
+      }, 0);
     });
 
     this.afterViewInit.emit(this.messageId);

--- a/src/app/mailviewer/singlemailviewer.component.ts
+++ b/src/app/mailviewer/singlemailviewer.component.ts
@@ -461,7 +461,6 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
   }
 
   private processMessageContents(messageContents: MessageContents): Mail {
-      console.log('processMessageContents processing', messageContents);
     const res: any = Object.assign({}, messageContents);
     if (res.status === 'warning') {
       // status === 'error' already displayed in showBackendErrors?
@@ -500,7 +499,7 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
 
     res.sanitized_html = this.expandAttachmentData(res.attachments, res.sanitized_html);
     res.sanitized_html_without_images = this.expandAttachmentData(res.attachments, res.sanitized_html_without_images);
-    res.visible_attachment_count = res.attachments.filter((att) => !att.inte    
+    res.visible_attachment_count = res.attachments.filter((att) => !att.inteinternal).length;    
 
     // Remove style tag otherwise angular sanitazion will display style tag content as text
 

--- a/src/app/mailviewer/singlemailviewer.component.ts
+++ b/src/app/mailviewer/singlemailviewer.component.ts
@@ -17,7 +17,7 @@
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
 
-import { map } from 'rxjs/operators';
+import { catchError, map } from 'rxjs/operators';
 import {
   Component, Input, OnInit, Output, EventEmitter, ViewChild,
   ViewChildren,
@@ -39,7 +39,7 @@ import { ProgressDialog } from '../dialog/progress.dialog';
 import { MobileQueryService } from '../mobile-query.service';
 
 import { HorizResizerDirective } from '../directives/horizresizer.directive';
-import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
+import { MessageContents, RunboxWebmailAPI } from '../rmmapi/rbwebmail';
 import { of } from 'rxjs';
 import { Router } from '@angular/router';
 import { MessageListService } from '../rmmapi/messagelist.service';
@@ -61,6 +61,8 @@ const resizerPercentageKey = 'rmm7resizerpercentage';
 
 const TOOLBAR_BUTTON_WIDTH = 30;
 
+
+type Mail = any;
 
 @Component({
   moduleId: 'angular2/app/mailviewer/',
@@ -96,7 +98,7 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
 
   public downloadProgress: number;
 
-  public mailObj: any;
+  public mailObj: Mail;
   public err: any;
 
   public mailContentHTML: string = null;
@@ -392,105 +394,13 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
     // ProgressDialog.open(this.dialog);
 
     this.rbwebmailapi.getMessageContents(this.messageId).pipe(
-      map((messageContents) => {
-        const res: any = Object.assign({}, messageContents);
-        if (res.status === 'warning') {
-          // status === 'error' already displayed in showBackendErrors?
-          // Skip if we previously had an issue loading this messge
-          throw res;
-        }
-        res.subject = res.headers.subject;
-        res.from = res.headers.from.value.map(f => new MailAddressInfo(f.name,f.address));
-        res.to = res.headers.to ? res.headers.to.value : '';
-        res.cc = res.headers.cc ? res.headers.cc.value : '';
-
-        // RFC 5322 says "Date" and "From" are the only 2 required fields
-        // and yet we get emails without em.
-        if (!res.headers.date) {
-          res.headers.date = '1970-01-01T00:00:00.000Z';
-        }
-        res.date = (
-          (arr: string[]): Date =>
-            new Date(
-              parseInt(arr[1], 10),
-              parseInt(arr[2], 10) - 1,
-              parseInt(arr[3], 10),
-              parseInt(arr[4], 10),
-              parseInt(arr[5], 10),
-              parseInt(arr[6], 10),
-              parseInt(arr[7], 10)
-            )
-        )
-          (
-            new RegExp('([0-9][0-9][0-9][0-9])-([0-9][0-9])-([0-9][0-9])T' +
-              '([0-9][0-9]):([0-9][0-9]):([0-9][0-9])\.([0-9][0-9][0-9])')
-              .exec(res.headers.date)
-          );
-
-        res.date.setMinutes(res.date.getMinutes() - res.date.getTimezoneOffset());
-
-        res.sanitized_html = this.expandAttachmentData(res.attachments, res.sanitized_html);
-        res.sanitized_html_without_images = this.expandAttachmentData(res.attachments, res.sanitized_html_without_images);
-        res.visible_attachment_count = res.attachments.filter((att) => !att.internal).length;
-
-
-        // Remove style tag otherwise angular sanitazion will display style tag content as text
-
-        if (res.text.html) {
-          // Pre-sanitized, however we need to escape ampersands and
-          // quotes for srcdoc, let angular do it:
-          res.html = this.domSanitizer.bypassSecurityTrustHtml(DOMPurify.sanitize(res.sanitized_html));
-          res.html_without_images = this.domSanitizer.bypassSecurityTrustHtml(DOMPurify.sanitize(res.sanitized_html_without_images));
-        } else {
-          res.html = null;
-        }
-
-        /**
-         * Transform the links so that they are clickable
-         */
-        let text = res.text.text;
-        res.rawtext = text;
-        text = String(text).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-
-        const LINKY_URL_REGEXP =
-          /((ftp|https?):\/\/|(www\.)|(mailto:)?[A-Za-z0-9._%+-]+@)\S*[^\s.;,(){}<>"\u201d\u2019]/i,
-          MAILTO_REGEXP = /^mailto:/i;
-
-        let match;
-        let raw = text;
-        const html = [];
-        let url;
-        let i;
-
-        while ((match = raw.match(LINKY_URL_REGEXP))) {
-          // We can not end in these as they are sometimes found at the end of the sentence
-          url = match[0];
-          // if we did not match ftp/http/www/mailto then assume mailto
-          if (!match[2] && !match[4]) {
-            url = (match[3] ? 'http://' : 'mailto:') + url;
-          }
-          i = match.index;
-          html.push(raw.substr(0, i));
-          ((u, t) => {
-            html.push('<a ');
-            html.push('target="_blank" rel="noopener"');
-            html.push('href="',
-              u.replace(/"/g, '&quot;'),
-              '">');
-            html.push(t);
-            html.push('</a>');
-          })(url, match[0].replace(MAILTO_REGEXP, ''));
-
-          raw = raw.substring(i + match[0].length);
-        }
-        html.push(raw);
-        text = html.join('');
-
-        // res.text = text;
-        res.text = this.domSanitizer.bypassSecurityTrustHtml(DOMPurify.sanitize(res.text.textAsHtml)); // res.text.textAsHtml;
-        return res;
-      }))
-      .subscribe((res) => {
+      catchError((err: Error) => {
+        console.warn(`Error loading message ${this.messageId}: ${err.toString()}, retrying`);
+        return this.rbwebmailapi.getMessageContents(this.messageId, true);
+      }),
+      map((res: MessageContents) => this.processMessageContents(res))
+    ).subscribe(
+      (res: Mail) => {
         if (res.html) {
           // default to no images
           this.mailContentHTML = res.html_without_images;
@@ -513,6 +423,13 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
         if (this.mailObj.seen_flag === 0) {
           this.messageActionsHandler.markSeen();
         }
+        setTimeout(() => {
+          // If forwarding HTML copy mail header from the visible mail viewer header
+          if (this.messageHeaderHTML) {
+            this.mailObj.origMailHeaderHTML = '<table>' + this.messageHeaderHTML.nativeElement.innerHTML + '</table>';
+            this.mailObj.origMailHeaderText = this.messageHeaderHTML.nativeElement.innerText;
+          }
+        }, 0);
       },
       err => {
         console.error('Error fetching message: ' + this.messageId);
@@ -528,8 +445,107 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
         // close the viewer pane
         this.close();
         // else - not outputting normal JS errors!
-      }
+      },
+    );
+  }
+
+  private processMessageContents(messageContents: MessageContents): Mail {
+      console.log('processMessageContents processing', messageContents);
+    const res: any = Object.assign({}, messageContents);
+    if (res.status === 'warning') {
+      // status === 'error' already displayed in showBackendErrors?
+      // Skip if we previously had an issue loading this messge
+      throw res;
+    }
+    res.subject = res.headers.subject;
+    res.from = res.headers.from.value.map(f => new MailAddressInfo(f.name,f.address));
+    res.to = res.headers.to ? res.headers.to.value : '';
+    res.cc = res.headers.cc ? res.headers.cc.value : '';
+
+    // RFC 5322 says "Date" and "From" are the only 2 required fields
+    // and yet we get emails without em.
+    if (!res.headers.date) {
+      res.headers.date = '1970-01-01T00:00:00.000Z';
+    }
+    res.date = (
+      (arr: string[]): Date =>
+        new Date(
+          parseInt(arr[1], 10),
+          parseInt(arr[2], 10) - 1,
+          parseInt(arr[3], 10),
+          parseInt(arr[4], 10),
+          parseInt(arr[5], 10),
+          parseInt(arr[6], 10),
+          parseInt(arr[7], 10)
+        )
+    )
+      (
+        new RegExp('([0-9][0-9][0-9][0-9])-([0-9][0-9])-([0-9][0-9])T' +
+          '([0-9][0-9]):([0-9][0-9]):([0-9][0-9])\.([0-9][0-9][0-9])')
+          .exec(res.headers.date)
       );
+
+    res.date.setMinutes(res.date.getMinutes() - res.date.getTimezoneOffset());
+
+    res.sanitized_html = this.expandAttachmentData(res.attachments, res.sanitized_html);
+    res.sanitized_html_without_images = this.expandAttachmentData(res.attachments, res.sanitized_html_without_images);
+    res.visible_attachment_count = res.attachments.filter((att) => !att.inte    
+
+    // Remove style tag otherwise angular sanitazion will display style tag content as text
+
+    if (res.text.html) {
+      // Pre-sanitized, however we need to escape ampersands and
+      // quotes for srcdoc, let angular do it:
+      res.html = this.domSanitizer.bypassSecurityTrustHtml(DOMPurify.sanitize(res.sanitized_html));
+      res.html_without_images = this.domSanitizer.bypassSecurityTrustHtml(DOMPurify.sanitize(res.sanitized_html_without_images));
+    } else {
+      res.html = null;
+    }
+
+    /**
+     * Transform the links so that they are clickable
+     */
+    let text = res.text.text;
+    res.rawtext = text;
+    text = String(text).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+
+    const LINKY_URL_REGEXP =
+      /((ftp|https?):\/\/|(www\.)|(mailto:)?[A-Za-z0-9._%+-]+@)\S*[^\s.;,(){}<>"\u201d\u2019]/i,
+      MAILTO_REGEXP = /^mailto:/i;
+
+    let match;
+    let raw = text;
+    const html = [];
+    let url;
+    let i;
+
+    while ((match = raw.match(LINKY_URL_REGEXP))) {
+      // We can not end in these as they are sometimes found at the end of the sentence
+      url = match[0];
+      // if we did not match ftp/http/www/mailto then assume mailto
+      if (!match[2] && !match[4]) {
+        url = (match[3] ? 'http://' : 'mailto:') + url;
+      }
+      i = match.index;
+      html.push(raw.substr(0, i));
+      ((u, t) => {
+        html.push('<a ');
+        html.push('target="_blank" rel="noopener"');
+        html.push('href="',
+          u.replace(/"/g, '&quot;'),
+          '">');
+        html.push(t);
+        html.push('</a>');
+      })(url, match[0].replace(MAILTO_REGEXP, ''));
+
+      raw = raw.substring(i + match[0].length);
+    }
+    html.push(raw);
+    text = html.join('');
+
+   //  res.text = text;
+    res.text = this.domSanitizer.bypassSecurityTrustHtml(DOMPurify.sanitize(res.text.textAsHtml)); // res.text.textAsHtml;
+    return res;
   }
 
   expandAttachmentData(attachments: any[], html: string): string {

--- a/src/app/rmmapi/lru-message-cache.ts
+++ b/src/app/rmmapi/lru-message-cache.ts
@@ -42,12 +42,24 @@ export class LRUMessageCache<T> {
         }
     }
 
+    checkIds(ids: number[]): number[] {
+        const keys = [...this.messages.keys()];
+        const matches = keys.filter((val) => ids.includes(val));
+        return matches;
+    }
+
     get(id: number): T {
         const row = this.messages.get(id);
         if (row) {
             row.accessTime = this.now();
         }
         return row?.message;
+    }
+
+    getMany(ids: number[]): T[] {
+        const found = this.checkIds(ids);
+        const results = found.map((id) => this.get(id));
+        return results;
     }
 
     delete(id: number): void {

--- a/src/app/rmmapi/messagecache.ts
+++ b/src/app/rmmapi/messagecache.ts
@@ -33,7 +33,7 @@ export class MessageCache {
             this.db.version(3).stores({
                 // use out-of-line keys, but index "id"
                 // yes, empty first arg is deliberate
-                messages: ',&id',
+                messages: ',&mid',
             });
         } catch (err) {
             console.log(`Error initializing messagecache: ${err}`);
@@ -50,7 +50,7 @@ export class MessageCache {
     // verify which ids we already have
     async checkIds(ids: number[]): Promise<number[]> {
         return this.db?.table('messages')
-            .where('id')
+            .where('mid')
             .anyOf(ids)
             .primaryKeys()
             .then(
@@ -60,7 +60,7 @@ export class MessageCache {
 
     async getMany(ids: number[]): Promise<MessageContents[]> {
         return this.db?.table('messages')
-            .where('id')
+            .where('mid')
             .anyOf(ids)
             .toArray()
             .then(

--- a/src/app/rmmapi/messagecache.ts
+++ b/src/app/rmmapi/messagecache.ts
@@ -30,8 +30,10 @@ export class MessageCache {
 
         try {
             this.db = new Dexie(`messageCache-${userId}`);
-            this.db.version(2).stores({
-                messages: '', // use out-of-line keys
+            this.db.version(3).stores({
+                // use out-of-line keys, but index "id"
+                // yes, empty first arg is deliberate
+                messages: ',&id',
             });
         } catch (err) {
             console.log(`Error initializing messagecache: ${err}`);
@@ -43,6 +45,28 @@ export class MessageCache {
             result => Object.assign(new MessageContents(), result).version === this.message_version ? result : null,
             _error => null,
         );
+    }
+
+    // verify which ids we already have
+    async checkIds(ids: number[]): Promise<number[]> {
+        return this.db?.table('messages')
+            .where('id')
+            .anyOf(ids)
+            .primaryKeys()
+            .then(
+                (keys) => keys.map((key) => key as number)
+            );
+    }
+
+    async getMany(ids: number[]): Promise<MessageContents[]> {
+        return this.db?.table('messages')
+            .where('id')
+            .anyOf(ids)
+            .toArray()
+            .then(
+            result => result,
+                _error => null,
+            );
     }
 
     set(id: number, contents: MessageContents): void {

--- a/src/app/rmmapi/rbwebmail.spec.ts
+++ b/src/app/rmmapi/rbwebmail.spec.ts
@@ -35,6 +35,13 @@ describe('RBWebMail', () => {
             ],
             providers: [
                 RunboxWebmailAPI,
+                { provide: MessageCache, useValue: {
+                    get: (_) => Promise.resolve(null),
+                    set: (_, __) => {},
+                    delete: (_) => {},
+                    checkIds: (_) => Promise.resolve([]),
+                    getMany: (_) => Promise.resolve([]),
+                } },
             ]
         });
     });

--- a/src/app/rmmapi/rbwebmail.spec.ts
+++ b/src/app/rmmapi/rbwebmail.spec.ts
@@ -23,6 +23,7 @@ import { FolderListEntry } from '../common/folderlistentry';
 import { MatLegacyDialogModule as MatDialogModule } from '@angular/material/legacy-dialog';
 import { MatLegacySnackBarModule as MatSnackBarModule } from '@angular/material/legacy-snack-bar';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { MessageCache } from './messagecache';
 import { firstValueFrom } from 'rxjs';
 
 describe('RBWebMail', () => {
@@ -85,7 +86,6 @@ describe('RBWebMail', () => {
 
         messageContentsObservable = rmmapi.getMessageContents(123, true);
         await new Promise(resolve => setTimeout(resolve, 0));
-        httpTestingController.expectOne('/rest/v1/email/123').flush({
         req = httpTestingController.expectOne('/rest/v1/email/123');
         req.flush({
             status: 'success',

--- a/src/app/rmmapi/rbwebmail.spec.ts
+++ b/src/app/rmmapi/rbwebmail.spec.ts
@@ -51,10 +51,12 @@ describe('RBWebMail', () => {
         // so we set it directly here
         rmmapi.setRunboxMe({'uid': '11', 'last_name': 'testuser'});
         const httpTestingController = TestBed.inject(HttpTestingController);
+
         // HACK: crappy solution to get the email request to resolve
         // see https://github.com/angular/angular/issues/25965
         await new Promise(resolve => setTimeout(resolve, 500));
-        httpTestingController.expectOne('/rest/v1/email/123').flush({
+        let req = httpTestingController.expectOne('/rest/v1/email/123');
+        req.flush({
             status: 'success',
             result: {
                 id: 123,
@@ -77,6 +79,8 @@ describe('RBWebMail', () => {
         messageContentsObservable = rmmapi.getMessageContents(123, true);
         await new Promise(resolve => setTimeout(resolve, 0));
         httpTestingController.expectOne('/rest/v1/email/123').flush({
+        req = httpTestingController.expectOne('/rest/v1/email/123');
+        req.flush({
             status: 'success',
             result: {
                 id: 123,
@@ -93,7 +97,8 @@ describe('RBWebMail', () => {
 
         messageContentsObservable = rmmapi.getMessageContents(123);
         await new Promise(resolve => setTimeout(resolve, 0));
-        httpTestingController.expectOne('/rest/v1/email/123').flush({
+        req = httpTestingController.expectOne('/rest/v1/email/123');
+        req.flush({
             status: 'success',
             result: {
                 id: 123,

--- a/src/app/rmmapi/rbwebmail.ts
+++ b/src/app/rmmapi/rbwebmail.ts
@@ -32,7 +32,7 @@ import { DraftFormModel } from '../compose/draftdesk.service';
 import { MatLegacySnackBar as MatSnackBar } from '@angular/material/legacy-snack-bar';
 import { filter, map, mergeMap } from 'rxjs/operators';
 
-import { HttpClient, HttpResponse } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { RunboxLocale } from '../rmmapi/rblocale';
 import { RMM } from '../rmm';
 import { Identity, FromPriority } from '../profiles/profile.service';
@@ -263,6 +263,54 @@ export class RunboxWebmailAPI {
                 return messagePromise;
             }
         }));
+    }
+
+    public downloadMessages(messageIds: number[]): Promise<MessageContents[]> {
+        const missingMessages = [];
+        for (const msgid of messageIds) {
+            if (!this.messageContentsCache[msgid]) {
+                this.messageContentsCache[msgid] = new AsyncSubject<MessageContents>();
+                missingMessages.push(msgid);
+            }
+        }
+
+        const messagePromises = messageIds.map(id => this.messageContentsCache[id].toPromise());
+
+        if (missingMessages.length > 0) {
+            this.http.get(`/rest/v1/email/download/${missingMessages.join(',')}`).pipe(
+                catchError((err: HttpErrorResponse) => throwError(err.message)),
+                concatMap((res: any) => {
+                    if (res.status === 'success') {
+                        return of(res.result);
+                    } else {
+                        return throwError(res.errors[0]);
+                    }
+                }),
+            ).subscribe(
+                (result: any) => {
+                    for (const resultKey of Object.keys(result)) {
+                        const msgid = parseInt(resultKey, 10);
+                        const contents = result[msgid]?.json;
+                        if (contents) {
+                            this.messageContentsCache[msgid].next(contents);
+                            this.messageContentsCache[msgid].complete();
+                        } else {
+                            this.messageContentsCache[msgid].error(result[msgid]?.error);
+                            delete this.messageContentsCache[msgid];
+                        }
+                    }
+                },
+                (err: Error) => {
+                    for (const msgid of missingMessages) {
+                        this.messageContentsCache[msgid].error(err.toString());
+                        delete this.messageContentsCache[msgid];
+                    }
+                }
+            );
+        }
+
+        // return Promise.allSettled(messagePromises);
+        return Promise.all(messagePromises);
     }
 
     public updateLastOn(): Observable<any> {

--- a/src/app/rmmapi/rbwebmail.ts
+++ b/src/app/rmmapi/rbwebmail.ts
@@ -19,7 +19,7 @@
 
 import { Injectable, NgZone } from '@angular/core';
 import { Observable, from, Subject, AsyncSubject, firstValueFrom } from 'rxjs';
-import { share } from 'rxjs/operators';
+import { catchError, concatMap, share, map, mergeMap, tap } from 'rxjs/operators';
 import { MessageInfo } from '../common/messageinfo';
 import { MailAddressInfo } from '../common/mailaddressinfo';
 import { FolderListEntry } from '../common/folderlistentry';
@@ -174,6 +174,10 @@ export class RunboxWebmailAPI {
     private messageCache: AsyncSubject<MessageCache> = new AsyncSubject();
     private messageContentsRequestCache = new LRUMessageCache<Promise<MessageContents>>();
 
+    // Track which messageids we're already fetching
+    // Else we attempt to refetch the same ones a fair bit on start-up
+    private downloadingMessages: number[] = [];
+
     constructor(
         private http: HttpClient,
         private ngZone: NgZone,
@@ -266,51 +270,57 @@ export class RunboxWebmailAPI {
     }
 
     public downloadMessages(messageIds: number[]): Promise<MessageContents[]> {
-        const missingMessages = [];
-        for (const msgid of messageIds) {
-            if (!this.messageContentsCache[msgid]) {
-                this.messageContentsCache[msgid] = new AsyncSubject<MessageContents>();
-                missingMessages.push(msgid);
-            }
-        }
+        const cached = this.messageCache.checkIds([...messageIds]);
+        return cached.then((inCache) => {
+            const missingMessages = messageIds.filter(
+                (msgId) => !inCache.includes(msgId)
+                    && !this.downloadingMessages.includes(msgId)
+            );
+            const messagePromises = missingMessages.map(id => this.messageCache.get(id));
 
-        const messagePromises = messageIds.map(id => this.messageContentsCache[id].toPromise());
-
-        if (missingMessages.length > 0) {
-            this.http.get(`/rest/v1/email/download/${missingMessages.join(',')}`).pipe(
-                catchError((err: HttpErrorResponse) => throwError(err.message)),
-                concatMap((res: any) => {
-                    if (res.status === 'success') {
-                        return of(res.result);
-                    } else {
-                        return throwError(res.errors[0]);
-                    }
-                }),
-            ).subscribe(
-                (result: any) => {
-                    for (const resultKey of Object.keys(result)) {
-                        const msgid = parseInt(resultKey, 10);
-                        const contents = result[msgid]?.json;
-                        if (contents) {
-                            this.messageContentsCache[msgid].next(contents);
-                            this.messageContentsCache[msgid].complete();
+            if (missingMessages.length > 0) {
+                this.downloadingMessages = this.downloadingMessages.concat(missingMessages);
+                this.http.get(`/rest/v1/email/download/${missingMessages.join(',')}`).pipe(
+                    catchError((err: HttpErrorResponse) => throwError(err.message)),
+                    concatMap((res: any) => {
+                        if (res.status === 'success') {
+                            return of(res.result);
                         } else {
-                            this.messageContentsCache[msgid].error(result[msgid]?.error);
-                            delete this.messageContentsCache[msgid];
+                            return throwError(res.errors[0]);
+                        }
+                    }),
+                ).subscribe(
+                    (result: any) => {
+                        for (const resultKey of Object.keys(result)) {
+                            const msgid = parseInt(resultKey, 10);
+                            const contents = result[msgid]?.json;
+                            if (contents) {
+                                this.messageCache.set(msgid, contents);
+                            } else {
+                                this.deleteCachedMessageContents(msgid);
+                            }
+                            const msgIndex = this.downloadingMessages
+                                .findIndex((id) => msgid === id);
+                            if (msgIndex > -1) {
+                                this.downloadingMessages.splice(msgIndex, 1);
+                            }
+                        }
+                    },
+                    (err: Error) => {
+                        for (const msgid of missingMessages) {
+                            this.deleteCachedMessageContents(msgid);
+                            const msgIndex = this.downloadingMessages
+                                .findIndex((id) => msgid === id);
+                            if (msgIndex > -1) {
+                                this.downloadingMessages.splice(msgIndex, 1);
+                            }
                         }
                     }
-                },
-                (err: Error) => {
-                    for (const msgid of missingMessages) {
-                        this.messageContentsCache[msgid].error(err.toString());
-                        delete this.messageContentsCache[msgid];
-                    }
-                }
-            );
-        }
-
-        // return Promise.allSettled(messagePromises);
-        return Promise.all(messagePromises);
+                );
+            }
+            // return Promise.allSettled(messagePromises);
+            return Promise.all(messagePromises);
+        });
     }
 
     public updateLastOn(): Observable<any> {

--- a/src/app/rmmapi/rbwebmail.ts
+++ b/src/app/rmmapi/rbwebmail.ts
@@ -272,53 +272,62 @@ export class RunboxWebmailAPI {
     public downloadMessages(messageIds: number[]): Promise<MessageContents[]> {
         const cached = this.messageCache.checkIds([...messageIds]);
         return cached.then((inCache) => {
+            // Filter out items we already have
+            // or are busy fetching
             const missingMessages = messageIds.filter(
                 (msgId) => !inCache.includes(msgId)
                     && !this.downloadingMessages.includes(msgId)
             );
-            const messagePromises = missingMessages.map(id => this.messageCache.get(id));
 
+            const messagePromises = [];
             if (missingMessages.length > 0) {
                 this.downloadingMessages = this.downloadingMessages.concat(missingMessages);
-                this.http.get(`/rest/v1/email/download/${missingMessages.join(',')}`).pipe(
-                    catchError((err: HttpErrorResponse) => throwError(err.message)),
-                    concatMap((res: any) => {
-                        if (res.status === 'success') {
-                            return of(res.result);
-                        } else {
-                            return throwError(res.errors[0]);
-                        }
-                    }),
-                ).subscribe(
-                    (result: any) => {
-                        for (const resultKey of Object.keys(result)) {
-                            const msgid = parseInt(resultKey, 10);
-                            const contents = result[msgid]?.json;
-                            if (contents) {
-                                this.messageCache.set(msgid, contents);
-                            } else {
-                                this.deleteCachedMessageContents(msgid);
+                messagePromises.push(
+                    new Promise((resolve, reject) => {
+                        this.http.get(`/rest/v1/email/download/${missingMessages.join(',')}`).pipe(
+                            catchError((err: HttpErrorResponse) => throwError(err.message)),
+                            concatMap((res: any) => {
+                                if (res.status === 'success') {
+                                    return of(res.result);
+                                } else {
+                                    return throwError(res.errors[0]);
+                                }
+                            }),
+                        ).subscribe(
+                            (result: any) => {
+                                for (const resultKey of Object.keys(result)) {
+                                    const msgid = parseInt(resultKey, 10);
+                                    console.log('RMMAPI Got some result:', result);
+                                    const contents = result[msgid]?.json;
+                                    if (contents) {
+                                        console.log(`RMMAPI setting cache for msgid = ${msgid}`);
+                                        this.messageCache.set(msgid, contents);
+                                    } else {
+                                        this.deleteCachedMessageContents(msgid);
+                                    }
+                                    const msgIndex = this.downloadingMessages
+                                        .findIndex((id) => msgid === id);
+                                    if (msgIndex > -1) {
+                                        this.downloadingMessages.splice(msgIndex, 1);
+                                    }
+                                }
+                                resolve();
+                            },
+                            (err: Error) => {
+                                for (const msgid of missingMessages) {
+                                    this.deleteCachedMessageContents(msgid);
+                                    const msgIndex = this.downloadingMessages
+                                        .findIndex((id) => msgid === id);
+                                    if (msgIndex > -1) {
+                                        this.downloadingMessages.splice(msgIndex, 1);
+                                    }
+                                }
+                                reject(err);
                             }
-                            const msgIndex = this.downloadingMessages
-                                .findIndex((id) => msgid === id);
-                            if (msgIndex > -1) {
-                                this.downloadingMessages.splice(msgIndex, 1);
-                            }
-                        }
-                    },
-                    (err: Error) => {
-                        for (const msgid of missingMessages) {
-                            this.deleteCachedMessageContents(msgid);
-                            const msgIndex = this.downloadingMessages
-                                .findIndex((id) => msgid === id);
-                            if (msgIndex > -1) {
-                                this.downloadingMessages.splice(msgIndex, 1);
-                            }
-                        }
-                    }
+                        );
+                    })
                 );
             }
-            // return Promise.allSettled(messagePromises);
             return Promise.all(messagePromises);
         });
     }

--- a/src/app/xapian/index.worker.ts
+++ b/src/app/xapian/index.worker.ts
@@ -1001,7 +1001,8 @@ ctx.addEventListener('message', ({ data }) => {
       searchIndexService.folderList = data['value'];
     } else if (data['action'] === PostMessageAction.messageCache) {
       // Add / update the text of a message which we can add to the search index
-      searchIndexService.messageTextCache.set(data['msgId'], data['value']);
+      const updates = data['updates'];
+      updates.forEach((val, key) => searchIndexService.messageTextCache.set(key, val));
     } else if (data['action'] === PostMessageAction.moveMessagesToFolder) {
       searchIndexService.moveMessagesToFolder(data['messageIds'], data['value']);
     } else if (data['action'] === PostMessageAction.deleteMessages) {

--- a/src/app/xapian/searchservice.spec.ts
+++ b/src/app/xapian/searchservice.spec.ts
@@ -21,6 +21,7 @@ import { SearchService, XAPIAN_GLASS_WR } from './searchservice';
 import { Type } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { RunboxWebmailAPI, RunboxMe } from '../rmmapi/rbwebmail';
+import { MessageCache } from '../rmmapi/messagecache';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { MatLegacyDialogModule as MatDialogModule } from '@angular/material/legacy-dialog';
 import { MatLegacySnackBarModule as MatSnackBarModule } from '@angular/material/legacy-snack-bar';

--- a/src/app/xapian/searchservice.spec.ts
+++ b/src/app/xapian/searchservice.spec.ts
@@ -106,6 +106,7 @@ describe('SearchService', () => {
           ],
             providers: [
                 SearchService,
+                MessageCache,
                 MessageListService,
                 RunboxWebmailAPI
                 // { provide: Worker, useValue: {
@@ -245,6 +246,7 @@ describe('SearchService', () => {
 
 
         expect(await searchService.initSubject.toPromise()).toBeTruthy();
+        console.log('search service initialised');
         expect(searchService.localSearchActivated).toBeTruthy();
         expect(localdir).toEqual(searchService.localdir);
 
@@ -286,12 +288,16 @@ describe('SearchService', () => {
 
         await new Promise(resolve => setTimeout(resolve, 1000));
 
-        req = httpMock.expectOne('/rest/v1/email/' + testMessageId);
+        req = httpMock.expectOne('/rest/v1/email/download/' + testMessageId);
         req.flush({
             status: 'success',
             result: {
-                text: {
-                    text: 'message body test text SecretSauceFormula'
+                [testMessageId]: {
+                    json: {
+                        text: {
+                            text: 'message body test text SecretSauceFormula'
+                        }
+                    }
                 }
             }
         });
@@ -314,7 +320,5 @@ describe('SearchService', () => {
 
         FS.chdir('/');
         FS.unmount('/' + localdir);
-
-        console.log(searchService.api.getXapianDocCount(), 'docs in xapian db');
     });
 });

--- a/src/app/xapian/searchservice.ts
+++ b/src/app/xapian/searchservice.ts
@@ -671,7 +671,7 @@ export class SearchService {
     ).map((pair: number[]) => pair[0]);
   }
 
-    checkIfDownloadableIndexExists(): Observable<boolean> {
+  checkIfDownloadableIndexExists(): Observable<boolean> {
       return this.httpclient.get('/mail/download_xapian_index?exists=check').pipe(
             map((stat: any) => {
               this.serverIndexSize = stat.size;

--- a/src/app/xapian/searchservice.ts
+++ b/src/app/xapian/searchservice.ts
@@ -908,8 +908,6 @@ export class SearchService {
       this.rmmapi.getMessageContents(messageId).subscribe((content) => {
         if (content['status'] === 'success') {
           this.messageTextCache.set(messageId, content.text.text);
-          // Send to the messageCache in the worker, so we can add the text to the index:
-          this.indexWorker.postMessage({'action': PostMessageAction.messageCache, 'msgId': messageId, 'value':  content.text.text });
           if (this.messagelistservice.messagesById[messageId]) {
             this.messagelistservice.messagesById[messageId].plaintext = content.text.text;
           }


### PR DESCRIPTION
On canvas update, fetch all in-view message contents at once (instead of one request per message), .. if not already in the cache. After fetching, update the index (to add the message contents to the index), for all the fetched messages at once, making less data exchanges between the two threads.

This should mean less busy threads and more prompt actions for users