### PR TITLE
Fix #1769: correct help center forum link

### DIFF
--- a/src/app/help/help.component.html
+++ b/src/app/help/help.component.html
@@ -62,7 +62,7 @@
 				</mat-card>
 
 				<mat-card class="settingsItem">
-					<a href="https://forum.runbox.com/" target="forum">
+					<a href="https://community.runbox.com/" target="forum">
 						<h3>
 							<mat-icon svgIcon="forum"></mat-icon> <strong>Forum</strong>
 						</h3>

--- a/src/app/help/help.component.spec.ts
+++ b/src/app/help/help.component.spec.ts
@@ -17,6 +17,7 @@
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
 
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { HelpComponent } from './help.component';
@@ -27,7 +28,8 @@ describe('HelpComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ HelpComponent ]
+      declarations: [ HelpComponent ],
+      schemas: [NO_ERRORS_SCHEMA]
     })
     .compileComponents();
   });
@@ -40,5 +42,11 @@ describe('HelpComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should link the forum card to the Runbox community', () => {
+    const forumLink = fixture.nativeElement.querySelector('a[target="forum"]');
+
+    expect(forumLink.getAttribute('href')).toBe('https://community.runbox.com/');
   });
 });


### PR DESCRIPTION
## Summary
- update the Help Center forum card to use the Runbox community URL
- add a regression spec that asserts the forum card still points at the community

## Verification
- `./node_modules/.bin/tsc -p src/tsconfig.spec.json --noEmit`
- `./node_modules/.bin/eslint src/app/help/help.component.ts src/app/help/help.component.html src/app/help/help.component.spec.ts` *(reports the repo's existing warning for the empty constructor in `help.component.ts`)*
- `npm test -- --watch=false --browsers=FirefoxHeadless --include src/app/help/help.component.spec.ts` *(blocked: `karma-firefox-launcher` could not find a local Firefox binary and requested `FIREFOX_BIN`)*
- `./node_modules/.bin/ng build --configuration production --base-href=/app/ runbox7`
