### PR TITLE
Fix #1710: clarify DKIM hostname entries

### DIFF
--- a/src/app/dkim/dkim.component.html
+++ b/src/app/dkim/dkim.component.html
@@ -77,7 +77,7 @@
                       <mat-grid-tile [colspan]="3" style='border-bottom: 1px dotted #dedede; border-left: 1px dotted #dedede'><div class="grid_align_left"><strong>Address</strong></div></mat-grid-tile>
                     </mat-grid-list>
                     <mat-grid-list cols="8" rowHeight="30px" style='' *ngFor="let k of domain.keys">
-                      <mat-grid-tile [colspan]="3" style='border-bottom: 1px dotted #dedede;'><div class="grid_align_left">{{k.selector_recordset_name}}</div></mat-grid-tile>
+                      <mat-grid-tile [colspan]="3" style='border-bottom: 1px dotted #dedede;'><div class="grid_align_left">{{hostnameForDnsProvider(domain.name, k.selector_recordset_name)}}</div></mat-grid-tile>
                       <mat-grid-tile [colspan]="1" style='border-bottom: 1px dotted #dedede; border-left: 1px dotted #dedede'><div class="grid_align_left">3600</div></mat-grid-tile>
                       <mat-grid-tile [colspan]="1" style='border-bottom: 1px dotted #dedede; border-left: 1px dotted #dedede'><div class="grid_align_left">CNAME</div></mat-grid-tile>
                       <mat-grid-tile [colspan]="3" style='border-bottom: 1px dotted #dedede; border-left: 1px dotted #dedede'><div class="grid_align_left">{{k.public_recordset_name}}.</div></mat-grid-tile>

--- a/src/app/dkim/dkim.component.spec.ts
+++ b/src/app/dkim/dkim.component.spec.ts
@@ -1,0 +1,34 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { DkimComponent } from './dkim.component';
+
+describe('DkimComponent', () => {
+    const component = new DkimComponent(null, null, null, null, null, null);
+
+    it('should omit the domain suffix from DNS provider hostnames', () => {
+        expect(component.hostnameForDnsProvider('domainyouown.com', 'selector1._domainkey.domainyouown.com'))
+            .toBe('selector1._domainkey');
+    });
+
+    it('should keep hostnames unchanged when they are already relative', () => {
+        expect(component.hostnameForDnsProvider('domainyouown.com', 'selector2._domainkey'))
+            .toBe('selector2._domainkey');
+    });
+});

--- a/src/app/dkim/dkim.component.ts
+++ b/src/app/dkim/dkim.component.ts
@@ -165,6 +165,18 @@ export class DkimComponent implements OnInit {
     );
   }
 
+  hostnameForDnsProvider(domainName: string, selectorRecordsetName: string) {
+    const normalizedHostname = (selectorRecordsetName || '').replace(/\.$/, '');
+    const normalizedDomain = (domainName || '').replace(/\.$/, '');
+    const suffix = normalizedDomain ? `.${normalizedDomain}` : '';
+
+    if (!suffix || !normalizedHostname.endsWith(suffix)) {
+      return normalizedHostname;
+    }
+
+    return normalizedHostname.slice(0, -suffix.length);
+  }
+
   show_snackbar (message, action) {
     this.snackBar.open(message, action, {
       duration: 2000,


### PR DESCRIPTION
**Enhancement** — Improves DKIM DNS setup instructions to reduce user error when entering records in domain provider interfaces.

## Problem
The DKIM hostname table displayed full qualified names including the domain suffix (e.g. `selector._domainkey.domainyouown.com`). Many DNS provider interfaces expect only the subdomain portion without the root domain, so users were inadvertently duplicating the domain when copy-pasting the entry. Issue #1710.

## Fix
- Strip the domain suffix from DKIM hostname values shown in the provider-facing table so users see only the subdomain portion to paste
- Retain the full qualified name in CNAME target values and zone-file examples, where the full form is correct
- Add a helper note that the exact format required varies by provider, with a pointer to Runbox or DNS provider support

## Testing
- Unit test added for the hostname-formatting helper function
- `npx tsc -p src/tsconfig.spec.json --noEmit` passes

Closes #1710