### PR TITLE
Fix #1551: show progress while selecting all rows

### DIFF
--- a/src/app/canvastable/canvastable.spec.ts
+++ b/src/app/canvastable/canvastable.spec.ts
@@ -17,7 +17,7 @@
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
 
-import { TestBed } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { CanvasTableModule, CanvasTableContainerComponent } from './canvastable';
 import { MessageList } from '../common/messagelist';
 
@@ -73,4 +73,54 @@ describe('canvastable', () => {
         expect(fixture.componentInstance.canvastable.floatingTooltip).toBeTruthy();
         expect(fixture.componentInstance.canvastable.columnOverlay).toBeTruthy();
     });
+
+    it('should show progress while selecting all rows in batches', fakeAsync(() => {
+        const fixture = TestBed.createComponent(CanvasTableContainerComponent);
+        const rows = new MessageList(Array.from({ length: 600 }, (_, index) => ({
+            id: index + 1,
+            seenFlag: false,
+            from: [],
+            to: [],
+            subject: `Subject ${index + 1}`,
+            plaintext: '',
+            size: 0,
+            attachment: false,
+            answeredFlag: false,
+            flaggedFlag: false,
+            messageDate: new Date()
+        })));
+
+        fixture.componentInstance.canvastableselectlistener = {
+            rowSelected: (rowIndex: number, colIndex: number, multiSelect?: boolean): void => {
+                rows.rowSelected(rowIndex, colIndex, multiSelect);
+            },
+            saveColumnWidthsPreference: (): void => undefined
+        };
+        fixture.componentInstance.canvastable.rows = rows;
+
+        fixture.componentInstance.canvastable.selectAllRows();
+        fixture.detectChanges();
+
+        expect(fixture.componentInstance.canvastable.bulkSelectionInProgress).toBeTrue();
+        expect(fixture.componentInstance.canvastable.bulkSelectionMessage).toContain('Selecting 0 of 600 messages');
+
+        tick();
+        fixture.detectChanges();
+
+        expect(fixture.componentInstance.canvastable.bulkSelectionInProgress).toBeTrue();
+        expect(fixture.componentInstance.canvastable.bulkSelectionMessage).toContain('Selecting 250 of 600 messages');
+
+        tick();
+        fixture.detectChanges();
+
+        expect(fixture.componentInstance.canvastable.bulkSelectionInProgress).toBeTrue();
+        expect(fixture.componentInstance.canvastable.bulkSelectionMessage).toContain('Selecting 500 of 600 messages');
+
+        tick();
+        fixture.detectChanges();
+
+        expect(fixture.componentInstance.canvastable.bulkSelectionInProgress).toBeFalse();
+        expect(fixture.componentInstance.canvastable.bulkSelectionMessage).toBe('');
+        expect(rows.selectedMessageIds().length).toBe(600);
+    }));
 });

--- a/src/app/canvastable/canvastable.ts
+++ b/src/app/canvastable/canvastable.ts
@@ -84,6 +84,7 @@ export namespace CanvasTable {
 })
 export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
   static incrementalId = 1;
+  private static readonly selectAllBatchSize = 250;
   public elementId: string;
   private _topindex = 0.0;
   public get topindex(): number { return this._topindex; }
@@ -212,6 +213,8 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
   public scrollLimitHit: BehaviorSubject<number> = new BehaviorSubject(0);
 
   public floatingTooltip: FloatingTooltip;
+  public bulkSelectionInProgress = false;
+  public bulkSelectionMessage = '';
 
   @Input() selectListener: CanvasTableSelectListener;
   @Output() touchscroll = new EventEmitter();
@@ -723,6 +726,10 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
   }
 
   public selectRows() {
+    if (this.bulkSelectionInProgress) {
+      return;
+    }
+
     if (this.selectWhichRows === CanvasTable.RowSelect.Visible) {
       this.selectAllVisibleRows();
     } else {
@@ -732,14 +739,36 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
 
   public selectAllRows() {
     const allSelected = this.rows.allSelected();
+    const totalRows = this.rows.rowCount();
+    let processedRows = 0;
 
-    this.rows.rows.forEach((rowobj, rowIndex) =>
-      this.selectListener.rowSelected(
-        rowIndex,
-        0,
-        !allSelected
-      )
-    );
+    if (totalRows === 0) {
+      return;
+    }
+
+    this.updateBulkSelectionMessage(allSelected, processedRows, totalRows);
+
+    const selectNextBatch = () => {
+      const batchEnd = Math.min(processedRows + CanvasTableComponent.selectAllBatchSize, totalRows);
+
+      for (let rowIndex = processedRows; rowIndex < batchEnd; rowIndex++) {
+        this.selectListener.rowSelected(rowIndex, 0, !allSelected);
+      }
+
+      processedRows = batchEnd;
+
+      if (processedRows < totalRows) {
+        this.updateBulkSelectionMessage(allSelected, processedRows, totalRows);
+        setTimeout(selectNextBatch);
+        return;
+      }
+
+      this.bulkSelectionInProgress = false;
+      this.bulkSelectionMessage = '';
+      this.hasChanges = true;
+    };
+
+    setTimeout(selectNextBatch);
   }
 
   public selectAllVisibleRows() {
@@ -756,6 +785,13 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
         !visibleRowsAlreadySelected)
     );
 
+    this.hasChanges = true;
+  }
+
+  private updateBulkSelectionMessage(allSelected: boolean, processedRows: number, totalRows: number) {
+    this.bulkSelectionInProgress = true;
+    this.bulkSelectionMessage =
+      `${allSelected ? 'Clearing' : 'Selecting'} ${processedRows} of ${totalRows} messages...`;
     this.hasChanges = true;
   }
 

--- a/src/app/canvastable/canvastablecontainer.component.html
+++ b/src/app/canvastable/canvastablecontainer.component.html
@@ -82,6 +82,9 @@
         </div>
       </ng-container>
     </ng-container>
+    <div class="selection-progress" *ngIf="canvastable.bulkSelectionInProgress">
+      {{ canvastable.bulkSelectionMessage }}
+    </div>
     <div *ngIf="canvastable.rowWrapMode && canvastable.hasSortColumns" style="display: flex">  
       <ng-container *ngFor="let col of canvastable.columns; let colIndex = index">
         <div *ngIf="col.sortColumn!==null"

--- a/src/app/canvastable/canvastablecontainer.component.scss
+++ b/src/app/canvastable/canvastablecontainer.component.scss
@@ -2,3 +2,17 @@
     position: relative;
     bottom: 3px;
 }
+
+.selection-progress {
+    position: absolute;
+    top: 6px;
+    left: 40px;
+    z-index: 2;
+    padding: 4px 10px;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.95);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.18);
+    font-size: 12px;
+    pointer-events: none;
+    white-space: nowrap;
+}


### PR DESCRIPTION
**Enhancement** — Shows a progress indicator while "Select All" is processing a large folder, preventing repeated clicks and confusion.

## Problem
Selecting all messages in a large folder could take several seconds with no visible feedback. The mail list appeared unresponsive, leading users to click the checkbox multiple times. Issue #1551.

## Fix
- Batch the all-row selection loop so the mail list can repaint between chunks
- Display transient in-table progress text while the selection is running, giving users a visible count of messages being selected
- Cover the batched selection flow with a focused `canvastable` spec

## Testing
- Regression test added for batched selection flow in `canvastable.spec.ts`
- `eslint` passes on modified files
- `git diff --check` passes

Closes #1551
