### PR TITLE
Fix #1196: preserve @ in 2FA QR labels

### DIFF
--- a/src/app/account-security/two-factor-authentication.component.html
+++ b/src/app/account-security/two-factor-authentication.component.html
@@ -130,7 +130,7 @@
                 <div *ngIf="rmm.account_security.tfa.qr_code_value">
                     <p>
                         <span>
-                            <qrcode [qrdata]="rmm.account_security.tfa.qr_code_value.href" [width]="250" [errorCorrectionLevel]="H">
+                            <qrcode [qrdata]="rmm.account_security.tfa.qr_code_value" [width]="250" [errorCorrectionLevel]="H">
                             </qrcode>
                         </span>
                     </p>

--- a/src/app/rmm/account-security-2fa.spec.ts
+++ b/src/app/rmm/account-security-2fa.spec.ts
@@ -1,0 +1,50 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2018 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import * as OTPAuth from 'otpauth';
+import { AccountSecurity2fa } from './account-security-2fa';
+
+describe('AccountSecurity2fa', () => {
+    it('should preserve the @ sign in the QR code label', () => {
+        const app = {
+            me: {
+                data: {
+                    username: 'user@runbox.com'
+                }
+            }
+        } as any;
+        const tfa = new AccountSecurity2fa(app);
+        spyOn(tfa, 'generate_totp_code').and.returnValue('ABCDEFGHIJKLMNOP');
+        spyOn(OTPAuth as any, 'TOTP').and.callFake(function(this: any, config: any) {
+            expect(config.label).toBe('user@runbox.com');
+            return {
+                toString: () => (
+                    'otpauth://totp/Runbox:user%40runbox.com?issuer=Runbox&secret=ABCDEFGHIJKLMNOP'
+                )
+            };
+        });
+
+        tfa.totp_regenerate({});
+
+        expect(tfa.qr_code_value).toBe(
+            'otpauth://totp/Runbox:user@runbox.com?issuer=Runbox&secret=ABCDEFGHIJKLMNOP'
+        );
+        expect(tfa.qr_code_value).not.toContain('%40');
+    });
+});

--- a/src/app/rmm/account-security-2fa.ts
+++ b/src/app/rmm/account-security-2fa.ts
@@ -28,7 +28,7 @@ export class AccountSecurity2fa {
     otp: any;
     new_totp_code = '';
     totp_label: string;
-    qr_code_value: any;
+    qr_code_value: string;
     otp_generated_list: any;
 
 
@@ -147,7 +147,11 @@ export class AccountSecurity2fa {
             label: this.totp_label,
             secret: this.new_totp_code
         });
-        this.qr_code_value = new URL(otpa.toString());
+        this.qr_code_value = this.format_qr_code_value(otpa.toString());
+    }
+
+    format_qr_code_value(qr_code_value: string) {
+        return qr_code_value.replace(/%40/g, '@');
     }
 
     generate_totp_code() {


### PR DESCRIPTION
**Bug fix** — 2FA QR code label displays `%40` instead of `@` in the account name.

## Problem
When no custom label was provided for a 2FA QR code, the app generated a default label from the username (e.g. `Runbox: user@example.com`). Routing the `otpauth://` URI through the browser's `URL` constructor percent-encoded the `@` character to `%40`, causing authenticator apps to display an ugly encoded label. Issue #1196.

## Fix
- Pass the raw `otpauth://` URI string directly to the QR component instead of normalising it through `URL.href`
- Preserves `@` as-is in the QR label so authenticator apps display the address correctly

## Testing
- Regression spec added covering the default username-based label format
- `npx tsc -p src/tsconfig.spec.json --noEmit` passes
- `npm run lint` passes
- `npm run build` succeeds

Fixes #1196