### PR TITLE
Fix #1558: close blank draft when opening Drafts

### DIFF
--- a/e2e/cypress/integration/compose.ts
+++ b/e2e/cypress/integration/compose.ts
@@ -103,6 +103,30 @@ describe('Composing emails', () => {
         });
     });
 
+    it('clicking Drafts after Compose should close the blank draft', () => {
+        cy.intercept('/mail/download_xapian_index?ngsw-bypass=1&listallmessages=1&page=0&sinceid=0&sincechangeddate=0&pagesize=100&skipcontent=1&folder=Drafts&avoidcacheuniqueparam=*').as('listAllmessages');
+        cy.visit('/compose');
+        cy.wait('@listAllmessages', {'timeout':10000});
+        cy.get('#draftsButton .foldersidebarcount').invoke('text').then((draftCount) => {
+            const initialDraftCount = draftCount.trim();
+
+            cy.visit('/compose?new=true');
+            cy.wait('@listAllmessages', {'timeout':10000});
+
+            cy.get('button[mattooltip="Close draft"').should('exist');
+            cy.get('#draftsButton').click();
+
+            cy.location().should((loc) => {
+                expect(loc.pathname).to.eq('/compose');
+                expect(loc.search).to.eq('');
+            });
+            cy.get('button[mattooltip="Close draft"').should('not.exist');
+            cy.get('#draftsButton .foldersidebarcount').invoke('text').should((updatedDraftCount) => {
+                expect(updatedDraftCount.trim()).to.eq(initialDraftCount);
+            });
+        });
+    });
+
     it('closing a new reply should return to inbox', () => {
         cy.visit('/');
         cy.wait(1000);

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -549,6 +549,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
   }
 
   public drafts() {
+    this.draftDeskService.closeBlankComposingDraft();
     this.router.navigate(['/compose']);
     setTimeout(() => {
         if (this.mobileQuery.matches && this.sidemenu.opened) {

--- a/src/app/compose/draftdesk.service.spec.ts
+++ b/src/app/compose/draftdesk.service.spec.ts
@@ -404,4 +404,39 @@ Subject: Test subject <br />
         expect(draft.isUnsaved()).toBe(false);
         done();
     });
+
+    it('Blank draft: close compose-created draft with no user content', () => {
+        const draft = DraftFormModel.create(
+            -1,
+            Identity.fromObject({'email': 'to@runbox.com'}),
+            null,
+            ''
+        );
+
+        expect(draft.isBlankDraft()).toBe(true);
+    });
+
+    it('Blank draft: ignore default signature-only content', () => {
+        const identity = Identity.fromObject({
+            'email': 'to@runbox.com',
+            'signature': 'Kind regards,\nRunbox User'
+        });
+        const draft = DraftFormModel.create(-1, identity, null, '');
+
+        draft.msg_body = 'Kind regards,\nRunbox User\n\n';
+
+        expect(draft.isBlankDraft([identity])).toBe(true);
+    });
+
+    it('Blank draft: keep prefilled draft visible in drafts', () => {
+        const identity = Identity.fromObject({'email': 'to@runbox.com'});
+        const draft = DraftFormModel.create(
+            -1,
+            identity,
+            '"Test Runbox" <test@runbox.com>',
+            ''
+        );
+
+        expect(draft.isBlankDraft([identity])).toBe(false);
+    });
 });

--- a/src/app/compose/draftdesk.service.ts
+++ b/src/app/compose/draftdesk.service.ts
@@ -216,6 +216,69 @@ ${mailObj.sanitized_html}`;
         return false;
     }
 
+    private static normalizeText(content: string): string {
+        return (content ?? '')
+            .replace(/\u00a0/g, ' ')
+            .replace(/\s+/g, ' ')
+            .trim();
+    }
+
+    private static normalizeHtml(content: string): string {
+        if (!content) {
+            return '';
+        }
+        const html = content.replace(/<br\s*\/?>/gi, '\n');
+        const previewElm = document.createElement('div');
+        previewElm.innerHTML = html;
+        return DraftFormModel.normalizeText(previewElm.textContent || previewElm.innerText || '');
+    }
+
+    private static removeKnownSignature(content: string, useHTML: boolean, froms: Identity[]): string {
+        let normalizedContent = useHTML
+            ? DraftFormModel.normalizeHtml(content)
+            : DraftFormModel.normalizeText(content);
+
+        for (const identity of froms || []) {
+            if (!identity.signature) {
+                continue;
+            }
+
+            const normalizedSignature = identity.is_signature_html
+                ? DraftFormModel.normalizeHtml(identity.signature)
+                : DraftFormModel.normalizeText(identity.signature);
+
+            if (!normalizedSignature) {
+                continue;
+            }
+
+            if (normalizedContent === normalizedSignature) {
+                return '';
+            }
+
+            if (normalizedContent.startsWith(normalizedSignature + ' ')) {
+                normalizedContent = normalizedContent.slice(normalizedSignature.length).trim();
+            }
+        }
+
+        return normalizedContent;
+    }
+
+    public isBlankDraft(froms: Identity[] = []): boolean {
+        return this.isUnsaved()
+            && this.to.length === 0
+            && this.cc.length === 0
+            && this.bcc.length === 0
+            && !DraftFormModel.normalizeText(this.subject)
+            && !this.attachments?.length
+            && !this.reply_to
+            && !this.in_reply_to
+            && !this.reply_to_id
+            && !this.tags
+            && !this.tid
+            && !DraftFormModel.removeKnownSignature(this.msg_body, false, froms)
+            && !DraftFormModel.removeKnownSignature(this.html, true, froms);
+    }
+
     private setFromForResponse(mailObj, froms: Identity[]): void {
         if (froms.length > 0) {
             this.from = (
@@ -310,6 +373,18 @@ export class DraftDeskService {
         let models = this.draftModels.value;
         models = models.filter(dm => dm.mid !== messageId);
         this.draftModels.next(models);
+    }
+
+    public closeBlankComposingDraft(): boolean {
+        if (!this.composingNewDraft?.isBlankDraft(this.fromsSubject.value)) {
+            return false;
+        }
+
+        this.composingNewDraft = null;
+        this.isEditing = -1;
+        this.shouldReturnToPreviousPage = false;
+        this.draftModels.next(this.draftModels.value.filter((draft) => draft.mid >= 0));
+        return true;
     }
 
     public async newTemplateDraft(


### PR DESCRIPTION
**Enhancement** — Closes blank compose drafts automatically when navigating to the Drafts list.

## Problem
When a user clicked Compose and then opened the Drafts folder without typing anything, the blank compose pane remained open in the drafts list instead of being dismissed. This made the drafts view cluttered and inconsistent. Issue #1558.

## Fix
- Detect and close blank unsaved drafts before navigating to the Drafts list
- Treat default signature-only content as blank so untouched drafts are dismissed
- Leave replies, forwards, and prefilled drafts unaffected — only truly empty drafts are closed

## Testing
- Unit tests added for blank-draft detection logic in `draftdesk.service.spec.ts`
- Cypress regression test added for the Compose → Drafts navigation flow
- `npx tsc -p src/tsconfig.spec.json --noEmit` passes

Closes #1558