### PR TITLE
style(searchservice): change of wording to be more clear to the user what they are downloading

### DIFF
--- a/src/app/xapian/searchservice.ts
+++ b/src/app/xapian/searchservice.ts
@@ -727,6 +727,7 @@ export class SearchService {
                         0)
                         / (1024 * 1024)
                       );
+                  // totalMessages = the number of messages in the remaining partitions yet to be synchronized 
                   const totalMessages = partitions.reduce((prev, curr, partitionNdx) => prev +
                         curr.numberOfMessages,
                         0);

--- a/src/app/xapian/searchservice.ts
+++ b/src/app/xapian/searchservice.ts
@@ -734,8 +734,8 @@ export class SearchService {
                   dialog.componentInstance.title = 'Continue synchronizing?';
                   dialog.componentInstance.question = `Already synchronized index for
                       ${doccount} of
-                      your most recent messages. To synchronize entire index
-                      (for ${totalMessages} messages),
+                      your most recent messages. To synchronize the entire index
+                      (another ${totalMessages} messages),
                       there's an additional download of ${remainingDownloadMB} MB.`;
                   dialog.afterClosed()
                     .subscribe(res => {


### PR DESCRIPTION
Previously the pop-up gave incorrect information to the user. It asked if the user wanted to
synchronize entire index of x number of messages where x was actually the additional number
of messages yet to be synchronized.
Message now correctly refers to x as the additional number of messages
Commented variable declaration of variable that may have caused this confusion due to its name