### PR TITLE
fix(2fa): Show QR codes for 2FA generation

### DIFF
--- a/src/app/account-security/two-factor-authentication.component.html
+++ b/src/app/account-security/two-factor-authentication.component.html
@@ -129,8 +129,8 @@
                 <div *ngIf="rmm.account_security.tfa.qr_code_value">
                     <p>
                         <span>
-                            <qr-code [value]="rmm.account_security.tfa.qr_code_value.href" [size]="250" level="H">
-                            </qr-code>
+                            <qrcode [qrdata]="rmm.account_security.tfa.qr_code_value.href" [width]="250" [errorCorrectionLevel]="H">
+                            </qrcode>
                         </span>
                     </p>
                 </div>


### PR DESCRIPTION
Missing since some angularx-qrcode update