### PR TITLE
fix(mailviewer): Text/HTML views blank when attachment has odd types

### DIFF
--- a/src/app/mailviewer/singlemailviewer.component.ts
+++ b/src/app/mailviewer/singlemailviewer.component.ts
@@ -275,6 +275,9 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
   }
 
   attachmentIconFromContentType(contentType: string) {
+    if (!contentType) {
+      return 'attachment';
+    }
     if (contentType.indexOf('pdf') > -1) {
       return 'pdf-box';
     } else if (contentType.indexOf('audio') > -1) {


### PR DESCRIPTION
Somehow the mailparser can output an attachment with content-type false, which breaks the mailviewer