### PR TITLE
fix(upgrades): Fetch the correct current subscription for the user

### DIFF
--- a/src/app/account-app/account-upgrades.component.html
+++ b/src/app/account-app/account-upgrades.component.html
@@ -98,7 +98,7 @@
             {{ plan.name.replace('Runbox', '') }}
           </mat-card-title>
           <mat-card-subtitle [ngClass]="{'themePaletteDarkGray': over_quota.length > 0}">
-            <h4><span *ngIf="is_current_subscription"> Your current subscription </span></h4>
+            <h4><span *ngIf="current_sub && current_sub.pid == plan.pid"> Your current subscription </span></h4>
           </mat-card-subtitle>
           <mat-card-content>
             <div>
@@ -142,8 +142,8 @@
               <span *ngIf="me.is_trial">Subscribe for</span>
               <span *ngIf="!me.is_trial && me.subscription === undefined">Purchase for</span>
               <span *ngIf="!me.is_trial && (orig_three_plans[i].pid === me.subscription || plan.pid === me.subscription)">Renew for</span>
-              <span *ngIf="!me.is_trial && plan.quotas.Disk.quota > current_sub.quotas.Disk.quota">Upgrade to</span>
-              <span *ngIf="!me.is_trial && plan.quotas.Disk.quota < current_sub.quotas.Disk.quota">Downgrade to</span>
+              <span *ngIf="!me.is_trial && current_sub && plan.quotas.Disk.quota > current_sub.quotas.Disk.quota">Upgrade to</span>
+              <span *ngIf="!me.is_trial && current_sub && plan.quotas.Disk.quota < current_sub.quotas.Disk.quota">Downgrade to</span>
               {{ plan.currency.replace("USD","$") }}{{ plan.price | number:'1.2-2' }}
             </button>
             <ng-template #unpurchase>
@@ -222,7 +222,7 @@
           <td class="planComponent priceForOneYear">Price for 1 year</td>
           <td  *ngFor="let plan of subs_regular" class="oneYear">
             <div>
-              {{ plan.currency.replace("USD","$") }}{{ plan.price }} <span *ngIf="is_current_subscription"> Your current {{ p.type }} </span>
+              {{ plan.currency.replace("USD","$") }}{{ plan.price }} <span *ngIf="current_sub && current_sub.pid == plan.pid"> Your current {{ plan.type }} </span>
             </div>
             <div>
               <button mat-raised-button

--- a/src/app/account-app/account-upgrades.component.ts
+++ b/src/app/account-app/account-upgrades.component.ts
@@ -148,9 +148,9 @@ export class AccountUpgradesComponent implements OnInit {
             this.rmmapi.me.subscribe(me => {
                 this.me = me;
                 // User's current subscription product:
-                if (this.subscriptions) {
-                    this.current_sub = products.find(p => p.pid === this.me.subscription);
-                }
+                this.rmmapi.getProducts([this.me.subscription]).subscribe(res => {
+                    this.current_sub = res[0];
+                });
                 this.limitedTimeOffer = !me.newerThan(this.limited_time_offer_age);
             });
         });


### PR DESCRIPTION
Existing code assumed the user's current subscription was one of the possible account upgrades - this isn't the case, so now we fetch the current sub separately. Also ensures any page parts that use the current subscription check it is loaded before applying calculations to it