### PR TITLE
fix(mail): auto-dismiss toggling flags notification

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,0 +1,67 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { AppComponent } from './app.component';
+
+describe('AppComponent', () => {
+  it('should auto-dismiss the toggling flags notification', () => {
+    const component = Object.create(AppComponent.prototype) as AppComponent;
+    const selectedMessageIds = [42];
+    const snackBar = {
+      open: jasmine.createSpy('open')
+    };
+    const updateMessages = jasmine.createSpy('updateMessages').and.callFake((args) => {
+      args.updateLocal(selectedMessageIds);
+    });
+    const flagChangeSubject = {
+      next: jasmine.createSpy('next')
+    };
+
+    component.snackBar = snackBar as any;
+    component.canvastable = {
+      rows: {
+        selectedMessageIds: () => selectedMessageIds
+      }
+    } as any;
+    component.messageActionsHandler = {
+      updateMessages
+    } as any;
+    component.rmmapi = {
+      messageFlagChangeSubject: flagChangeSubject
+    } as any;
+    component.clearSelection = jasmine.createSpy('clearSelection');
+    component.singlemailviewer = null;
+    component.rmm = {
+      email: {
+        update: jasmine.createSpy('update')
+      }
+    } as any;
+
+    component.setFlaggedStatus(true);
+
+    expect(snackBar.open).toHaveBeenCalledWith(
+      'Toggling flags...',
+      undefined,
+      { duration: 3000 }
+    );
+    expect(component.clearSelection).toHaveBeenCalled();
+    expect(flagChangeSubject.next).toHaveBeenCalled();
+    expect(updateMessages).toHaveBeenCalled();
+  });
+});

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -779,7 +779,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
   }
 
   public setFlaggedStatus(status: boolean) {
-    this.snackBar.open('Toggling flags...');
+    this.snackBar.open('Toggling flags...', undefined, { duration: 3000 });
     const messageIds = this.canvastable.rows.selectedMessageIds();
 
     this.messageActionsHandler.updateMessages({


### PR DESCRIPTION
Fixes #1732

## Problem
The "Toggling flags..." snackbar shown from the message list had no duration, so it stayed visible until the user dismissed it manually or reloaded.

## Fix
Add a 3-second duration to the snackbar opened by \ and add a focused spec covering the snackbar configuration.

## Testing
- Focused Node-based validation of \ behavior
- \
> runbox7@0.1.1 build
> node src/build/pre-build.js && ng build --configuration production --base-href=/app/ runbox7; RES=$?; node src/build/post-build.js; exit $RES

WARNING: Reverting to committed package-lock.json. If that means your changes are lost you should rebuild it.
All dependency versions ok. Will build production bundle.

Updating changelog
changes.ts updated
Updating appData

Initial Chunk Files                                             | Names                            |  Raw Size | Estimated Transfer Size
main.5939afddff8d889d.js                                        | main                             |   3.45 MB |               581.94 kB
scripts.b9d51b4e1ab69b6a.js                                     | scripts                          | 486.03 kB |               147.26 kB
styles.555fc4b7cb74ba62.css                                     | styles                           | 140.38 kB |                16.15 kB
polyfills.f74b78f4f6795abc.js                                   | polyfills                        |  70.29 kB |                22.33 kB
runtime.c39162d4ab90c2f1.js                                     | runtime                          |   3.93 kB |                 1.82 kB

| Initial Total                    |   4.14 MB |               769.49 kB

Lazy Chunk Files                                                | Names                            |  Raw Size | Estimated Transfer Size
src_app_calendar-app_calendar-app_module_ts.3be23388b3f37a27.js | calendar-app-calendar-app-module | 316.02 kB |                60.54 kB
src_app_xapian_index_worker_ts.33f3a01e2f7d1db7.js              | -                                | 266.28 kB |                56.56 kB
src_app_changelog_changelog_module_ts.2fae88cf5e397388.js       | changelog-changelog-module       | 147.67 kB |                41.48 kB
src_app_contacts-app_contacts-app_module_ts.f3c53b0d9b584af0.js | contacts-app-contacts-app-module |  72.21 kB |                14.63 kB
src_app_dev_dev_module_ts.34ea55c51bf35b1b.js                   | dev-dev-module                   |  24.91 kB |                 5.91 kB
src_app_dkim_dkim_module_ts.b0b9aa978f723513.js                 | dkim-dkim-module                 |  13.86 kB |                 3.85 kB
common.f5176967c7c93e69.js                                      | common                           |  10.47 kB |                 3.43 kB
src_app_onscreen_onscreen_module_ts.2b403b614c70bb13.js         | onscreen-onscreen-module         | 727 bytes |               432 bytes

Build at: 2026-03-25T21:28:01.709Z - Hash: 9c47c42aaf23351c - Time: 23966ms

    ==========================
    Changelog has been updated
    ==========================
Run the following command to commit it:

git commit src/app/changelog/changes.ts -em "docs(changelog): Update changelog"

## Notes
- \
> runbox7@0.1.1 test
> ng test --watch=false --browsers=FirefoxHeadless --include=src/app/app.component.spec.ts

25 03 2026 22:28:07.696:INFO [karma-server]: Karma v6.4.4 server started at http://localhost:9876/
25 03 2026 22:28:07.696:INFO [launcher]: Launching browsers FirefoxHeadless with concurrency unlimited
25 03 2026 22:28:07.697:INFO [launcher]: Starting browser FirefoxHeadless
25 03 2026 22:28:07.698:ERROR [launcher]: No binary for FirefoxHeadless browser on your platform.
  Please, set "FIREFOX_BIN" env variable.
25 03 2026 22:28:07.699:ERROR [karma-server]: UncaughtException: TypeError: Cannot read properties of undefined (reading 'stderr')
    at FirefoxBrowser._start (/Users/kjetil/Code/runbox7/node_modules/karma-firefox-launcher/index.js:273:19)
    at Object.<anonymous> (/Users/kjetil/Code/runbox7/node_modules/karma/lib/launchers/process.js:19:10)
    at Object.emit (node:events:520:22)
    at Object.emit (node:domain:489:12)
    at BaseLauncher.start (/Users/kjetil/Code/runbox7/node_modules/karma/lib/launchers/base.js:52:10)
    at Object.j (/Users/kjetil/Code/runbox7/node_modules/karma/lib/launcher.js:108:17)
    at setTimeout.bind.j (/Users/kjetil/Code/runbox7/node_modules/qjobs/qjobs.js:143:18)
    at listOnTimeout (node:internal/timers:605:17)
    at process.processTimers (node:internal/timers:541:7)
25 03 2026 22:28:07.699:ERROR [karma-server]: TypeError: Cannot read properties of undefined (reading 'stderr')
    at FirefoxBrowser._start (/Users/kjetil/Code/runbox7/node_modules/karma-firefox-launcher/index.js:273:19)
    at Object.<anonymous> (/Users/kjetil/Code/runbox7/node_modules/karma/lib/launchers/process.js:19:10)
    at Object.emit (node:events:520:22)
    at Object.emit (node:domain:489:12)
    at BaseLauncher.start (/Users/kjetil/Code/runbox7/node_modules/karma/lib/launchers/base.js:52:10)
    at Object.j (/Users/kjetil/Code/runbox7/node_modules/karma/lib/launcher.js:108:17)
    at setTimeout.bind.j (/Users/kjetil/Code/runbox7/node_modules/qjobs/qjobs.js:143:18)
    at listOnTimeout (node:internal/timers:605:17)
    at process.processTimers (node:internal/timers:541:7) could not run in this environment because Firefox is not installed