### PR TITLE
fix(mailviewer): route plain text mailto links to compose (#939)

### DIFF
--- a/src/app/mailviewer/singlemailviewer.component.spec.ts
+++ b/src/app/mailviewer/singlemailviewer.component.spec.ts
@@ -231,6 +231,22 @@ describe('SingleMailViewerComponent', () => {
       expect(component.mailObj.attachments[1].downloadURL.indexOf('blob:')).toBe(0);
     }));
 
+  it('should rewrite plain text mailto links to in-app compose links', () => {
+      const preparedHtml = component['preparePlainTextHtml'](
+        'Contact <a href="mailto:user@example.com?subject=Test" target="_blank">user@example.com</a>'
+      );
+
+      const htmlDocument = document.implementation.createHTMLDocument('');
+      htmlDocument.body.innerHTML = preparedHtml;
+      const anchor = htmlDocument.body.querySelector('a');
+
+      expect(anchor).not.toBeNull();
+      expect(anchor.getAttribute('data-href')).toBe('mailto:user@example.com?subject=Test');
+      expect(anchor.getAttribute('href')).toBe('#');
+      expect(anchor.getAttribute('target')).toBeNull();
+      expect(anchor.getAttribute('rel')).toBe('noopener');
+    });
+
   describe('mailto: link interceptor', () => {
     let messageContentsElement: HTMLElement;
     let mailtoLink: HTMLAnchorElement;
@@ -338,7 +354,8 @@ describe('SingleMailViewerComponent', () => {
     it('should extract email address from mailto: link correctly', fakeAsync(() => {
       // Create a mailto: link with query parameters
       mailtoLink = document.createElement('a');
-      mailtoLink.href = 'mailto:user@example.com?subject=Test&body=Hello';
+      mailtoLink.href = '#';
+      mailtoLink.setAttribute('data-href', 'mailto:user@example.com?subject=Test&body=Hello');
       mailtoLink.textContent = 'Email me';
       messageContentsElement.appendChild(mailtoLink);
 

--- a/src/app/mailviewer/singlemailviewer.component.ts
+++ b/src/app/mailviewer/singlemailviewer.component.ts
@@ -203,10 +203,10 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
       if (
         target &&
         target.tagName === 'A' &&
-        target.getAttribute('href')?.toLowerCase().startsWith('mailto:')
+        this.getMailtoHref(target)?.toLowerCase().startsWith('mailto:')
       ) {
         event.preventDefault();
-        const href = target.getAttribute('href');
+        const href = this.getMailtoHref(target);
         if (href) {
           const matches = /^mailto:([^?]+)/i.exec(href);
           const emailTo = matches ? matches[1] : '';
@@ -218,6 +218,10 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
     this.lastMailtoInterceptorNode = messageContents;
   }
   private _mailtoInterceptorListener: any;
+
+  private getMailtoHref(target: HTMLElement): string | null {
+    return target.getAttribute('data-href') || target.getAttribute('href');
+  }
 
 
   /**
@@ -621,8 +625,23 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
     text = html.join('');
 
    //  res.text = text;
-    res.text = this.domSanitizer.bypassSecurityTrustHtml(DOMPurify.sanitize(res.text.textAsHtml)); // res.text.textAsHtml;
+    res.text = this.domSanitizer.bypassSecurityTrustHtml(this.preparePlainTextHtml(res.text.textAsHtml));
     return res;
+  }
+
+  private preparePlainTextHtml(textAsHtml: string): string {
+    const sanitizedText = DOMPurify.sanitize(textAsHtml || '');
+    const htmlDocument = document.implementation.createHTMLDocument('');
+    htmlDocument.body.innerHTML = sanitizedText;
+
+    htmlDocument.body.querySelectorAll('a[href^="mailto:"], a[href^="MAILTO:"]').forEach((anchor: HTMLAnchorElement) => {
+      anchor.setAttribute('data-href', anchor.getAttribute('href'));
+      anchor.setAttribute('href', '#');
+      anchor.removeAttribute('target');
+      anchor.setAttribute('rel', 'noopener');
+    });
+
+    return htmlDocument.body.innerHTML;
   }
 
   expandAttachmentData(attachments: any[], html: string): string {


### PR DESCRIPTION
## Summary
- rewrite plain text message mailto anchors to store the original target in a data attribute
- stop the browser from opening an external mail client for those links
- reuse the existing mailto interceptor to route clicks into Runbox compose

## Testing
- ./node_modules/.bin/tsc -p src/tsconfig.spec.json --noEmit
- ./node_modules/.bin/tsc -p src/tsconfig.app.json --noEmit
- npm test -- --watch=false --browsers=FirefoxHeadless --include src/app/mailviewer/singlemailviewer.component.spec.ts *(build completed, but no Firefox binary is installed in this environment)*

Closes #939