### PR TITLE
fix(compose): preserve reply and forward subjects

### DIFF
--- a/e2e/cypress/integration/mailviewer.ts
+++ b/e2e/cypress/integration/mailviewer.ts
@@ -55,7 +55,8 @@ describe('Interacting with mailviewer', () => {
             expect(loc.pathname).to.eq('/compose');
         });
         cy.wait(500);
-        cy.get('mat-card-actions div').should('contain', "Re: No 'To', just 'CC'");
+        cy.get('mat-card-actions div').should('contain', "No 'To', just 'CC'");
+        cy.get('mat-card-actions div').should('not.contain', 'Re:');
     });
 
     it('can forward an email with no "To"', () => {
@@ -70,7 +71,8 @@ describe('Interacting with mailviewer', () => {
             expect(loc.pathname).to.eq('/compose');
         });
         cy.wait(500);
-        cy.get('mat-card-actions div').should('contain', "Fwd: No 'To', just 'CC'");
+        cy.get('mat-card-actions div').should('contain', "No 'To', just 'CC'");
+        cy.get('mat-card-actions div').should('not.contain', 'Fwd:');
     });
 
     it('can reply to an email with no "To" or "Subject"', () => {
@@ -85,7 +87,7 @@ describe('Interacting with mailviewer', () => {
             expect(loc.pathname).to.eq('/compose');
         });
         cy.wait(500);
-        cy.get('mat-card-actions div').should('contain', "Re: ");
+        cy.get('mat-card-actions div').should('not.contain', 'Re:');
     });
 
     it('can forward an email with no "To" or "Subject"', () => {
@@ -100,7 +102,7 @@ describe('Interacting with mailviewer', () => {
             expect(loc.pathname).to.eq('/compose');
         });
         cy.wait(500);
-        cy.get('mat-card-actions div').should('contain', "Fwd: ");
+        cy.get('mat-card-actions div').should('not.contain', 'Fwd:');
     });
 
     it('Vertical to horizontal mode exposes full height button', () => {

--- a/src/app/compose/draftdesk.service.spec.ts
+++ b/src/app/compose/draftdesk.service.spec.ts
@@ -58,7 +58,7 @@ describe('DraftDesk', () => {
         [ Identity.fromObject({'email':'to@runbox.com'})],
         false);
 
-        expect(draft.subject).toBe('Fwd: Test subject');
+        expect(draft.subject).toBe('Test subject');
         expect(draft.from).toBe('to@runbox.com');
         // expect(draft.to[0].nameAndAddress).toBe('"From" <from@runbox.com>');
         expect(draft.msg_body).toBe(
@@ -97,7 +97,7 @@ blabla\nabcde`);
         [ Identity.fromObject({'email':'to@runbox.com'})],
         true);
 
-        expect(draft.subject).toBe('Fwd: Test subject');
+        expect(draft.subject).toBe('Test subject');
         expect(draft.from).toBe('to@runbox.com');
         // expect(draft.to[0].nameAndAddress).toBe('"From" <from@runbox.com>');
         expect(draft.html).toBe(
@@ -150,7 +150,7 @@ Subject: Test subject <br />
         [ Identity.fromObject({'email':'to@runbox.com'})],
         false, false);
 
-        expect(draft.subject).toBe('Re: Test subject');
+        expect(draft.subject).toBe('Test subject');
         expect(draft.from).toBe('to@runbox.com');
         expect(draft.to[0].nameAndAddress).toBe('"Reply-To" <reply-to@runbox.com>');
         expect(draft.msg_body).toBe(`\n\nOn ${formatDate(mailDate)}, "From" <from@runbox.com> wrote:\n> blabla\n> abcde`);
@@ -180,7 +180,7 @@ Subject: Test subject <br />
         [ Identity.fromObject({'email':'to@runbox.com'})],
         false, false);
 
-        expect(draft.subject).toBe('Re: Test subject');
+        expect(draft.subject).toBe('Test subject');
         expect(draft.from).toBe('to@runbox.com');
         expect(draft.to[0].nameAndAddress).toBe('"From" <from@runbox.com>');
         expect(draft.msg_body).toBe(`\n\nOn ${formatDate(mailDate)}, "From" <from@runbox.com> wrote:\n> blabla\n> abcde`);
@@ -217,7 +217,7 @@ Subject: Test subject <br />
         [ Identity.fromObject({'email':'to@runbox.com'})],
         false, false);
 
-        expect(draft.subject).toBe('Re: Test subject');
+        expect(draft.subject).toBe('Test subject');
         expect(draft.from).toBe('to@runbox.com');
         expect(draft.to[0].nameAndAddress).toBe('"Reply-To" <reply-to@runbox.com>');
         expect(draft.msg_body).toBe(`\n\nOn ${formatDate(mailDate)}, "From" <from@runbox.com> wrote:\n> blabla\n> abcde`);
@@ -258,7 +258,7 @@ Subject: Test subject <br />
         [ Identity.fromObject({'email':'to@runbox.com'})],
         true, false);
 
-        expect(draft.subject).toBe('Re: Test subject');
+        expect(draft.subject).toBe('Test subject');
         expect(draft.from).toBe('to@runbox.com');
         expect(draft.to[0].nameAndAddress).toBe('"Reply-To" <reply-to@runbox.com>');
         expect(draft.to[1].nameAndAddress).toBe('"To-Extra" <to-extra@runbox.com>');
@@ -289,7 +289,7 @@ Subject: Test subject <br />
         [ Identity.fromObject({'email':'to@runbox.com'})],
         true, false);
 
-        expect(draft.subject).toBe('Re: Test subject');
+        expect(draft.subject).toBe('Test subject');
         expect(draft.from).toBe('to@runbox.com');
         expect(draft.to[0].nameAndAddress).toBe('"From" <from@runbox.com>');
         expect(draft.msg_body).toBe(`\n\nOn ${formatDate(mailDate)}, "From" <from@runbox.com> wrote:\n> blabla\n> abcde`);
@@ -317,7 +317,7 @@ Subject: Test subject <br />
         [ Identity.fromObject({'email':'to@runbox.com'}) ],
         true, false);
 
-        expect(draft.subject).toBe('Re: Test subject');
+        expect(draft.subject).toBe('Test subject');
         expect(draft.from).toBe('to@runbox.com');
         expect(draft.to[0].nameAndAddress).toBe('"From" <from@runbox.com>');
         expect(draft.msg_body).toBe(`\n\nOn ${formatDate(mailDate)}, "From" <from@runbox.com> wrote:\n> blabla\n> abcde`);
@@ -365,7 +365,7 @@ Subject: Test subject <br />
         [ Identity.fromObject({'email':'from@runbox.com'}) ],
         false, false);
 
-        expect(replydraft.subject).toBe('Re: Test subject');
+        expect(replydraft.subject).toBe('Test subject');
         expect(replydraft.from).toBe('from@runbox.com');
         expect(replydraft.to[0].nameAndAddress).toBe('to@runbox.com');
         expect(replydraft.msg_body).toBe(`\n\nOn ${formatDate(replyDate)}, to@runbox.com wrote:\n` +
@@ -374,6 +374,52 @@ Subject: Test subject <br />
           `> On ${formatDate(mailDate)}, from@runbox.com wrote:\n` +
                                          '>> blabla\n>> abcde');
         expect(replydraft.isUnsaved()).toBe(true);
+        done();
+    });
+
+    it('Reply: preserve existing reply subject prefix', (done) => {
+        const draft = DraftFormModel.reply({
+            headers: {
+                'message-id': 'themessageid1093re',
+            },
+            from: [
+                {address: 'from@runbox.com', name: 'From'}
+            ],
+            to: [
+                {address: 'to@runbox.com', name: 'To'}
+            ],
+            date: mailDate,
+            subject: 'Re: Existing reply subject',
+            rawtext: 'blabla\nabcde'
+        },
+        [ Identity.fromObject({'email':'to@runbox.com'}) ],
+        false, false);
+
+        expect(draft.subject).toBe('Re: Existing reply subject');
+        done();
+    });
+
+    it('Forward: preserve existing forward subject prefix', (done) => {
+        const draft = DraftFormModel.forward({
+            headers: {
+                'message-id': 'themessageid1093fwd',
+            },
+            from: [
+                {address: 'from@runbox.com', name: 'From'}
+            ],
+            to: [
+                {address: 'to@runbox.com', name: 'To'}
+            ],
+            attachments: [],
+            date: mailDate,
+            subject: 'Fwd: Existing forward subject',
+            rawtext: 'blabla\nabcde',
+            sanitized_html: '<p>blabla</p><p>abcde</p>'
+        },
+        [ Identity.fromObject({'email':'to@runbox.com'}) ],
+        false);
+
+        expect(draft.subject).toBe('Fwd: Existing forward subject');
         done();
     });
 

--- a/src/app/compose/draftdesk.service.ts
+++ b/src/app/compose/draftdesk.service.ts
@@ -21,7 +21,6 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
 import { FolderListEntry } from '../common/folderlistentry';
-import { MessageInfo } from '../common/messageinfo';
 import { MailAddressInfo } from '../common/mailaddressinfo';
 import { MessageListService } from '../rmmapi/messagelist.service';
 import { MessageTableRowTool} from '../messagetable/messagetablerow';
@@ -127,7 +126,7 @@ export class DraftFormModel {
             }
         }
         ret.setFromForResponse(mailObj, froms);
-        ret.setSubjectForResponse(mailObj, 'Re: ');
+        ret.setSubjectForResponse(mailObj);
 
         const localTZ = moment.tz.guess();
         const replyHeaderHTML = 'On '
@@ -185,7 +184,7 @@ ${fwdSubjectStr} <br />`
 <span>To: <span>` + fwdTo.join('</span><span>') + '</span></span> <br />' : '')
             + (fwdCC.length > 0 ? `
 <span>CC: <span>` + fwdCC.join('</span><span>') + '</span></span> <br />' : '');
-        ret.setSubjectForResponse(mailObj, 'Fwd: ');
+        ret.setSubjectForResponse(mailObj);
         if (!useHTML) {
             const fwdHeaderText = fwdHeaderHTML
                 .replaceAll(' <br />', '')
@@ -228,8 +227,8 @@ ${mailObj.sanitized_html}`;
         }
     }
 
-    private setSubjectForResponse(mailObj, prefix): void {
-        this.subject = prefix + MessageInfo.getSubjectWithoutAbbreviation(mailObj.subject);
+    private setSubjectForResponse(mailObj): void {
+        this.subject = mailObj.subject || '';
     }
 }
 


### PR DESCRIPTION
## Summary
- preserve the original message subject when creating reply and forward drafts
- update compose unit coverage for plain, nested, and already-prefixed subjects
- update mailviewer Cypress expectations so compose no longer requires injected Re:/Fwd: prefixes

## Verification
- `npx ng test --watch=false --browsers=FirefoxHeadless --include src/app/compose/draftdesk.service.spec.ts` *(blocked locally: FirefoxHeadless binary is not installed in this environment)*
- `npx eslint src/app/compose/draftdesk.service.ts src/app/compose/draftdesk.service.spec.ts`
- `npm run build`

## Issue
Closes #1093