### PR TITLE
Fix #1762: advanced search updates without regular search focus

### DIFF
--- a/src/app/websocketsearch/websocketsearch.service.spec.ts
+++ b/src/app/websocketsearch/websocketsearch.service.spec.ts
@@ -1,0 +1,89 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { TestBed } from '@angular/core/testing';
+import { MatLegacySnackBarModule as MatSnackBarModule } from '@angular/material/legacy-snack-bar';
+import { WebSocketSearchService } from './websocketsearch.service';
+
+describe('WebSocketSearchService', () => {
+    let service: WebSocketSearchService;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [
+                MatSnackBarModule
+            ],
+            providers: [
+                WebSocketSearchService
+            ]
+        });
+
+        service = TestBed.inject(WebSocketSearchService);
+    });
+
+    it('should open a websocket automatically before searching', () => {
+        const websocket = {
+            readyState: WebSocket.OPEN,
+            send: jasmine.createSpy('send'),
+            close: jasmine.createSpy('close')
+        } as unknown as WebSocket;
+
+        spyOn(service, 'open').and.callFake(() => {
+            service.websocket = websocket;
+        });
+
+        service.search('subject:test');
+
+        expect(service.open).toHaveBeenCalled();
+        expect(service.searchInProgress).toBeTrue();
+
+        service.searchReadySubject.next(true);
+        service.searchReadySubject.complete();
+
+        expect(websocket.send).toHaveBeenCalledWith(JSON.stringify({
+            querystring: 'subject:test',
+            sortcol: 2,
+            reverse: 1,
+            offset: 0,
+            maxresults: 100,
+            collapsecol: -1
+        }));
+
+        service.searchresults.next([]);
+
+        expect(service.searchInProgress).toBeFalse();
+    });
+
+    it('should reset websocket state when closing', () => {
+        const websocket = {
+            readyState: WebSocket.OPEN,
+            send: jasmine.createSpy('send'),
+            close: jasmine.createSpy('close')
+        } as unknown as WebSocket;
+
+        service.websocket = websocket;
+        service.searchInProgress = true;
+
+        service.close();
+
+        expect(websocket.close).toHaveBeenCalled();
+        expect(service.websocket).toBeNull();
+        expect(service.searchInProgress).toBeFalse();
+    });
+});

--- a/src/app/websocketsearch/websocketsearch.service.ts
+++ b/src/app/websocketsearch/websocketsearch.service.ts
@@ -109,6 +109,10 @@ export class WebSocketSearchService {
             return;
         }
 
+        if (!this.websocket || this.websocket.readyState > WebSocket.OPEN) {
+            this.open();
+        }
+
         this.searchInProgress = true;
 
         this.searchReadySubject
@@ -137,7 +141,10 @@ export class WebSocketSearchService {
     }
 
     close() {
-        this.websocket.close();
+        if (this.websocket) {
+            this.websocket.close();
+            this.websocket = null;
+        }
         this.searchReadySubject = new AsyncSubject();
         this.searchInProgress = false;
     }


### PR DESCRIPTION
**Bug fix** — Advanced search does not execute unless the cursor has been placed in the regular search input at least once.

## Problem
With index synchronisation disabled, submitting an advanced search query would hang indefinitely unless the user had previously clicked into the regular search box. The WebSocket search connection was only opened on regular-search focus, so advanced-search requests silently waited for a socket that never came. Issue #1762.

## Fix
- Open the WebSocket search connection automatically when a search is requested and no active socket exists
- Ensure advanced-search updates trigger the connection regardless of whether the regular search input has ever been focused
- Reset the socket correctly so subsequent searches continue to work

## Testing
- Regression tests added for auto-open and WebSocket reset behaviour in `websocketsearch.service.spec.ts`
- `npx tsc -p src/tsconfig.spec.json --noEmit` passes
- `npm run lint` passes (existing repo-wide warnings only)
- `npm run build` succeeds

Closes #1762