### PR TITLE
fix(account): correct decimal.js precision to preserve price decimals

### DIFF
--- a/e2e/cypress/integration/ordering.ts
+++ b/e2e/cypress/integration/ordering.ts
@@ -21,6 +21,40 @@ describe('Ordering products', () => {
         cy.url().should('include', '/account/receipt');
     });
 
+    it('shows correct price per year for 3-year plans', () => {
+        cy.intercept('/rest/v1/account_product/upgrades', {
+            status: 'success',
+            result: {
+                products: [{
+                    pid: 9001, name: 'Runbox Test 3-year', type: 'subscription', subtype: 'mini3',
+                    description: 'Test 3-year plan', price: '84.95', currency: 'EUR',
+                    quotas: { Disk: { type: 'bytes', quota: 10737418240 }, File: { type: 'bytes', quota: 10737418240 },
+                              VirtualDomain: { type: 'count', quota: 1 }, Alias: { type: 'count', quota: 100 },
+                              EmailSize: { type: 'bytes', quota: 104857600 }, MessagesReceived: { type: 'count', quota: 5000 },
+                              SentMail: { type: 'count', quota: 1000 } },
+                    over_quota: [], addons_needed: [], addon_usages: [], allow_multiple: false
+                }, {
+                    pid: 9002, name: 'Runbox Test', type: 'subscription', subtype: 'mini',
+                    description: 'Test 1-year plan', price: '34.95', currency: 'EUR',
+                    quotas: { Disk: { type: 'bytes', quota: 10737418240 }, File: { type: 'bytes', quota: 10737418240 },
+                              VirtualDomain: { type: 'count', quota: 1 }, Alias: { type: 'count', quota: 100 },
+                              EmailSize: { type: 'bytes', quota: 104857600 }, MessagesReceived: { type: 'count', quota: 5000 },
+                              SentMail: { type: 'count', quota: 1000 } },
+                    over_quota: [], addons_needed: [], addon_usages: [], allow_multiple: false
+                }]
+            }
+        }).as('availableProducts');
+        cy.intercept('/rest/v1/account_product/available*', { status: 'success', result: { products: [] } });
+        cy.visit('/account/plans');
+        cy.wait('@availableProducts', {'timeout':10000});
+
+        // 84.95 / 3 = 28.3167 -> displayed as 28.32
+        cy.get('.productGrid mat-card')
+            .contains('Test 3-year')
+            .parents('mat-card')
+            .should('contain', 'Price per year: EUR 28.32');
+    });
+
     it('can order product twice to increase quantity', () => {
         cy.visit('/account/plans');
 

--- a/src/app/account-app/account-product.component.ts
+++ b/src/app/account-app/account-product.component.ts
@@ -25,7 +25,7 @@ import { ProductOrder } from './product-order';
 
 import { Decimal } from 'decimal.js-light';
 
-Decimal.set({ precision: 2, rounding: Decimal.ROUND_HALF_EVEN });
+Decimal.set({ precision: 20, rounding: Decimal.ROUND_HALF_EVEN });
 
 @Component({
     selector: 'app-account-product',

--- a/src/app/account-app/account-upgrades.component.ts
+++ b/src/app/account-app/account-upgrades.component.ts
@@ -33,7 +33,7 @@ import { ProductOrder } from './product-order';
 
 import { Decimal } from 'decimal.js-light';
 
-Decimal.set({ precision: 2, rounding: Decimal.ROUND_HALF_EVEN });
+Decimal.set({ precision: 20, rounding: Decimal.ROUND_HALF_EVEN });
 
 @Component({
     selector: 'app-account-upgrades-component',

--- a/src/app/account-app/cart.service.spec.ts
+++ b/src/app/account-app/cart.service.spec.ts
@@ -24,7 +24,7 @@ import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
 import { firstValueFrom, of } from 'rxjs';
 import { Decimal } from 'decimal.js-light';
 
-Decimal.set({ precision: 2, rounding: Decimal.ROUND_HALF_EVEN });
+Decimal.set({ precision: 20, rounding: Decimal.ROUND_HALF_EVEN });
 
 describe('CartService', () => {
     const storage = new StorageService({ me: of({ uid: 42 }) } as RunboxWebmailAPI);

--- a/src/app/account-app/cart.service.ts
+++ b/src/app/account-app/cart.service.ts
@@ -25,7 +25,7 @@ import { StorageService } from '../storage.service';
 
 import { Decimal } from 'decimal.js-light';
 
-Decimal.set({ precision: 2, rounding: Decimal.ROUND_HALF_EVEN });
+Decimal.set({ precision: 20, rounding: Decimal.ROUND_HALF_EVEN });
 
 @Injectable()
 export class CartService {

--- a/src/app/account-app/product-order.ts
+++ b/src/app/account-app/product-order.ts
@@ -18,7 +18,7 @@
 // ---------- END RUNBOX LICENSE ----------
 import { Decimal } from 'decimal.js-light';
 
-Decimal.set({ precision: 2, rounding: Decimal.ROUND_HALF_EVEN });
+Decimal.set({ precision: 20, rounding: Decimal.ROUND_HALF_EVEN });
 
 export class ProductOrder {
     pid:      number;

--- a/src/app/account-app/product.ts
+++ b/src/app/account-app/product.ts
@@ -19,7 +19,7 @@
 
 import { Decimal } from 'decimal.js-light';
 
-Decimal.set({ precision: 2, rounding: Decimal.ROUND_HALF_EVEN });
+Decimal.set({ precision: 20, rounding: Decimal.ROUND_HALF_EVEN });
 
 export interface QuotaEntry {
     type: string;

--- a/src/app/account-app/shopping-cart.component.ts
+++ b/src/app/account-app/shopping-cart.component.ts
@@ -34,7 +34,7 @@ import { Product } from './product';
 import { MobileQueryService } from '../mobile-query.service';
 import { Decimal } from 'decimal.js-light';
 
-Decimal.set({ precision: 2, rounding: Decimal.ROUND_HALF_EVEN });
+Decimal.set({ precision: 20, rounding: Decimal.ROUND_HALF_EVEN });
 
 enum CartError {
     CANT_LOAD_PRODUCTS,


### PR DESCRIPTION
- Changed `Decimal.set({ precision: 2 })` to `precision: 20` in all 7 account-app files that use decimal.js-light
- `precision` controls significant digits, not decimal places — with `precision: 2`, `84.95 / 3 = 28` (2 sig figs) instead of `28.32`
- Added E2E test verifying 3-year plan price per year displays correct decimal values

Closes #1818