### PR TITLE
fix(compose): Stop creating new draft copies after sending

### DIFF
--- a/src/app/compose/compose.component.ts
+++ b/src/app/compose/compose.component.ts
@@ -877,6 +877,10 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
 
     ngOnDestroy() {
         if (this.editor) {
+            // turn off onChange handler because it changes the
+            // msg_body and causes auto-save to trigger. See
+            // https://github.com/runbox/runbox7/issues/644#issuecomment-1651655948
+            this.editor.off('change');
             this.tinymce_plugin.remove(this.editor);
         }
     }

--- a/src/app/compose/draftdesk.component.ts
+++ b/src/app/compose/draftdesk.component.ts
@@ -114,7 +114,6 @@ export class DraftDeskComponent implements OnInit {
 
     draftDeleted(messageId) {
         this.draftDeskservice.deleteDraft(messageId);
-        this.updateDraftsInView();
     }
 
     exitToTable() {


### PR DESCRIPTION
Fixes: #644

@antoniskalou did this as a commit a while ago, somehow we lost / didnt apply it!

Also removed, bonus call to updateDraftsInView which isn't needed as its already called in a subscription to changes: draftDeskservice.draftModels.subscribe