### PR TITLE
fix(help): correct forum link in help center

### DIFF
--- a/src/app/help/help.component.html
+++ b/src/app/help/help.component.html
@@ -62,7 +62,7 @@
 				</mat-card>
 
 				<mat-card class="settingsItem">
-					<a href="https://forum.runbox.com/" target="forum">
+					<a href="https://community.runbox.com/" target="forum">
 						<h3>
 							<mat-icon svgIcon="forum"></mat-icon> <strong>Forum</strong>
 						</h3>

--- a/src/app/help/help.component.spec.ts
+++ b/src/app/help/help.component.spec.ts
@@ -17,6 +17,7 @@
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
 
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { HelpComponent } from './help.component';
@@ -27,7 +28,8 @@ describe('HelpComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ HelpComponent ]
+      declarations: [ HelpComponent ],
+      schemas: [NO_ERRORS_SCHEMA]
     })
     .compileComponents();
   });
@@ -40,5 +42,11 @@ describe('HelpComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should link the forum card to the Runbox community', () => {
+    const forumLink = fixture.nativeElement.querySelector('a[target="forum"]');
+
+    expect(forumLink.getAttribute('href')).toBe('https://community.runbox.com/');
   });
 });


### PR DESCRIPTION
## Summary
- update the Help Center forum card to point to https://community.runbox.com/
- add a regression spec that asserts the forum card link uses the community URL
- keep the change isolated to the Help component

## Verification
- git log -1 --stat --oneline
- npm run lint
- npm run ci-tests

## Results
- git log confirms a single clean fix commit on top of master
- npm run lint passes with the repositorys existing warnings only
- npm run ci-tests reaches the unit-test phase and then fails because FirefoxHeadless is not installed on this machine: No binary for FirefoxHeadless browser on your platform

## Notes
- closes #1769
- the CI failure above is an environment blocker on this host, not a code-level failure from the help-link change