### PR TITLE
fix(security): publish security.txt for researchers

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -19,6 +19,11 @@
             "assets": [
               "src/assets",
               {
+                "glob": "security.txt",
+                "input": "src/.well-known",
+                "output": "/.well-known/"
+              },
+              {
                 "glob": "xapianasm*",
                 "input": "node_modules/@runboxcom/runbox-searchindex/",
                 "output": "/"
@@ -128,6 +133,11 @@
             ],
             "assets": [
               "src/assets",
+              {
+                "glob": "security.txt",
+                "input": "src/.well-known",
+                "output": "/.well-known/"
+              },
               {
                 "glob": "xapianasm*",
                 "input": "node_modules/runbox-searchindex/",

--- a/policy-tests/check-securitytxt.js
+++ b/policy-tests/check-securitytxt.js
@@ -1,0 +1,50 @@
+const fs = require('fs');
+
+function fail(message) {
+    throw new Error(message);
+}
+
+function expect(condition, message) {
+    if (!condition) {
+        fail(message);
+    }
+}
+
+function readJson(filename) {
+    return JSON.parse(fs.readFileSync(filename, 'utf8'));
+}
+
+function hasSecurityTxtAsset(assets) {
+    return assets.some(asset => asset &&
+        asset.glob === 'security.txt' &&
+        asset.input === 'src/.well-known' &&
+        asset.output === '/.well-known/');
+}
+
+const angularConfig = readJson('angular.json');
+const buildAssets = angularConfig.projects.runbox7.architect.build.options.assets;
+const testAssets = angularConfig.projects.runbox7.architect.test.options.assets;
+
+expect(hasSecurityTxtAsset(buildAssets),
+    'runbox7 build assets must publish src/.well-known/security.txt to /.well-known/');
+expect(hasSecurityTxtAsset(testAssets),
+    'runbox7 test assets must publish src/.well-known/security.txt to /.well-known/');
+
+const securityTxt = fs.readFileSync('src/.well-known/security.txt', 'utf8').trim().split('\n');
+const requiredLines = [
+    'Contact: https://support.runbox.com/',
+    'Canonical: https://runbox.com/.well-known/security.txt',
+    'Policy: https://blog.runbox.com/2019/02/runbox-7-feature-and-bug-bounty-program/',
+    'Preferred-Languages: en',
+];
+
+for (const line of requiredLines) {
+    expect(securityTxt.includes(line), `security.txt is missing "${line}"`);
+}
+
+const expiresLine = securityTxt.find(line => line.startsWith('Expires: '));
+expect(Boolean(expiresLine), 'security.txt must contain an Expires field');
+expect(!Number.isNaN(Date.parse(expiresLine.slice('Expires: '.length))),
+    'security.txt Expires field must contain a valid ISO-8601 timestamp');
+
+console.log('security.txt policy checks passed');

--- a/policy-tests/run-all.js
+++ b/policy-tests/run-all.js
@@ -1,2 +1,3 @@
 require('./check-licenses.js');
 require('./check-commit-log.js');
+require('./check-securitytxt.js');

--- a/src/.well-known/security.txt
+++ b/src/.well-known/security.txt
@@ -1,0 +1,5 @@
+Contact: https://support.runbox.com/
+Canonical: https://runbox.com/.well-known/security.txt
+Policy: https://blog.runbox.com/2019/02/runbox-7-feature-and-bug-bounty-program/
+Preferred-Languages: en
+Expires: 2027-03-26T00:00:00.000Z


### PR DESCRIPTION
## Summary
- publish a security.txt file from /.well-known/security.txt
- add the Runbox support contact, canonical URL, policy link, language, and expiry
- add a policy test that verifies both the Angular asset mapping and the required file contents

## Validation
- node policy-tests/check-securitytxt.js
- npm run policy
- npm run build
- npm run ci-tests (fails in this environment because Karma is configured for FirefoxHeadless and no Firefox binary is installed)

Closes #149
