### PR TITLE
fix(drag): Shows correct drag-image while moving images to folders

### DIFF
--- a/src/app/canvastable/canvastable.component.html
+++ b/src/app/canvastable/canvastable.component.html
@@ -15,4 +15,3 @@
             (dragstart)="dragColumnOverlay($event)"
             >              
 </div>
-<canvas id="thedragimage"></canvas>

--- a/src/app/folder/folderlist.component.ts
+++ b/src/app/folder/folderlist.component.ts
@@ -240,6 +240,7 @@ export class FolderListComponent implements OnChanges {
         this.dropAboveOrBelowOrInside = DropPosition.NONE;
         this.dragFolderInProgress = false;
         this.dropFolderId = 0;
+        document.getElementById('thedragcanvas').remove();
     }
 
     dragFolderStart(event, folderId: NumberConstructor): void {


### PR DESCRIPTION
This was "fun with browsers and standards" time, chrome needs the canvas-to-copy to be in the DOM (MDN/firefox doesnt), either way whats used as the dragimage is the, view of the element as the user would see it.. so we were seeing whatever  was displaying where the dragcanvas element was being created (which was the top of the main canvas).

Fixed by creating the canvas-copy in the code, and adding it to the DOM off the left edge (off the top doesnt work in all browsers... standards!) 

Fixes: #1095