### PR TITLE
style(payment): Replace link to legacy payment UI with Stripe details note.

### DIFF
--- a/src/app/account-app/stripe-payment-dialog.component.html
+++ b/src/app/account-app/stripe-payment-dialog.component.html
@@ -28,7 +28,6 @@
         <div> Your payment was successful and your products have been activated. </div>
     </div>
 
-    <div class="description" style="text-align: center"> Note: You do not need to save any details via Stripe or Link to make purchases. </div>
   </div>
     <div mat-dialog-actions style="justify-content: center;" *ngIf="state === 'loading'">
       <button mat-button (click)="close()"> Cancel </button>


### PR DESCRIPTION
<img width="1016" height="1142" alt="Stripe note" src="https://github.com/user-attachments/assets/28404570-b215-40d6-b737-fdbf2027fd5f" />
