### PR TITLE
Fix #1753: show embedded images without external image toggle

### DIFF
--- a/src/app/mailviewer/singlemailviewer.component.spec.ts
+++ b/src/app/mailviewer/singlemailviewer.component.spec.ts
@@ -231,6 +231,62 @@ describe('SingleMailViewerComponent', () => {
       expect(component.mailObj.attachments[1].downloadURL.indexOf('blob:')).toBe(0);
     }));
 
+  it('keeps inline images visible without enabling external images', () => {
+    component.messageId = 77;
+
+    const processed = component['processMessageContents'](Object.assign(new MessageContents(), {
+      headers: {
+        from: {
+          value: [{ address: 'test@runbox.com', name: 'Testy' }]
+        },
+        date: new Date(2016, 0, 1).toJSON(),
+        subject: 'Inline image'
+      },
+      text: {
+        text: 'Inline image',
+        html: '<p><img src="cid:inline-logo"></p>',
+        textAsHtml: '<p>Inline image</p>'
+      },
+      sanitized_html: '<p><img src="cid:inline-logo"></p>',
+      sanitized_html_without_images: '<p>No images</p>',
+      attachments: [{
+        cid: 'inline-logo',
+        filename: 'inline-logo.png',
+        contentType: 'image/png'
+      }]
+    }));
+
+    expect(processed.sanitized_html_without_images).toEqual(processed.sanitized_html);
+  });
+
+  it('still hides truly external images by default', () => {
+    component.messageId = 78;
+
+    const processed = component['processMessageContents'](Object.assign(new MessageContents(), {
+      headers: {
+        from: {
+          value: [{ address: 'test@runbox.com', name: 'Testy' }]
+        },
+        date: new Date(2016, 0, 1).toJSON(),
+        subject: 'External image'
+      },
+      text: {
+        text: 'External image',
+        html: '<p><img src="cid:inline-logo"><img src="https://example.com/remote.png"></p>',
+        textAsHtml: '<p>External image</p>'
+      },
+      sanitized_html: '<p><img src="cid:inline-logo"><img src="https://example.com/remote.png"></p>',
+      sanitized_html_without_images: '<p>No images</p>',
+      attachments: [{
+        cid: 'inline-logo',
+        filename: 'inline-logo.png',
+        contentType: 'image/png'
+      }]
+    }));
+
+    expect(processed.sanitized_html_without_images).toBe('<p>No images</p>');
+  });
+
   describe('mailto: link interceptor', () => {
     let messageContentsElement: HTMLElement;
     let mailtoLink: HTMLAnchorElement;

--- a/src/app/mailviewer/singlemailviewer.component.ts
+++ b/src/app/mailviewer/singlemailviewer.component.ts
@@ -568,6 +568,10 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
 
     res.sanitized_html_without_images = this.expandAttachmentData(res.attachments, res.sanitized_html_without_images);
 
+    if (res.text.html && !this.containsExternalImages(res.sanitized_html, res.attachments)) {
+      res.sanitized_html_without_images = res.sanitized_html;
+    }
+
     // Remove style tag otherwise angular sanitazion will display style tag content as text
 
     if (res.text.html) {
@@ -661,6 +665,45 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
       });
     }
     return html;
+  }
+
+  private containsExternalImages(html: string, attachments: any[] = []): boolean {
+    if (!html) {
+      return false;
+    }
+
+    const attachmentUrls = new Set(
+      (attachments || [])
+        .filter((att) => att?.contentType && att.contentType.indexOf('image/') === 0 && att.downloadURL)
+        .map((att) => att.downloadURL)
+    );
+    const documentFragment = new DOMParser().parseFromString(html, 'text/html');
+    const images = Array.from(documentFragment.querySelectorAll('img'));
+
+    return images.some((image: HTMLImageElement) => {
+      const src = image.getAttribute('src') || '';
+      if (!src) {
+        return false;
+      }
+      if (src.startsWith('cid:') || src.startsWith('data:') || src.startsWith('blob:')) {
+        return false;
+      }
+      if (attachmentUrls.has(src)) {
+        return false;
+      }
+      if (src.startsWith('/rest/v1/email/')) {
+        return false;
+      }
+      try {
+        const url = new URL(src, window.location.origin);
+        if (url.origin === window.location.origin && url.pathname.startsWith('/rest/v1/email/')) {
+          return false;
+        }
+      } catch {
+        return true;
+      }
+      return true;
+    });
   }
 
   saveShowHTMLDecision() {


### PR DESCRIPTION
**Bug fix** — Embedded (CID-backed) images are hidden unless "Show External Images" is enabled, even though they are not remote resources.

## Problem
Turning on HTML view was not sufficient to display inline images attached via Content-ID (CID). Users also had to enable "Show External Images" — a toggle intended for remotely-hosted images — before embedded images would appear. This was incorrect behaviour: CID images are part of the message and carry no privacy risk. Issue #1753.

## Fix
- Show CID-backed inline images as soon as HTML view is enabled when the message contains no truly external image sources
- Continue blocking remote images by default when external image URLs are present, preserving the existing privacy protection

## Testing
- Regression tests added for inline-only and mixed inline/external image messages in `singlemailviewer.component.spec.ts`
- `npx tsc -p src/tsconfig.spec.json --noEmit` passes
- `npx tsc -p src/tsconfig.app.json --noEmit` passes

Fixes #1753
