### PR TITLE
fix(identities): preserve default identity name casing

### DIFF
--- a/src/app/profiles/profiles.default.html
+++ b/src/app/profiles/profiles.default.html
@@ -4,7 +4,7 @@
     <div class="profiles-select">
         <mat-form-field id="default-identity-form">
             <mat-select [value]="selectedProfile" [(ngModel)]="selectedProfile">
-                <mat-option class="identity-profile" *ngFor="let profile of validProfiles" [value]="profile">
+                <mat-option *ngFor="let profile of validProfiles" [value]="profile">
                     {{profile.nameAndAddress}}
                 </mat-option>
             </mat-select>

--- a/src/app/profiles/profiles.default.scss
+++ b/src/app/profiles/profiles.default.scss
@@ -20,10 +20,6 @@
     text-transform: capitalize;
 }
 
-.identity-profile {
-    text-transform: lowercase;
-}
-
 #default-identity-form {
     margin-right: 20px;
     min-width: 200px;

--- a/src/app/profiles/profiles.default.spec.ts
+++ b/src/app/profiles/profiles.default.spec.ts
@@ -17,57 +17,73 @@
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
 
+import { CommonModule } from '@angular/common';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
-import { of } from 'rxjs';
+import { MatLegacySnackBar as MatSnackBar } from '@angular/material/legacy-snack-bar';
+import { BehaviorSubject } from 'rxjs';
 
 import { DefaultProfileComponent } from './profiles.default';
 import { Identity, ProfileService } from './profile.service';
 import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
-import { MatLegacySnackBar as MatSnackBar } from '@angular/material/legacy-snack-bar';
 
 describe('DefaultProfileComponent', () => {
     let fixture: ComponentFixture<DefaultProfileComponent>;
     let component: DefaultProfileComponent;
 
-    beforeEach(waitForAsync(() => {
-        TestBed.configureTestingModule({
-            imports: [FormsModule],
+    const profiles$ = new BehaviorSubject<Identity[]>([]);
+    const validProfiles$ = new BehaviorSubject<Identity[]>([]);
+
+    const mockProfileService = {
+        profiles: profiles$,
+        validProfiles: validProfiles$,
+        composeProfile: null,
+    };
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
             declarations: [DefaultProfileComponent],
+            imports: [CommonModule, FormsModule],
             providers: [
+                { provide: ProfileService, useValue: mockProfileService },
                 { provide: RunboxWebmailAPI, useValue: {} },
-                { provide: MatSnackBar, useValue: { open: jasmine.createSpy('open') } },
-                {
-                    provide: ProfileService, useValue: {
-                        profiles: of([]),
-                        composeProfile: null,
-                        validProfiles: { value: [] },
-                    }
-                },
+                { provide: MatSnackBar, useValue: { open: () => undefined } },
             ],
             schemas: [NO_ERRORS_SCHEMA],
         }).compileComponents();
-    }));
+    });
 
     beforeEach(() => {
         fixture = TestBed.createComponent(DefaultProfileComponent);
         component = fixture.componentInstance;
-    });
 
-    it('renders default identity options with their original casing', () => {
-        const mixedCaseProfile = Identity.fromObject({
-            email: 'mixed@example.com',
-            from_name: 'Jane McTest',
-        });
+        const profiles = [
+            Identity.fromObject({
+                id: 1,
+                email: 'alice@example.com',
+                from_name: 'Alice Example',
+            }),
+            Identity.fromObject({
+                id: 2,
+                email: 'bob@example.com',
+                from_name: 'Bob Example',
+            }),
+        ];
 
-        component.validProfiles = [mixedCaseProfile];
-        component.selectedProfile = mixedCaseProfile;
+        component.validProfiles = profiles;
+        component.selectedProfile = profiles[0];
+        mockProfileService.composeProfile = profiles[0];
+        profiles$.next(profiles);
+        validProfiles$.next(profiles);
 
         fixture.detectChanges();
+    });
 
-        const option = fixture.nativeElement.querySelector('mat-option') as HTMLElement;
-        expect(option.textContent.trim()).toBe('Jane McTest <mixed@example.com>');
+    it('should not apply the lowercase-only identity option class', () => {
+        const option = fixture.nativeElement.querySelector('mat-option');
+
         expect(option.classList.contains('identity-profile')).toBeFalse();
+        expect(option.textContent).toContain('Alice Example <alice@example.com>');
     });
 });

--- a/src/app/profiles/profiles.default.spec.ts
+++ b/src/app/profiles/profiles.default.spec.ts
@@ -1,0 +1,73 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { of } from 'rxjs';
+
+import { DefaultProfileComponent } from './profiles.default';
+import { Identity, ProfileService } from './profile.service';
+import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
+import { MatLegacySnackBar as MatSnackBar } from '@angular/material/legacy-snack-bar';
+
+describe('DefaultProfileComponent', () => {
+    let fixture: ComponentFixture<DefaultProfileComponent>;
+    let component: DefaultProfileComponent;
+
+    beforeEach(waitForAsync(() => {
+        TestBed.configureTestingModule({
+            imports: [FormsModule],
+            declarations: [DefaultProfileComponent],
+            providers: [
+                { provide: RunboxWebmailAPI, useValue: {} },
+                { provide: MatSnackBar, useValue: { open: jasmine.createSpy('open') } },
+                {
+                    provide: ProfileService, useValue: {
+                        profiles: of([]),
+                        composeProfile: null,
+                        validProfiles: { value: [] },
+                    }
+                },
+            ],
+            schemas: [NO_ERRORS_SCHEMA],
+        }).compileComponents();
+    }));
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(DefaultProfileComponent);
+        component = fixture.componentInstance;
+    });
+
+    it('renders default identity options with their original casing', () => {
+        const mixedCaseProfile = Identity.fromObject({
+            email: 'mixed@example.com',
+            from_name: 'Jane McTest',
+        });
+
+        component.validProfiles = [mixedCaseProfile];
+        component.selectedProfile = mixedCaseProfile;
+
+        fixture.detectChanges();
+
+        const option = fixture.nativeElement.querySelector('mat-option') as HTMLElement;
+        expect(option.textContent.trim()).toBe('Jane McTest <mixed@example.com>');
+        expect(option.classList.contains('identity-profile')).toBeFalse();
+    });
+});


### PR DESCRIPTION
## Summary
- remove the lowercase-only styling from the default identity dropdown
- preserve the stored From-name casing in the rendered identity labels
- add a focused regression spec for the default identity selector

## Verification
- git log -2 --oneline --decorate
- npm run lint
- npm run test -- --watch=false --progress=false --browsers=FirefoxHeadless --include src/app/profiles/profiles.default.spec.ts

## Results
- the branch now contains the existing fix commit plus a new regression-test commit
- npm run lint passes with the repositorys existing warnings only
- the targeted Angular test command reaches Karma startup and then stops because FirefoxHeadless is not installed on this machine: No binary for FirefoxHeadless browser on your platform

## Notes
- closes #1402
- the test failure above is an environment blocker on this host, not a compile failure from the new spec