### PR TITLE
build(ci): Remove redundant cache action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,5 @@ jobs:
               with:
                   node-version: '16.x'
                   cache: 'npm'
-            - uses: actions/cache@v3
-              with:
-                  path: ~/.npm
-                  key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-node-
             - run: npm ci
             - run: npm run ci-tests -- ${{ matrix.phase }}


### PR DESCRIPTION
The node action already does caching of the .npm
directory.