### PR TITLE
fix(identities): clone identity on edit so Cancel discards changes (#1571)

### DIFF
--- a/src/app/profiles/profile.service.spec.ts
+++ b/src/app/profiles/profile.service.spec.ts
@@ -36,6 +36,34 @@ describe('Identity', () => {
         });
         expect(ident.nameAndAddress).toEqual('Fred Bloggs <test@example.com>');
     });
+
+    // Regression test for issue #1571: ProfilesEditorModalComponent must clone
+    // the identity on edit so that cancelling the dialog discards changes instead
+    // of mutating the original identity object.
+    it('Clone identity on edit: mutating the clone does not affect the original', () => {
+        const original = Identity.fromObject({
+            'email': 'test@example.com',
+            'from_name': 'Original Name',
+            'signature': 'Original Sig',
+            'reference': { status: 1 },
+        });
+
+        // Replicate constructor cloning logic from ProfilesEditorModalComponent
+        const clone = Object.assign(new Identity(), original);
+        if (clone.reference) {
+            clone.reference = { ...original.reference };
+        }
+
+        // Mutate the clone
+        clone.from_name = 'Edited Name';
+        clone.signature = 'Edited Sig';
+        clone.reference.status = 99;
+
+        // Original must be unchanged
+        expect(original.from_name).toEqual('Original Name');
+        expect(original.signature).toEqual('Original Sig');
+        expect(original.reference.status).toEqual(1);
+    });
 });
 
 describe('ProfileService', () => {

--- a/src/app/profiles/profiles.editor.modal.ts
+++ b/src/app/profiles/profiles.editor.modal.ts
@@ -62,10 +62,14 @@ export class ProfilesEditorModalComponent implements OnDestroy {
                 return this.profileService.me[attr];
             }).join(' ');
         }
-        if (identity.email) {
-            this.set_localpart(identity);
+        // Clone the identity so that edits don't mutate the original until saved
+        this.identity = Object.assign(new Identity(), identity);
+        if (this.identity.reference) {
+            this.identity.reference = { ...identity.reference };
         }
-        this.identity = identity;
+        if (this.identity.email) {
+            this.set_localpart(this.identity);
+        }
         if (this.identity.is_signature_html) {
             this.init_tinymce();
         } else {


### PR DESCRIPTION
Fixes #1571

## Problem
When editing an identity, `[(ngModel)]` bindings in the editor dialog mutated the original identity object directly (passed by reference via `MAT_DIALOG_DATA`). Clicking Cancel closed the dialog but the mutations were already applied to the in-memory identity, persisting until page refresh.

## Fix
Clone the identity at dialog construction with `Object.assign(new Identity(), identity)` so the editor works on a copy. Cancel simply closes the dialog without writing anything back. Save continues to work through the profile service as before.

## Testing
- Verified build compiles cleanly (`ng build runbox7`)

Closes #1571