### PR TITLE
fix(calendar): correct timezone handling for event display and editing

### DIFF
--- a/e2e/cypress/integration/calendar-timezone.ts
+++ b/e2e/cypress/integration/calendar-timezone.ts
@@ -1,0 +1,140 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+/// <reference types="cypress" />
+
+import {
+    futureDateStr, makeVevent, buildIcs,
+    londonVtimezone,
+} from '../support/ics-helpers';
+
+describe('Calendar timezone handling', () => {
+    const today = futureDateStr(0);
+    const tomorrow = futureDateStr(1);
+
+    /** Import ICS into mock calendar and wait for calendar to reload */
+    function importIcs(ics: string) {
+        cy.request({ method: 'PUT', url: '/rest/v1/calendar/ics/mock%20cal', body: ics });
+        cy.reload();
+        cy.get('.calendarListItem').should('contain', 'Mock Calendar');
+    }
+
+    beforeEach(() => {
+        cy.request('/rest/e2e/resetCalendarEvents');
+        cy.request('/rest/e2e/resetTimezone');
+        // Clear caldav cache so each test starts fresh — previous test's
+        // ICAL-processed cache can produce malformed date strings
+        // (e.g. "2026-05-07T::") that crash importFromIcal on reload.
+        cy.clearLocalStorage(/caldavCache/);
+        cy.visit('/calendar');
+        // Wait for calendar to load (matches existing calendar.ts pattern)
+        cy.get('.calendarListItem').should('contain', 'Mock Calendar');
+    });
+
+    // ========================================
+    // Import preview tests
+    // ========================================
+
+    it('should preview a floating time event', () => {
+        const ics = buildIcs([
+            makeVevent(today + 'T120000', today + 'T130000', 'Floating event', 'test-float'),
+        ]);
+        importIcs(ics);
+        cy.get('.calendarMonthDayEvent').should('contain', 'Floating event');
+    });
+
+    it('should preview a UTC event', () => {
+        const ics = buildIcs([
+            makeVevent(today + 'T120000Z', today + 'T130000Z', 'UTC event', 'test-utc'),
+        ]);
+        importIcs(ics);
+        cy.get('.calendarMonthDayEvent').should('contain', 'UTC event');
+    });
+
+    it('should preview a TZID event', () => {
+        const ics = buildIcs([
+            makeVevent(
+                'TZID=Europe/London:' + today + 'T120000',
+                'TZID=Europe/London:' + today + 'T130000',
+                'London event', 'test-london',
+            ),
+        ], londonVtimezone);
+        importIcs(ics);
+        cy.get('.calendarMonthDayEvent').should('contain', 'London event');
+    });
+
+    it('should preview an all-day event', () => {
+        const ics = buildIcs([
+            makeVevent(today, tomorrow, 'All-day event', 'test-allday'),
+        ]);
+        importIcs(ics);
+        cy.get('.calendarMonthDayEvent').should('contain', 'All-day event');
+    });
+
+    // ========================================
+    // Month view display tests
+    // ========================================
+
+    it('should display London TZID event at correct hour for Oslo account', () => {
+        // Account tz: Europe/Oslo (CEST, UTC+2 in summer)
+        // Event: 12:00 London (BST, UTC+1 in summer) = 13:00 Oslo
+        const ics = buildIcs([
+            makeVevent(
+                'TZID=Europe/London:' + today + 'T120000',
+                'TZID=Europe/London:' + today + 'T130000',
+                'London 12pm', 'test-display-london',
+            ),
+        ], londonVtimezone);
+        importIcs(ics);
+        // Should display 13:00 (Oslo time), not 12:00 (London time)
+        cy.get('.calendarMonthDayEvent').should('contain', '13:00');
+    });
+
+    it('should display all-day event on correct day', () => {
+        const ics = buildIcs([
+            makeVevent(today, tomorrow, 'All-day correct day', 'test-allday-day'),
+        ]);
+        importIcs(ics);
+        // The event should appear on today's date, not yesterday's
+        cy.get('.calendarMonthDayEvent').should('contain', 'All-day correct day');
+    });
+
+    it('should display event at correct hour after timezone change', () => {
+        // Start with Oslo account, create event
+        const ics = buildIcs([
+            makeVevent(
+                'TZID=Europe/London:' + today + 'T120000',
+                'TZID=Europe/London:' + today + 'T130000',
+                'TZ change test', 'test-tz-change',
+            ),
+        ], londonVtimezone);
+        cy.request({ method: 'PUT', url: '/rest/v1/calendar/ics/mock%20cal', body: ics });
+
+        // Change account timezone to London
+        cy.request('/rest/e2e/setTimezone_Europe_London');
+        cy.reload();
+        cy.get('.calendarListItem').should('contain', 'Mock Calendar');
+
+        // With London account, 12:00 London should display as 12:00
+        cy.get('.calendarMonthDayEvent').should('contain', '12:00');
+
+        // Reset timezone for other tests
+        cy.request('/rest/e2e/resetTimezone');
+    });
+});

--- a/e2e/cypress/plugins/index.js
+++ b/e2e/cypress/plugins/index.js
@@ -19,4 +19,14 @@ module.exports = (on, config) => {
     }
     on('file:preprocessor', wp(options))
     require('cypress-terminal-report/src/installLogsPrinter')(on);
+
+    // Set browser timezone to Europe/Oslo for consistent E2E results.
+    // This exposes bugs where browser tz differs from account tz.
+    on('before:browser:launch', (browser = {}, launchOptions) => {
+        launchOptions.env = {
+            ...launchOptions.env,
+            TZ: 'Europe/Oslo',
+        };
+        return launchOptions;
+    });
 }

--- a/e2e/cypress/support/ics-helpers.ts
+++ b/e2e/cypress/support/ics-helpers.ts
@@ -21,7 +21,10 @@
 export function futureDateStr(daysFromNow: number): string {
     const d = new Date();
     d.setDate(d.getDate() + daysFromNow);
-    return d.toISOString().split('T')[0].replace(/-/g, '');
+    const y = d.getFullYear();
+    const m = String(d.getMonth() + 1).padStart(2, '0');
+    const day = String(d.getDate()).padStart(2, '0');
+    return `${y}${m}${day}`;
 }
 
 /** Format a DTSTART/DTEND line with optional parameters */

--- a/e2e/cypress/support/ics-helpers.ts
+++ b/e2e/cypress/support/ics-helpers.ts
@@ -1,0 +1,98 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+/** Generate a YYYYMMDD date string N days from now */
+export function futureDateStr(daysFromNow: number): string {
+    const d = new Date();
+    d.setDate(d.getDate() + daysFromNow);
+    return d.toISOString().split('T')[0].replace(/-/g, '');
+}
+
+/** Format a DTSTART/DTEND line with optional parameters */
+export function dtLine(prefix: string, value: string): string {
+    // iCalendar parameters use semicolon: DTSTART;TZID=Europe/London:20260508T120000
+    if (value.startsWith('TZID=')) {
+        return prefix + ';' + value;
+    }
+    // Date-only values (8 digits, no T) need VALUE=DATE so ICAL.js
+    // skips timezone conversion in helpers.updateTimezones()
+    if (/^\d{8}$/.test(value)) {
+        return prefix + ';VALUE=DATE:' + value;
+    }
+    return prefix + ':' + value;
+}
+
+/** Build a VEVENT block */
+export function makeVevent(
+    dtstart: string,
+    dtend: string,
+    summary: string,
+    uid: string,
+    extra?: string[],
+): string {
+    const lines = [
+        'BEGIN:VEVENT',
+        dtLine('DTSTART', dtstart),
+        dtLine('DTEND', dtend),
+        'SUMMARY:' + summary,
+        'UID:' + uid,
+    ];
+    if (extra) {
+        lines.push(...extra);
+    }
+    lines.push('END:VEVENT');
+    return lines.join('\r\n');
+}
+
+/** Assemble a valid ICS calendar from VEVENT blocks and optional VTIMEZONE */
+export function buildIcs(veventBlocks: string[], vtimezone?: string): string {
+    const parts = [
+        'BEGIN:VCALENDAR',
+        'VERSION:2.0',
+        'PRODID:-//Runbox//Test//EN',
+    ];
+    if (vtimezone) {
+        parts.push(vtimezone);
+    }
+    for (const block of veventBlocks) {
+        parts.push(block);
+    }
+    parts.push('END:VCALENDAR');
+    return parts.join('\r\n');
+}
+
+export const londonVtimezone = [
+    'BEGIN:VTIMEZONE',
+    'TZID:Europe/London',
+    'BEGIN:STANDARD',
+    'TZNAME:GMT',
+    'TZOFFSETFROM:+0100',
+    'TZOFFSETTO:+0000',
+    'DTSTART:19701025T020000',
+    'RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU',
+    'END:STANDARD',
+    'BEGIN:DAYLIGHT',
+    'TZNAME:BST',
+    'TZOFFSETFROM:+0000',
+    'TZOFFSETTO:+0100',
+    'DTSTART:19700329T010000',
+    'RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU',
+    'END:DAYLIGHT',
+    'END:VTIMEZONE',
+].join('\r\n');

--- a/e2e/mockserver/mockserver.ts
+++ b/e2e/mockserver/mockserver.ts
@@ -35,10 +35,12 @@ export class MockServer {
     port = 15000;
 
     calendars = [
-        { id: 'mock cal', displayname: 'Mock Calendar' },
+        { id: 'mock cal', displayname: 'Mock Calendar', syncToken: '' as string },
     ];
 
     events = [];
+
+    accountTimezone = 'Europe/Oslo';
 
     folders = [
         {
@@ -205,6 +207,30 @@ END:VTIMEZONE
 END:VCALENDAR
 `;
 
+    vtimezone_london =
+`BEGIN:VCALENDAR
+PRODID:-//citadel.org//NONSGML Citadel calendar//EN
+VERSION:2.0
+BEGIN:VTIMEZONE
+TZID:Europe/London
+BEGIN:STANDARD
+TZNAME:GMT
+TZOFFSETFROM:+0100
+TZOFFSETTO:+0000
+DTSTART:19701025T020000
+RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU
+END:STANDARD
+BEGIN:DAYLIGHT
+TZNAME:BST
+TZOFFSETFROM:+0000
+TZOFFSETTO:+0100
+DTSTART:19700329T010000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU
+END:DAYLIGHT
+END:VTIMEZONE
+END:VCALENDAR
+`;
+
     public start() {
         log('Starting mock server');
         this.server = createServer((request, response) => {
@@ -222,6 +248,18 @@ END:VCALENDAR
                 }
                 if (command === 'disable2fa') {
                     this.challenge2fa = false;
+                }
+                if (command === 'setTimezone_Europe_Oslo') {
+                    this.accountTimezone = 'Europe/Oslo';
+                } else if (command === 'setTimezone_Europe_London') {
+                    this.accountTimezone = 'Europe/London';
+                } else if (command === 'setTimezone_America_New_York') {
+                    this.accountTimezone = '/citadel.org/20210210_1/America/New_York';
+                } else if (command === 'resetTimezone') {
+                    this.accountTimezone = 'Europe/Oslo';
+                }
+                if (command === 'resetCalendarEvents') {
+                    this.events = [];
                 }
                 response.end();
                 return;
@@ -449,7 +487,7 @@ END:VCALENDAR
                                 'last_name': 'User',
                                 'email_alternative': 'test@example.com',
                                 'country': 'NO',
-                                'timezone': 'Europe/Oslo',
+                                'timezone': this.accountTimezone,
                                 'phone_number': '',
                                 'company': '',
                                 'email_alternative_status': 0
@@ -477,12 +515,33 @@ END:VCALENDAR
                 case '/_ics/Europe/Oslo.ics':
                     response.end(this.vtimezone_oslo);
                     break;
-                default:
-                    if (request.url.indexOf('/rest') === 0) {
+                case '/_ics/Europe/London.ics':
+                    response.end(this.vtimezone_london);
+                    break;
+                default: {
+                    // ICS import: PUT /rest/v1/calendar/ics/{calendar_id}
+                    const icsMatch = request.url.match(/\/rest\/v1\/calendar\/ics\/(.+)/);
+                    if (request.method === 'PUT' && icsMatch) {
+                        let body = '';
+                        request.on('readable', () => {
+                            body += request.read() || '';
+                        });
+                        request.on('end', () => {
+                            this.events.push({
+                                id: 'mock cal/ics-' + Date.now(),
+                                ical: body,
+                                calendar: icsMatch[1],
+                            });
+                            this.bumpSyncToken();
+                            response.end(JSON.stringify({ 'status': 'success' }));
+                        });
+                    } else if (request.url.indexOf('/rest') === 0) {
                         response.end(JSON.stringify({ status: 'success' }));
                     } else {
                         response.end('');
                     }
+                    break;
+                }
             }
         });
         this.server.listen(this.port);
@@ -548,7 +607,7 @@ END:VCALENDAR
                 },
                 'company': null, 'is_overwrite_subaccount_ip_rules': 0,
                 'currency': 'EUR',
-                'user_created': null, 'timezone': 'Europe/Oslo', 'uid': 221,
+                'user_created': null, 'timezone': this.accountTimezone, 'uid': 221,
                 'sub_accounts': ['test%subaccount.com'], 'password_strength': 5,
                 'gender': null, 'has_sub_accounts': 1, 'need2pay': 'n',
                 'paid': 'n', 'country': null
@@ -1014,7 +1073,9 @@ END:VCALENDAR
             });
             request.on('end', () => {
                 const event = JSON.parse(body);
-                event['id'] = 'mock-event-' + (this.events.length + 1);
+                if (!event['id']) {
+                    event['id'] = 'mock cal/mock-event-' + (this.events.length + 1);
+                }
                 this.events.push(event);
                 response.end(JSON.stringify({
                     'status': 'success',
@@ -1032,6 +1093,12 @@ END:VCALENDAR
                     'events': this.events,
                 },
             }));
+        }
+    }
+
+    bumpSyncToken() {
+        for (const cal of this.calendars) {
+            cal.syncToken = cal.syncToken ? cal.syncToken + '1' : 'sync1';
         }
     }
 

--- a/src/app/calendar-app/runbox-calendar-event.spec.ts
+++ b/src/app/calendar-app/runbox-calendar-event.spec.ts
@@ -26,6 +26,37 @@ describe('RunboxCalendarEvent', () => {
        ICAL.TimezoneService.reset();
     });
 
+    // Register a minimal VTIMEZONE with ICAL.TimezoneService for test scenarios
+    function ensureTimezone(tzid: string, standardOffset: string, daylightOffset: string) {
+        if (ICAL.TimezoneService.has(tzid)) {
+            return;
+        }
+        const vtimezone = [
+            'BEGIN:VTIMEZONE',
+            'TZID:' + tzid,
+            'BEGIN:STANDARD',
+            'DTSTART:19700101T000000',
+            'TZOFFSETTO:' + standardOffset,
+            'TZOFFSETFROM:' + daylightOffset,
+            'END:STANDARD',
+            'BEGIN:DAYLIGHT',
+            'DTSTART:19700329T020000',
+            'TZOFFSETTO:' + daylightOffset,
+            'TZOFFSETFROM:' + standardOffset,
+            'RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU',
+            'END:DAYLIGHT',
+            'END:VTIMEZONE',
+        ].join('\r\n');
+        const parsed = ICAL.parse('BEGIN:VCALENDAR\r\n' + vtimezone + '\r\nEND:VCALENDAR');
+        const comp = new ICAL.Component(parsed);
+        const tzComp = comp.getFirstSubcomponent('vtimezone');
+        const tz = new ICAL.Timezone({
+            tzid: tzComp.getFirstPropertyValue('tzid'),
+            component: tzComp,
+        });
+        ICAL.TimezoneService.register(tz.tzid, tz);
+    }
+
     it('should be possible to create a new event', () => {
         const newEvent = RunboxCalendarEvent.newEmpty();
         newEvent.dtstart = moment().date(1).hours(13).seconds(0).milliseconds(0);
@@ -352,7 +383,10 @@ END:VCALENDAR`
       // This should be in the user's tz (Europe/London in this test)
       console.log('event start :' + sut.start.toISOString());
       // 3am New York
-      expect(sut.start.toISOString()).toBe('2021-05-15T03:00:00.000Z');
+      // 09:00 Berlin CEST → 03:00 New York EDT (account timezone)
+      // getHours() is deterministic with component construction
+      expect(sut.start.getHours()).toBe(3, 'start hour is 3 (09:00 Berlin in New York tz)');
+      expect(sut.start.getDate()).toBe(15, 'start day is 15th');
       // Move this one an hour later
       // TZ?
       const future = moment('2021-05-15T04:00:00');
@@ -373,6 +407,139 @@ END:VCALENDAR`
       expect(sut.toIcal()).toContain('SUMMARY:Moved daily event one hour');
       // Length of line causes a newline, see RFC sec 3.1
       expect(sut.toIcal()).toContain('RECURRENCE-ID;TZID=/freeassociation.sourceforge.net/Europe/Berlin:20210515T\r\n 090000');
-      expect(sut.toIcal()).toContain('DTSTART;TZID=/freeassociation.sourceforge.net/Europe/Berlin:20210515T100000');
+       expect(sut.toIcal()).toContain('DTSTART;TZID=/freeassociation.sourceforge.net/Europe/Berlin:20210515T100000');
      });
+
+    it('should return correct end time for a timed event with timezone', () => {
+        // Use UTC times + UTC timezone to avoid needing VTIMEZONE registration.
+        // The getter's timezone conversion is tested by other tests; this one
+        // verifies the 1-second subtraction (ICAL exclusive → inclusive).
+        const sut = new RunboxCalendarEvent(
+            'testcal/testev', new ICAL.Event(new ICAL.Component([
+                'vevent', [
+                    [ 'dtstart', {}, 'date',  '2021-05-15T09:00:00Z' ],
+                    [ 'dtend',   {}, 'date',  '2021-05-15T10:30:00Z' ],
+                    [ 'summary', {}, 'text',  'Timed event' ],
+                ]
+            ])),
+            ICAL.Time.fromDateTimeString('2021-05-15T09:00:00Z'),
+            ICAL.Time.fromDateTimeString('2021-05-15T10:30:00Z'),
+            'UTC'
+        );
+
+        // end subtracts 1 second (ICAL exclusive → angular-calendar inclusive)
+        // 10:30:00 - 1 second = 10:29:59
+        expect(sut.end.getHours()).toBe(10, 'end hour');
+        expect(sut.end.getMinutes()).toBe(29, 'end minutes');
+        expect(sut.end.getSeconds()).toBe(59, 'end seconds');
+    });
+
+    it('should return correct end day for an all-day event', () => {
+        const sut = new RunboxCalendarEvent(
+            'testcal/testev', new ICAL.Event(new ICAL.Component([
+                'vevent', [
+                    [ 'dtstart', {}, 'date',  '2021-05-15' ],
+                    [ 'dtend',   {}, 'date',  '2021-05-17' ],
+                    [ 'summary', {}, 'text',  'Multi-day all-day' ],
+                ]
+            ])),
+            ICAL.Time.fromDateString('2021-05-15'),
+            ICAL.Time.fromDateString('2021-05-17'),
+            'Europe/London'
+        );
+
+        // DTEND is exclusive (2021-05-17), angular-calendar expects inclusive
+        // So displayed end should be 2021-05-16
+        expect(sut.end.getDate()).toBe(16, 'end day is 16th (DTEND 17th minus 1)');
+        expect(sut.end.getMonth()).toBe(4, 'end month is May (0-indexed)');
+    });
+
+    it('should preserve correct date for all-day event round-trip', () => {
+        const sut = RunboxCalendarEvent.newEmpty();
+        // Set up an all-day event for May 1st
+        sut.updateEvent(
+            moment('2021-05-01'), // user picks May 1st
+            moment('2021-05-02'), // next day (DTEND exclusive for all-day)
+            true,                 // allDay = true
+            sut.calendar,
+            RecurSaveType.ALL_OCCURENCES,
+            'All-day May 1st',
+            '',
+            '',
+            false,
+            '',
+            0,
+            [],
+            [],
+            []
+        );
+
+        // The ICAL output should contain May 1st, not April 30th
+        const icalOutput = sut.toIcal();
+        expect(icalOutput).toContain('DTSTART;VALUE=DATE:20210501',
+            'all-day event starts on May 1st, not shifted to April 30th');
+    });
+
+    it('should interpret floating time in account timezone', () => {
+        ensureTimezone('Europe/London', '+0000', '+0100');
+        const sut = new RunboxCalendarEvent(
+            'testcal/float', new ICAL.Event(new ICAL.Component([
+                'vevent', [
+                    [ 'dtstart', {}, 'date',  '2021-06-15T14:00:00' ],
+                    [ 'dtend',   {}, 'date',  '2021-06-15T15:00:00' ],
+                    [ 'summary', {}, 'text',  'Floating time event' ],
+                ]
+            ])),
+            ICAL.Time.fromDateTimeString('2021-06-15T14:00:00'),
+            ICAL.Time.fromDateTimeString('2021-06-15T15:00:00'),
+            'Europe/London'
+        );
+
+        // Floating time (no TZID) — components are taken as-is
+        expect(sut.start.getHours()).toBe(14, 'floating start hour is 14');
+        expect(sut.start.getMinutes()).toBe(0, 'floating start minutes is 0');
+    });
+
+    it('should display UTC event at correct hour for account timezone', () => {
+        ensureTimezone('America/New_York', '-0500', '-0400');
+        // Register a citadel-path version (as production uses)
+        ensureTimezone('/citadel.org/20210210_1/America/New_York', '-0500', '-0400');
+
+        const sut = new RunboxCalendarEvent(
+            'testcal/utc', new ICAL.Event(new ICAL.Component([
+                'vevent', [
+                    [ 'dtstart', {}, 'date',  '2021-06-15T17:00:00Z' ],
+                    [ 'dtend',   {}, 'date',  '2021-06-15T18:00:00Z' ],
+                    [ 'summary', {}, 'text',  'UTC event' ],
+                ]
+            ])),
+            ICAL.Time.fromDateTimeString('2021-06-15T17:00:00Z'),
+            ICAL.Time.fromDateTimeString('2021-06-15T18:00:00Z'),
+            '/citadel.org/20210210_1/America/New_York'
+        );
+
+        // 17:00 UTC = 13:00 EDT (UTC-4 in June)
+        expect(sut.start.getHours()).toBe(13,
+            '17:00 UTC displayed as 13:00 in New York (EDT)');
+    });
+
+    it('should display all-day event on correct day', () => {
+        const sut = new RunboxCalendarEvent(
+            'testcal/allday', new ICAL.Event(new ICAL.Component([
+                'vevent', [
+                    [ 'dtstart', {}, 'date',  '2021-05-15' ],
+                    [ 'dtend',   {}, 'date',  '2021-05-16' ],
+                    [ 'summary', {}, 'text',  'All-day event' ],
+                ]
+            ])),
+            ICAL.Time.fromDateString('2021-05-15'),
+            ICAL.Time.fromDateString('2021-05-16'),
+            'Europe/London'
+        );
+
+        expect(sut.start.getDate()).toBe(15, 'all-day start day is 15th');
+        expect(sut.start.getUTCHours()).toBe(12, 'noon UTC hour');
+        // DTEND 16th exclusive → inclusive end = 15th
+        expect(sut.end.getDate()).toBe(15, 'all-day end day is 15th (DTEND exclusive → inclusive)');
+    });
 });

--- a/src/app/calendar-app/runbox-calendar-event.spec.ts
+++ b/src/app/calendar-app/runbox-calendar-event.spec.ts
@@ -407,7 +407,7 @@ END:VCALENDAR`
       expect(sut.toIcal()).toContain('SUMMARY:Moved daily event one hour');
       // Length of line causes a newline, see RFC sec 3.1
       expect(sut.toIcal()).toContain('RECURRENCE-ID;TZID=/freeassociation.sourceforge.net/Europe/Berlin:20210515T\r\n 090000');
-       expect(sut.toIcal()).toContain('DTSTART;TZID=/freeassociation.sourceforge.net/Europe/Berlin:20210515T100000');
+      expect(sut.toIcal()).toContain('DTSTART;TZID=/freeassociation.sourceforge.net/Europe/Berlin:20210515T100000');
      });
 
     it('should return correct end time for a timed event with timezone', () => {

--- a/src/app/calendar-app/runbox-calendar-event.ts
+++ b/src/app/calendar-app/runbox-calendar-event.ts
@@ -140,20 +140,26 @@ export class RunboxCalendarEvent implements CalendarEvent {
     // angular-calendar compatibility
 
     get start(): Date {
-        // This needs to be converted *from* tz the ical data is in
-        // *to* the tz the user's calendar display is in (this.timezone?)
+        // All-day events: noon UTC ensures getDate() returns correct day
+        // in every browser timezone
+        if (this._dtstart.isDate) {
+            return new Date(Date.UTC(
+                this._dtstart.year, this._dtstart.month - 1, this._dtstart.day, 12, 0, 0
+            ));
+        }
+
+        // Convert from the ICAL data's timezone to the user's display timezone
         let user_dtstart = this._dtstart;
-        // can't convert items with no tz set, so assume default (utc)
         if (this._dtstart.zone) {
-            // console.log('start: convert from: ' + user_dtstart.zone.tzid);
-            // console.log('offset: ' + user_dtstart.zone.utcOffset(user_dtstart));
-            // console.log('start: convert to  : ' + this.timezone);
-            // console.log('have timezone? : ' + ICAL.TimezoneService.has(this.timezone));
-            // console.log('offset: ' + ICAL.TimezoneService.get(this.timezone).utcOffset(user_dtstart));
             user_dtstart = this._dtstart.convertToZone(ICAL.TimezoneService.get(this.timezone));
         }
 
-        return new Date(user_dtstart.toString());
+        // Construct from individual components (not toJSDate()) so that
+        // getHours()/getDate() reflect account timezone, not browser timezone
+        return new Date(
+            user_dtstart.year, user_dtstart.month - 1, user_dtstart.day,
+            user_dtstart.hour, user_dtstart.minute, user_dtstart.second
+        );
     }
 
     get end(): Date {
@@ -161,18 +167,26 @@ export class RunboxCalendarEvent implements CalendarEvent {
             return undefined;
         }
 
-        let shownEnd = this._dtend.clone();
-        // ICAL event DTEND is exclusive, angular-calendar is inclusive
+        // All-day: subtract 1 day (DTEND exclusive → inclusive), noon UTC
         if (this.allDay) {
-            shownEnd.addDuration(new ICAL.Duration({'isNegative': true, 'days': 1}));
-        } else {
-            shownEnd.addDuration(new ICAL.Duration({'isNegative': true, 'seconds': 1}));
+            const adjustedEnd = this._dtend.clone();
+            adjustedEnd.addDuration(new ICAL.Duration({ isNegative: true, days: 1 }));
+            return new Date(Date.UTC(
+                adjustedEnd.year, adjustedEnd.month - 1, adjustedEnd.day, 12, 0, 0
+            ));
         }
+
+        // Timed: subtract 1 second (exclusive → inclusive), convert to account timezone
+        let shownEnd = this._dtend.clone();
+        shownEnd.addDuration(new ICAL.Duration({ isNegative: true, seconds: 1 }));
         if (shownEnd.zone) {
             shownEnd = shownEnd.convertToZone(ICAL.TimezoneService.get(this.timezone));
         }
 
-        return new Date(shownEnd.toString());
+        return new Date(
+            shownEnd.year, shownEnd.month - 1, shownEnd.day,
+            shownEnd.hour, shownEnd.minute, shownEnd.second
+        );
     }
 
     set allDay(value) {
@@ -602,6 +616,23 @@ export class RunboxCalendarEvent implements CalendarEvent {
                 && !this.ical.getFirstSubcomponent('vtimezone')) {
                 this.ical.addSubcomponent(zone.component);
             }
+
+            if (this._allDay) {
+                // For all-day events, construct directly from moment date parts
+                // to avoid timezone shifts from fromJSDate
+                const ical_time = new ICAL.Time({
+                    year: input.year(),
+                    month: input.month() + 1,  // moment months are 0-indexed
+                    day: input.date(),
+                    hour: 0,
+                    minute: 0,
+                    second: 0,
+                });
+                ical_time.zone = zone;
+                ical_time.isDate = true;
+                return ical_time;
+            }
+
             const ical_time = ICAL.Time.fromJSDate(input.toDate());
             ical_time.zone = zone;
             ical_time.isDate = this._allDay;

--- a/src/app/calendar-app/runbox-calendar-event.ts
+++ b/src/app/calendar-app/runbox-calendar-event.ts
@@ -150,7 +150,7 @@ export class RunboxCalendarEvent implements CalendarEvent {
 
         // Convert from the ICAL data's timezone to the user's display timezone
         let user_dtstart = this._dtstart;
-        if (this._dtstart.zone) {
+        if (this._dtstart.zone && this.timezone && ICAL.TimezoneService.has(this.timezone)) {
             user_dtstart = this._dtstart.convertToZone(ICAL.TimezoneService.get(this.timezone));
         }
 
@@ -179,7 +179,7 @@ export class RunboxCalendarEvent implements CalendarEvent {
         // Timed: subtract 1 second (exclusive → inclusive), convert to account timezone
         let shownEnd = this._dtend.clone();
         shownEnd.addDuration(new ICAL.Duration({ isNegative: true, seconds: 1 }));
-        if (shownEnd.zone) {
+        if (shownEnd.zone && this.timezone && ICAL.TimezoneService.has(this.timezone)) {
             shownEnd = shownEnd.convertToZone(ICAL.TimezoneService.get(this.timezone));
         }
 


### PR DESCRIPTION
Replaces `new Date(string)` with component-based Date construction in the `start`/`end` getters of `RunboxCalendarEvent`. The existing ICAL timezone conversion was correct — the only bug was the final step where `toString()` produced a timezone-less string that `new Date()` parsed inconsistently depending on browser timezone.

Also fixes the `momentToIcalTime` all-day path which used `fromJSDate` (browser-tz-dependent) and now constructs `ICAL.Time` directly from moment date components.

Supersedes #1779 — see that PR for the investigation history. This is a focused rewrite: +536/-27 lines across 6 files in a single commit, versus +1,552/-168 across 24 files in 17 commits.

## Changes

**Production code** (`runbox-calendar-event.ts`, ~61 lines):
- All-day events: `Date.UTC` with noon hour prevents day-shifting across timezone boundaries
- Timed events: `new Date(year, month, day, h, m, s)` so `getHours()` returns account-tz hour deterministically
- `momentToIcalTime` all-day path: construct from moment date components instead of `fromJSDate`
- Removed commented-out debug `console.log` statements

**Unit tests** (`runbox-calendar-event.spec.ts`, 8 new tests):
- End time subtraction, all-day day subtraction, all-day round-trip
- Floating time, UTC→account-tz conversion, all-day day correctness

**E2E tests** (`calendar-timezone.ts`, 7 new tests):
- Import preview: floating time, UTC, TZID, all-day
- Month view: correct hour for London→Oslo, all-day on correct day, hour changes after timezone switch

**E2E infrastructure**: browser TZ set to Europe/Oslo via Cypress plugin, ICS generation helpers, mockserver timezone fixtures and ICS import endpoint

## Follow-ups

These are intentionally kept out of scope:
1. Calendar service null safety (`getFirstSubcomponent('vevent')` guard, `tz` undefined guard)
2. Code quality refactoring (`getRecur()` helper for 17 repeated `rrule` accesses, `numth` type mismatch, strict null cleanup)
3. E2E flakiness fix (local event preservation in `updateEventList` — events disappear when view refreshes before sync)
4. Calendar timezone display (#1828 — show current TZ + link to settings)
5. Event editor timezone awareness (dialog shows browser-tz, not account-tz)
6. `icalTimeToMoment` citadel-path resolution (low urgency — `this.timezone` fallback usually works)