### PR TITLE
Fix #1443: sort countries alphabetically

### DIFF
--- a/src/app/account-details/personal-details.component.spec.ts
+++ b/src/app/account-details/personal-details.component.spec.ts
@@ -19,6 +19,7 @@
 
 import { of } from 'rxjs';
 import { UntypedFormBuilder } from '@angular/forms';
+import * as ct from 'countries-and-timezones';
 import { PersonalDetailsComponent } from './personal-details.component';
 
 describe('PersonalDetailsComponent', () => {
@@ -55,6 +56,12 @@ describe('PersonalDetailsComponent', () => {
     };
 
     it('loads countries in alphabetical order', () => {
+        spyOn(ct, 'getAllCountries').and.returnValue({
+            US: { name: 'United States', timezones: ['America/New_York'] },
+            NO: { name: 'Norway', timezones: ['Europe/Oslo'] },
+            DE: { name: 'Germany', timezones: ['Europe/Berlin'] },
+        } as any);
+
         const component = new PersonalDetailsComponent(
             new UntypedFormBuilder(),
             httpMock as any,
@@ -63,8 +70,7 @@ describe('PersonalDetailsComponent', () => {
         );
 
         const countryNames = component.countriesAndTimezones.map((country) => country.name);
-        const sortedCountryNames = [...countryNames].sort((left, right) => left.localeCompare(right));
 
-        expect(countryNames).toEqual(sortedCountryNames);
+        expect(countryNames).toEqual(['Germany', 'Norway', 'United States']);
     });
 });

--- a/src/app/account-details/personal-details.component.spec.ts
+++ b/src/app/account-details/personal-details.component.spec.ts
@@ -1,0 +1,70 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { of } from 'rxjs';
+import { UntypedFormBuilder } from '@angular/forms';
+import { PersonalDetailsComponent } from './personal-details.component';
+
+describe('PersonalDetailsComponent', () => {
+    const httpMock = {
+        get: (url: string) => {
+            if (url === '/rest/v1/timezones') {
+                return of({ result: { timezones: ['Europe/Oslo'] } });
+            }
+
+            if (url === '/rest/v1/account/details') {
+                return of({
+                    result: {
+                        country: 'NO',
+                        timezone: 'Europe/Oslo',
+                        email_alternative_status: 0,
+                    },
+                });
+            }
+
+            throw new Error(`Unexpected GET ${url}`);
+        },
+        post: () => of({ result: {} }),
+    };
+
+    const dialogMock = {
+        open: () => ({
+            afterClosed: () => of(null),
+        }),
+    };
+
+    const rmmMock = {
+        account_security: { user_password: 'secret' },
+        show_error: () => undefined,
+    };
+
+    it('loads countries in alphabetical order', () => {
+        const component = new PersonalDetailsComponent(
+            new UntypedFormBuilder(),
+            httpMock as any,
+            dialogMock as any,
+            rmmMock as any,
+        );
+
+        const countryNames = component.countriesAndTimezones.map((country) => country.name);
+        const sortedCountryNames = [...countryNames].sort((left, right) => left.localeCompare(right));
+
+        expect(countryNames).toEqual(sortedCountryNames);
+    });
+});

--- a/src/app/account-details/personal-details.component.ts
+++ b/src/app/account-details/personal-details.component.ts
@@ -96,16 +96,16 @@ export class PersonalDetailsComponent implements OnInit {
     }
 
     loadCountryList() {
-        for (const country in ct.getAllCountries()) {
-            if (country) {
-                const ctObject = {
-                    id: country,
-                    name: ct.getAllCountries()[country].name,
-                    timezones: ct.getAllCountries()[country].timezones,
-                };
-                this.countriesAndTimezones.push(ctObject);
-            }
-        }
+        const countries = ct.getAllCountries();
+
+        this.countriesAndTimezones = Object.keys(countries)
+            .filter((country) => !!country)
+            .map((country) => ({
+                id: country,
+                name: countries[country].name,
+                timezones: countries[country].timezones,
+            }))
+            .sort((left, right) => left.name.localeCompare(right.name));
     }
 
     loadTimezones() {


### PR DESCRIPTION
## Summary
- build the country dropdown from a mapped array and sort it by country name
- keep the existing country metadata intact for timezone handling
- add a focused unit spec that checks the resulting list is alphabetical

## Testing
- npx tsc -p tsconfig.json --noEmit

Closes #1443