### PR TITLE
Fix #1435: remove Stripe mentions from card payments

### DIFF
--- a/src/app/account-app/account-transactions.component.spec.ts
+++ b/src/app/account-app/account-transactions.component.spec.ts
@@ -1,0 +1,35 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { of } from 'rxjs';
+
+import { AccountTransactionsComponent } from './account-transactions.component';
+import { MobileQueryService } from '../mobile-query.service';
+import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
+
+describe('AccountTransactionsComponent', () => {
+    it('shows a generic label for card-or-wallet transactions', () => {
+        const component = new AccountTransactionsComponent(
+            { matches: false, changed: of(false) } as MobileQueryService,
+            {} as RunboxWebmailAPI,
+        );
+
+        expect(component.methods.stripe).toBe('Card or wallet');
+    });
+});

--- a/src/app/account-app/account-transactions.component.ts
+++ b/src/app/account-app/account-transactions.component.ts
@@ -53,7 +53,7 @@ export class AccountTransactionsComponent implements OnInit {
         creditcard: 'Netaxept',
         giro:       'Offline',
         paypal:     'PayPal',
-        stripe:     'Stripe',
+        stripe:     'Card or wallet',
     };
 
     statuses = {

--- a/src/app/account-app/credit-cards/credit-cards.component.html
+++ b/src/app/account-app/credit-cards/credit-cards.component.html
@@ -14,7 +14,7 @@
 
     <p> Here are the payment cards currently associated with your account.</p>
     
-    <p> The details of your payment cards are securely stored and processed by Stripe. </p>
+    <p> Your payment card details are handled securely through our card payment provider. </p>
     
     <p> Runbox accepts a number of payment methods including credit and debit cards, PayPal, cryptocurrencies, and bank transfers. For details, please see <a href="https://runbox.com/price-plans/payment-methods/" target="info">Payment Methods</a>.</p>
       

--- a/src/app/account-app/credit-cards/credit-cards.component.spec.ts
+++ b/src/app/account-app/credit-cards/credit-cards.component.spec.ts
@@ -1,0 +1,60 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+
+import { CreditCardsComponent } from './credit-cards.component';
+import { RunboxWebmailAPI } from '../../rmmapi/rbwebmail';
+import { RunboxContactSupportSnackBar } from '../../common/contact-support-snackbar.service';
+import { MatDialog } from '@angular/material/dialog';
+
+describe('CreditCardsComponent', () => {
+    let fixture: ComponentFixture<CreditCardsComponent>;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            declarations: [CreditCardsComponent],
+            providers: [
+                { provide: MatDialog, useValue: { open: jasmine.createSpy('open') } },
+                {
+                    provide: RunboxWebmailAPI,
+                    useValue: {
+                        getCreditCards: () => of({ payment_methods: [], default: null }),
+                    },
+                },
+                { provide: RunboxContactSupportSnackBar, useValue: { open: jasmine.createSpy('open') } },
+            ],
+            schemas: [NO_ERRORS_SCHEMA],
+        }).compileComponents();
+    });
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(CreditCardsComponent);
+        fixture.detectChanges();
+    });
+
+    it('describes card handling without naming Stripe', () => {
+        const text = fixture.nativeElement.textContent;
+
+        expect(text).toContain('handled securely through our card payment provider');
+        expect(text).not.toContain('Stripe');
+    });
+});

--- a/src/app/account-app/credit-cards/stripe-add-card-dialog.component.html
+++ b/src/app/account-app/credit-cards/stripe-add-card-dialog.component.html
@@ -31,13 +31,13 @@
 }
 </style>
 
-<h1 mat-dialog-title>Credit card setup via Stripe</h1>
+<h1 mat-dialog-title>Add a payment card</h1>
 
 <ng-template #legacyFallback>
     <p> Form not loading? </p>
 
     <p>
-        Make sure your browser extensions are not blocking access to <span style="font-family: monospace">stripe.com</span>.
+        Make sure your browser extensions are not blocking the payment form.
     </p>
 </ng-template>
 
@@ -51,7 +51,7 @@
     </div>
 
     <div [style.display]="state === 'loading' ? 'block' : 'none'">
-        <div> Loading Stripe form... </div>
+        <div> Loading payment form... </div>
         <mat-spinner style="margin:0 auto;"></mat-spinner>
 
         <ng-container *ngTemplateOutlet="legacyFallback"></ng-container>

--- a/src/app/account-app/stripe-payment-dialog.component.html
+++ b/src/app/account-app/stripe-payment-dialog.component.html
@@ -11,7 +11,7 @@
     </div>
 
     <div [style.display]="state === 'loading' ? 'block' : 'none'">
-        <div> Loading Stripe payment form... </div>
+        <div> Loading payment form... </div>
         <mat-spinner style="margin:0 auto;"></mat-spinner>
     </div>
 

--- a/src/app/account-app/stripe-payment-dialog.component.ts
+++ b/src/app/account-app/stripe-payment-dialog.component.ts
@@ -143,12 +143,12 @@ export class StripePaymentDialogComponent implements AfterViewInit {
             }
         } catch (err) {
             console.error(err);
-            this.stripeError = 'Stripe validate failed';
+            this.stripeError = 'Unable to validate your payment details.';
             this.state = 'failure';
             return;
         }
 
-        this.processing_message = 'Sending details to Stripe .. ';
+        this.processing_message = 'Sending your payment details...';
         try {
             const confirmed = await this.stripe.createConfirmationToken({
                 'elements': this.elements});
@@ -169,7 +169,7 @@ export class StripePaymentDialogComponent implements AfterViewInit {
                     });
         } catch (err) {
             console.error(err);
-            this.stripeError = 'Stripe submit failed';
+            this.stripeError = 'Unable to submit your payment details.';
             this.state = 'failure';
             return;
         }
@@ -178,7 +178,7 @@ export class StripePaymentDialogComponent implements AfterViewInit {
 
     handleConfirmationToken(cId: string) {
         return new Promise<void>((resolve, reject) => {
-            this.processing_message = 'Confirming payment with Stripe .. ';
+            this.processing_message = 'Submitting your payment...';
             this.paymentsservice.submitStripePayment(this.tid, cId).subscribe(res => {
                 if (res.status === 'requires_action') {
                     this.processing_message = 'Updating payment after redirect .. ';


### PR DESCRIPTION
## Summary
- replace user-facing Stripe branding in the saved-card page and card entry dialogs with generic card-payment wording
- use a generic transaction label for Stripe-backed payments so the UI reads as a normal card-or-wallet flow
- add focused specs for the updated saved-card copy and transaction method label

## Testing
- `tsc -p tsconfig.json --noEmit --incremental false`
- `git diff --check`
- `ng test --watch=false --browsers=FirefoxHeadless --include src/app/account-app/credit-cards/credit-cards.component.spec.ts --include src/app/account-app/account-transactions.component.spec.ts` *(fails locally: FirefoxHeadless has no installed browser binary here, and the Karma launcher then throws `TypeError: Cannot read properties of undefined (reading 'stderr')`)*

Closes #1435
