### PR TITLE
fix(payments): Upgrade to latest version of Stripe SDK

### DIFF
--- a/src/app/account-app/credit-cards/stripe-add-card-dialog.component.html
+++ b/src/app/account-app/credit-cards/stripe-add-card-dialog.component.html
@@ -42,31 +42,8 @@
 </ng-template>
 
 <div mat-dialog-content style="max-width: 500px;">
-    <div style="width: 100%; text-align: center">
-        <img src="/_img/pay/stripe-logo.png" alt="VISA, MasterCard, AmEx" style="width: inherit; height: auto" />
-    </div>
     <div [style.display]="state === 'initial' ? 'block' : 'none'">
-        <div class="payment-row">
-            <div class="payment-field payment-field-big">
-                <div #cardNumber></div>
-                <label for="cardNumber">Card number</label>
-            </div>
-        </div>
-        <div class="payment-row">
-            <div class="payment-field payment-field-small">
-                <div #cardExpiry></div>
-                <label for="cardExpiry">Expiration date</label>
-            </div>
-            <div class="payment-field payment-field-small">
-                <div #cardCvc></div>
-                <label for="cardCvc">CVC code</label>
-            </div>
-            <div class="payment-field payment-field-small StripeElement">
-                <mat-form-field>
-                    <input matInput [(ngModel)]="zipCode" placeholder="ZIP code">
-                </mat-form-field>
-            </div>
-        </div>
+      <div #paymentElement id="payment-element"></div>
 
         <div id="card-errors" role="alert" style="display: flex; justify-content: center;">
             <strong> {{ stripeError }} </strong>

--- a/src/app/account-app/payments.service.ts
+++ b/src/app/account-app/payments.service.ts
@@ -50,6 +50,10 @@ export class PaymentsService {
         });
     }
 
+    customerSession(): Observable<any> {
+        return this.rmmapi.createCustomerSession();
+    }
+
     submitStripePayment(tid: number, token: string): Observable<any> {
         return this.rmmapi.payWithStripe(tid, token);
     }

--- a/src/app/account-app/stripe-payment-dialog.component.html
+++ b/src/app/account-app/stripe-payment-dialog.component.html
@@ -1,66 +1,8 @@
-<style>
-    .payment-row {
-        display: -ms-flexbox;
-        display: flex;
-        justify-content: space-between;
-        flex-wrap: wrap;
-        gap: 5px;
-        margin: 0 5px 10px;
-    }
-
-    .payment-field {
-        position: relative;
-        height: 50px;
-        padding: 5px;
-        text-align: center;
-    }
-
-    @media only screen and (max-width: 767px) {
-        .payment-field {
-            font-size: 14px;
-        }
-    }
-
-    .payment-field-big {
-        width: 100%;
-    }
-
-    .payment-field-small {
-        flex: 1 0 25%;
-    }
-</style>
-
 <h1 mat-dialog-title>Card payment</h1>
-    <div style="width: 95%; text-align: center; margin: auto;">
-        <img src="/_img/pay/stripe-logo.png" alt="VISA, MasterCard, AmEx" style="width: inherit; height: auto" />
-    </div>
     <div [style.display]="state === 'initial' ? 'block' : 'none'">
-        <div id="payment-button-row" class="payment-row" [style.display]="paymentRequestsSupported ? 'block' : 'none'">
-            <div class="payment-field payment-field-big">
-                <div #paymentRequestButton></div>
-            </div>
-        </div>
-        <div class="payment-row" autofocus>
-            <div class="payment-field payment-field-big">
-                <label for="cardNumber">Card number</label>
-                <div #cardNumber id="cardNumber"></div>
-            </div>
-        </div>
-        <div class="payment-row">
-            <div class="payment-field payment-field-small">
-                <label for="cardExpiry">Expiration date</label>
-                <div #cardExpiry></div>
-            </div>
-            <div class="payment-field payment-field-small">
-                <label for="cardCvc">CVC code</label>
-                <div #cardCvc></div>
-            </div>
-            <div class="payment-field payment-field-small StripeElement">
-                <mat-form-field>
-                    <input matInput [(ngModel)]="zipCode" placeholder="ZIP/postal code">
-                </mat-form-field>
-            </div>
-        </div>
+      <div >
+        <div #paymentElement id="payment-element"></div>
+      </div>
 
         <div id="card-errors" role="alert" style="display: flex; justify-content: center;">
             <strong> {{ stripeError }} </strong>

--- a/src/app/rmmapi/rbwebmail.ts
+++ b/src/app/rmmapi/rbwebmail.ts
@@ -824,6 +824,12 @@ export class RunboxWebmailAPI {
         );
     }
 
+    public createCustomerSession(): Observable<string> {
+        return this.http.get('/rest/v1/account_product/stripe/session').pipe(
+            map((res: HttpResponse<any>) => res['result'])
+        );
+    }
+
     public payWithBitpay(tid: number, return_url: string, cancel_url: string): Observable<any> {
         return this.http.post('/rest/v1/account_product/crypto/pay', {
             tid, return_url, cancel_url
@@ -840,9 +846,9 @@ export class RunboxWebmailAPI {
         );
     }
 
-    public payWithStripe(tid: number, paymentMethod: string): Observable<any> {
+    public payWithStripe(tid: number, confirmation_id: string): Observable<any> {
         return this.http.post('/rest/v1/account_product/stripe/pay', {
-            tid: tid, payment_method: paymentMethod
+            tid: tid, confirmation_id: confirmation_id
         }).pipe(
             map((res: HttpResponse<any>) => res['result'])
         );


### PR DESCRIPTION
Switches from card elements to "payment element" which draws all the card fields for us, it will also allow the customer to use Link, PayPal, Apple Pay and Google Pay (if enabled in Stripe), as well as re-use saved card details

Notes / implementation details:
* I am switching the implementation from "card elements" to "payment element", this is a recommended upgrade
* The actual version of the SDK in-use by backend API calls is set in the stripe account, my backend patch adds a way to change it via the API call for testing.
* we are using (for which I cannot find reasons), the deferred payment (collect details, then create payment intent), and the finalize payments on the server functionality I am keeping this in case there were reasons
* This all works apart from: Enabling the "re-use payment details" / "present a checkbox to save payment details" functionality - the "create customer session" part required for this does work, so I am baffled why there is no checkbox / previous details shown.

Links:
* migrate to the payment element: https://docs.stripe.com/payments/payment-element/migration?integration-path=one-time, https://docs.stripe.com/payments/payment-element/migration-ct
* payment details before intent (why, I dunno!?): https://docs.stripe.com/payments/accept-a-payment-deferred
* especially this section: https://docs.stripe.com/payments/accept-a-payment-deferred?platform=web&type=payment#save-payment-methods
* also this one?: https://docs.stripe.com/payments/finalize-payments-on-the-server


Fixes: #1448