### PR TITLE
refactor(2fa): Change 2FA Unlock Code description

### DIFF
--- a/src/app/account-security/two-factor-authentication.component.html
+++ b/src/app/account-security/two-factor-authentication.component.html
@@ -10,8 +10,9 @@
         <div runbox-section-content class="runbox-section-content">
             <p>This is the Two-Factor Authentication (2FA) configuration screen, where you can configure the various
                 options for enabling and using 2FA.</p>
-            <p>We recommended that you create an <strong>Unlock Code</strong> when enabling 2FA. This special code can
-                be used to disable 2FA if you have problems logging in with your 2FA codes.</p>
+            <p><strong>Unlock Code:</strong> An unlock code is required so that if you lose access to your TOTP or OTP codes, you can still get access to your account. 
+                Using the unlock code will turn off 2FA for your account. 
+                You can easily re-instate 2FA on this page once you are successfully logged in again. </p>
             <p><em><strong>Note:</strong> For security reasons, enabling 2FA will disable your
                     account password for non-web services. These include IMAP, POP, SMTP, FTP, CalDAV, and CardDAV
                     services that may be used with progams or apps on your device. Therefore you will need to set up App


### PR DESCRIPTION
Altered the unlock code description on the 2FA page to match what is displayed in runbox 6 as an unlock code is now a requirement.