### PR TITLE
fix(trash): Removed Trash messages should stay gone

### DIFF
--- a/src/app/rmmapi/messagelist.service.ts
+++ b/src/app/rmmapi/messagelist.service.ts
@@ -298,6 +298,10 @@ export class MessageListService {
         // Just lie a bit, we'll fix it in a mo..
         this.folderMessageCountSubject.next(this.folderCounts);
         this.folderMessageLists[this.trashFolderName] = [];
+        // redraw if currently viewing the Trash folder:
+        if (this.currentFolder === this.trashFolderName) {
+            this.messagesInViewSubject.next(this.folderMessageLists[this.currentFolder]);
+        }
     }
 
     // almost duplicate of code in applyChanges, except for hasChanges!?

--- a/src/app/xapian/index.worker.ts
+++ b/src/app/xapian/index.worker.ts
@@ -745,7 +745,8 @@ not matching with rest api counts for current folder`);
           // only got ids for deleted messages
           // deletedMessages.forEach((msg) => folders.add(msg.folder));
           ctx.postMessage({'action': PostMessageAction.updateMessageListService,
-                          'foldersUpdated': Array.from(folders) });
+                           'foldersUpdated': Array.from(folders),
+                           'deletedMessages': deletedMessages});
         }
         // Update folder lists + counts
         // postMessage

--- a/src/app/xapian/searchservice.ts
+++ b/src/app/xapian/searchservice.ts
@@ -150,6 +150,7 @@ export class SearchService {
           this.progressSnackBar.dismiss();
         } else if (data['action'] === PostMessageAction.updateMessageListService) {
           this.messagelistservice.updateStaleFolders(data['foldersUpdated']);
+          this.messagelistservice.applyChanges([], data['deletedMessages']);
           this.messagelistservice.refreshFolderList();
         } else if (data['action'] === PostMessageAction.indexDeleted) {
           this.stopIndexDownloadingInProgress = false;


### PR DESCRIPTION
Empty Trash folder if viewing when calling "Empty Trash".

Remove any messages marked as deleted (by empty trash or IMAP etc)