### PR TITLE
fix(compose): remove signature when switching to identity without one (#1572)

### DIFF
--- a/src/app/compose/compose.component.spec.ts
+++ b/src/app/compose/compose.component.spec.ts
@@ -1,0 +1,50 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2022 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { updateMessageSignature } from './compose.component';
+
+describe('ComposeComponent.updateMessageSignature', () => {
+    it('removes the current signature when switching to an identity without one', () => {
+        const signature = 'Best regards\nAlice';
+        const bodyContent = 'Hello world';
+        const msgBody = signature + '\n\n' + bodyContent;
+
+        const result = updateMessageSignature(msgBody, signature, null);
+
+        expect(result).toBe('\n\n' + bodyContent);
+    });
+
+    it('handles signatures with regex-special characters', () => {
+        const signature = 'A.B (C) [D] x+y';
+        const msgBody = signature + '\n\nEmail body';
+
+        const result = updateMessageSignature(msgBody, signature, null);
+
+        expect(result).toBe('\n\nEmail body');
+    });
+
+    it('leaves the message unchanged when the current signature is not at the start', () => {
+        const signature = 'My Sig';
+        const msgBody = 'Some text without the sig';
+
+        const result = updateMessageSignature(msgBody, signature, null);
+
+        expect(result).toBe(msgBody);
+    });
+});

--- a/src/app/compose/compose.component.ts
+++ b/src/app/compose/compose.component.ts
@@ -48,6 +48,24 @@ const LOCAL_STORAGE_SHOW_POPULAR_RECIPIENTS = 'showPopularRecipients';
 const LOCAL_STORAGE_DEFAULT_HTML_COMPOSE = 'composeInHTMLByDefault';
 const DOWNLOAD_DRAFT_URL = '/ajax/download_draft_attachment?filename=';
 
+const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+export const updateMessageSignature = (message: string, currentSignature: string | null, nextSignature: string | null) => {
+    if (currentSignature && nextSignature) {
+        return message.replace(new RegExp('^' + escapeRegExp(currentSignature), 'g'), nextSignature);
+    }
+
+    if (currentSignature && !nextSignature) {
+        return message.replace(new RegExp('^' + escapeRegExp(currentSignature), 'g'), '');
+    }
+
+    if (!currentSignature && nextSignature) {
+        return nextSignature.concat('\n\n', message);
+    }
+
+    return message;
+};
+
 @Component({
     // eslint-disable-next-line @angular-eslint/component-selector
     selector: 'compose',
@@ -227,34 +245,39 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
                 if ( this.formGroup.controls.msg_body.pristine ) {
                     if ( this.signature && from.signature ) {
                         // replaces current signature with new one
+                        const current_signature = this.signature;
                         const new_signature = from.signature;
-                        const rgx = new RegExp('^' + this.signature, 'g');
-                        const msg_body = this.formGroup.controls.msg_body.value.replace(rgx, new_signature);
+                        const msg_body = updateMessageSignature(
+                            this.formGroup.controls.msg_body.value,
+                            current_signature,
+                            new_signature,
+                        );
                         this.signature = new_signature;
                         if (this.formGroup.value.useHTML && this.editor) {
-                            this.model.html = this.model.html.replace(rgx, new_signature);
+                            this.model.html = updateMessageSignature(this.model.html, current_signature, new_signature);
                             this.editor.setContent(this.model.html);
                         } else {
                             this.formGroup.controls.msg_body.setValue(msg_body);
                         }
                     } else if ( this.signature && !from.signature ) {
                         // remove current signature when switching to identity with no signature
-                        const rgx = new RegExp('^' + this.signature.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g');
+                        const current_signature = this.signature;
                         if (this.formGroup.value.useHTML && this.editor) {
-                            this.model.html = this.model.html.replace(rgx, '');
+                            this.model.html = updateMessageSignature(this.model.html, current_signature, null);
                             this.editor.setContent(this.model.html);
                         } else {
-                            const msg_body = this.formGroup.controls.msg_body.value.replace(rgx, '');
+                            const msg_body = updateMessageSignature(this.formGroup.controls.msg_body.value, current_signature, null);
                             this.formGroup.controls.msg_body.setValue(msg_body);
                         }
                         this.signature = null;
                         this.has_pasted_signature = false;
                     } else if ( !this.signature && from.signature) {
+                        const new_signature = from.signature;
                         this.has_pasted_signature = true;
-                        const msg_body = from.signature.concat('\n\n', this.model.msg_body);
-                        this.signature = from.signature;
+                        const msg_body = updateMessageSignature(this.model.msg_body, null, new_signature);
+                        this.signature = new_signature;
                         if (from.is_signature_html || (this.formGroup.value.useHTML && this.editor)) {
-                            this.model.html = this.signature.concat('\n\n', this.model.html);
+                            this.model.html = updateMessageSignature(this.model.html, null, new_signature);
                             if (!this.formGroup.value.useHTML) {
                                 this.formGroup.controls.msg_body.setValue(true);
                                 this.htmlToggled();

--- a/src/app/compose/compose.component.ts
+++ b/src/app/compose/compose.component.ts
@@ -237,6 +237,18 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
                         } else {
                             this.formGroup.controls.msg_body.setValue(msg_body);
                         }
+                    } else if ( this.signature && !from.signature ) {
+                        // remove current signature when switching to identity with no signature
+                        const rgx = new RegExp('^' + this.signature.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g');
+                        if (this.formGroup.value.useHTML && this.editor) {
+                            this.model.html = this.model.html.replace(rgx, '');
+                            this.editor.setContent(this.model.html);
+                        } else {
+                            const msg_body = this.formGroup.controls.msg_body.value.replace(rgx, '');
+                            this.formGroup.controls.msg_body.setValue(msg_body);
+                        }
+                        this.signature = null;
+                        this.has_pasted_signature = false;
                     } else if ( !this.signature && from.signature) {
                         this.has_pasted_signature = true;
                         const msg_body = from.signature.concat('\n\n', this.model.msg_body);


### PR DESCRIPTION
Fixes #1572

## Problem
When composing an email with a default identity that has a signature, switching to an identity with no signature left the original signature in the message body. The code handled three cases:
1. Both old and new identity have signatures → replace
2. No old signature, new identity has one → prepend
3. ❌ Old signature exists, new identity has none → **nothing happened**

## Fix
Added the missing third case: when the current identity has a signature and the new one does not, the old signature is removed from both the plain text body and HTML content.

The regex properly escapes special characters in the signature text to avoid regex injection issues.

## Testing
- Verified build compiles cleanly (`ng build runbox7`)

Closes #1572