### PR TITLE
fix(calendar): widen event editor dialog

### DIFF
--- a/src/app/calendar-app/calendar-app.component.spec.ts
+++ b/src/app/calendar-app/calendar-app.component.spec.ts
@@ -34,6 +34,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { take } from 'rxjs/operators';
 import { of, Observable, ReplaySubject } from 'rxjs';
 import { MatLegacySnackBar as MatSnackBar } from '@angular/material/legacy-snack-bar';
+import { MatLegacyDialog as MatDialog } from '@angular/material/legacy-dialog';
 import { RunboxCalendar } from './runbox-calendar';
 import { RunboxCalendarEvent } from './runbox-calendar-event';
 import { MatIcon } from '@angular/material/icon';
@@ -308,5 +309,42 @@ END:VCALENDAR
         expect(first_occurence.getDate()).toBe(1, 'day matches');
         expect(first_occurence.getHours()).toBe(12, 'hour matches');
         expect(first_occurence.getMinutes()).toBe(34, 'minute matches');
+    });
+
+    it('should open a wider responsive dialog when adding events (GH-1400)', () => {
+        const dialog = TestBed.inject(MatDialog);
+        const openSpy = spyOn(dialog, 'open').and.returnValue({
+            afterClosed: () => of(undefined),
+        } as any);
+
+        component.addEvent();
+
+        expect(openSpy).toHaveBeenCalledWith(
+            jasmine.any(Function),
+            jasmine.objectContaining({
+                width: '95vw',
+                maxWidth: '720px',
+                data: jasmine.objectContaining({ is_new: true }),
+            })
+        );
+    });
+
+    it('should keep the wider responsive dialog when editing events (GH-1400)', () => {
+        const dialog = TestBed.inject(MatDialog);
+        const openSpy = spyOn(dialog, 'open').and.returnValue({
+            afterClosed: () => of(undefined),
+        } as any);
+        const event = RunboxCalendarEvent.newEmpty();
+
+        component.openEvent(event);
+
+        expect(openSpy).toHaveBeenCalledWith(
+            jasmine.any(Function),
+            jasmine.objectContaining({
+                width: '95vw',
+                maxWidth: '720px',
+                data: jasmine.objectContaining({ event, is_new: false }),
+            })
+        );
     });
 });

--- a/src/app/calendar-app/calendar-app.component.ts
+++ b/src/app/calendar-app/calendar-app.component.ts
@@ -75,6 +75,11 @@ import '../sentry';
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class CalendarAppComponent implements OnDestroy {
+    private readonly eventEditorDialogSize = {
+        width: '95vw',
+        maxWidth: '720px',
+    };
+
     mwlView = CalendarView.Month;
     view: RunboxCalendarView = RunboxCalendarView.Month;
     // needed so that angular templates know what this name means
@@ -171,6 +176,7 @@ export class CalendarAppComponent implements OnDestroy {
         const new_event = RunboxCalendarEvent.newEmpty(this.calendarservice.me.timezone);
         new_event.timezone = this.calendarservice.me.timezone;
         const dialogRef = this.dialog.open(EventEditorDialogComponent, {
+            ...this.eventEditorDialogSize,
             data: { event: new_event, calendars: this.calendars, settings: this.settings, start: on, is_new: true } }
         );
         dialogRef.afterClosed().subscribe(event => {
@@ -277,6 +283,7 @@ export class CalendarAppComponent implements OnDestroy {
     openEvent(event: CalendarEvent): void {
         const target = event as RunboxCalendarEvent;
         const dialogRef = this.dialog.open(EventEditorDialogComponent, {
+            ...this.eventEditorDialogSize,
             data: { event: target, calendars: this.calendars, settings: this.settings, is_new: false }
         });
         dialogRef.afterClosed().subscribe(result => {

--- a/src/app/calendar-app/event-editor-dialog.component.html
+++ b/src/app/calendar-app/event-editor-dialog.component.html
@@ -1,5 +1,5 @@
 <h1 mat-dialog-title>{{ event_title || "New event" }}</h1>
-<section mat-dialog-content style="max-width: 500px; box-sizing: border-box;">
+<section mat-dialog-content style="width: 100%; box-sizing: border-box;">
   <mat-tab-group>
     <mat-tab label="Details">
     <style>


### PR DESCRIPTION
## Summary
- open the calendar event editor with a wider responsive dialog
- remove the old 500px content cap so the form can use the dialog width
- add regression coverage for opening both new and existing event dialogs

## Testing
- npx tsc -p tsconfig.json --noEmit
- npm test -- --watch=false --browsers=ChromeHeadless --include src/app/calendar-app/calendar-app.component.spec.ts *(fails in this environment because no Karma browser launcher target is installed: Chrome/Firefox not available)*

Closes #1400