### PR TITLE
Make folder buttons keyboard navigable

### DIFF
--- a/src/app/folder/folderlist.component.html
+++ b/src/app/folder/folderlist.component.html
@@ -18,7 +18,6 @@
         (drop)="dropToFolder($event,node.folderId)"         
         (dragover)="allowDropToFolder($event,node)" 
         (dragend)="dragCancel()" 
-        (click)="selectFolder(node.folderPath)"
       >
         <button mat-icon-button matTreeNodeToggle
                 [attr.aria-label]="'toggle ' + node.folderName"
@@ -33,11 +32,14 @@
         <mat-icon *ngIf="node.folderType=='templates'" mat-list-icon class="folderIconStandard" svgIcon="file-document"></mat-icon>
         <mat-icon *ngIf="node.folderType=='trash'" mat-list-icon class="folderIconStandard" svgIcon="delete"></mat-icon>
         <mat-icon *ngIf="node.folderType=='user'" mat-list-icon class="folderIconUser" svgIcon="folder"></mat-icon>
-        <div style="margin-left: 5px;" 
-              draggable="true"
-              (dragstart)="dragFolderStart($event, node.folderId)">
-              {{node.folderName}}
-        </div>
+        <a
+          href="#{{node.folderPath}}"
+          draggable="true"
+          (dragstart)="dragFolderStart($event, node.folderId)"
+          (click)="onFolderClick($event, node.folderPath)"
+        >
+          {{node.folderName}}
+        </a>
         <span *ngIf="folderMessageCounts | async as messageCounts">
           <span *ngIf="messageCounts[node.folderPath] !== undefined">
             <span

--- a/src/app/folder/folderlist.component.scss
+++ b/src/app/folder/folderlist.component.scss
@@ -1,7 +1,28 @@
-.mailFolder:hover {
+.mailFolder {
+    position: relative;
+}
+
+.mailFolder:hover,
+.mailFolder:focus-within,
+.mailFolder:has(a:focus) {
     background-color: #F5F5F5;
     cursor: pointer;
-}  
+}
+
+.mailFolder a {
+    margin-left: 1ch;
+    text-decoration: none;
+    color: #444;
+}
+
+.mailFolder a::after {
+    content: "";
+    position: absolute;    
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+}
 
 .nonLocalFolder {
     opacity: 0.5;

--- a/src/app/folder/folderlist.component.ts
+++ b/src/app/folder/folderlist.component.ts
@@ -64,7 +64,7 @@ export class RenameFolderEvent {
     templateUrl: 'folderlist.component.html',
     // eslint-disable-next-line @angular-eslint/component-selector
     selector: 'rmm-folderlist',
-    styleUrls: ['folderlist.component.css']
+    styleUrls: ['folderlist.component.scss']
 })
 export class FolderListComponent implements OnChanges {
     dropFolderId: number;
@@ -253,6 +253,11 @@ export class FolderListComponent implements OnChanges {
         this.dropFolderId = 0;
         this.dragFolderInProgress = false;
         this.dropAboveOrBelowOrInside = DropPosition.NONE;
+    }
+
+    onFolderClick($event, folder) {
+        $event.preventDefault()
+        this.selectFolder(folder)
     }
 
     selectFolder(folder: string): void {


### PR DESCRIPTION
It is currently not possible to select a folder using the keyboard. Considering this is a primary use-case I decided to fix it as one of the first a11y improvements.