### PR TITLE
Fix #1763: clarify additional index download prompt

### DIFF
--- a/src/app/xapian/searchservice.spec.ts
+++ b/src/app/xapian/searchservice.spec.ts
@@ -17,7 +17,7 @@
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
 
-import { SearchService, XAPIAN_GLASS_WR } from './searchservice';
+import { SearchService, XAPIAN_GLASS_WR, buildAdditionalIndexDownloadQuestion } from './searchservice';
 import { Type } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { RunboxWebmailAPI, RunboxMe } from '../rmmapi/rbwebmail';
@@ -121,6 +121,14 @@ describe('SearchService', () => {
 
         httpMock = TestBed.inject(HttpTestingController as Type<HttpTestingController>);
     }));
+
+    it('should describe the full index message count in the download confirmation', () => {
+        expect(buildAdditionalIndexDownloadQuestion(12865, 70577, 31)).toBe(
+            'Already synchronized index for 12865 of your most recent messages. ' +
+            'To synchronize the entire index (of 83442 messages), ' +
+            'there\'s an additional download of 31 MB.'
+        );
+    });
 
     xit('should load searchservice, but no local index', async () => {
         const searchService = TestBed.inject(SearchService);

--- a/src/app/xapian/searchservice.ts
+++ b/src/app/xapian/searchservice.ts
@@ -66,6 +66,17 @@ export class SearchIndexDocumentData {
   attachment?: boolean;
 }
 
+export function buildAdditionalIndexDownloadQuestion(
+  synchronizedMessages: number,
+  additionalMessages: number,
+  remainingDownloadMB: number
+): string {
+  const totalMessages = synchronizedMessages + additionalMessages;
+  return `Already synchronized index for ${synchronizedMessages} of your most recent messages. ` +
+    `To synchronize the entire index (of ${totalMessages} messages), ` +
+    `there's an additional download of ${remainingDownloadMB} MB.`;
+}
+
 @Injectable({
     providedIn: 'root'
 })
@@ -727,16 +738,16 @@ export class SearchService {
                         0)
                         / (1024 * 1024)
                       );
-                  const totalMessages = partitions.reduce((prev, curr, partitionNdx) => prev +
+                  const additionalMessages = partitions.reduce((prev, curr) => prev +
                         curr.numberOfMessages,
                         0);
 
                   dialog.componentInstance.title = 'Continue synchronizing?';
-                  dialog.componentInstance.question = `Already synchronized index for
-                      ${doccount} of
-                      your most recent messages. To synchronize entire index
-                      (for ${totalMessages} messages),
-                      there's an additional download of ${remainingDownloadMB} MB.`;
+                  dialog.componentInstance.question = buildAdditionalIndexDownloadQuestion(
+                    doccount,
+                    additionalMessages,
+                    remainingDownloadMB
+                  );
                   dialog.afterClosed()
                     .subscribe(res => {
                       userHasAcceptedDownloadAllPartitions = res;


### PR DESCRIPTION
## Summary
- clarify the download confirmation so it explains the full index total and the extra download size
- factor the copy into a small helper for straightforward reuse and testing
- add a focused unit test that locks the wording for the prompt

## Verification
- npm run build ✅
- node src/build/gen-env.js && npm run test -- --watch=false --progress=false --browsers=FirefoxHeadless --include=src/app/xapian/searchservice.spec.ts ⚠️ compiles successfully, then fails to launch because FirefoxHeadless is not installed on this host

Closes #1763