### PR TITLE
fix(routes): set sub-app page titles

### DIFF
--- a/src/app/account-app/account-app.module.ts
+++ b/src/app/account-app/account-app.module.ts
@@ -165,6 +165,7 @@ import { DomainRegisterComponent } from '../domainregister/domainregister.compon
         RouterModule.forChild([
             {
                 path: 'account',
+                title: 'Runbox Account',
                 canActivateChild: [RMMAuthGuardService, NoProductsForSubaccountsGuard],
                 children: [
                     {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -102,41 +102,45 @@ const routes: Routes = [
         path: '', outlet: 'headertoolbar',
         component: HeaderToolbarComponent
       },
-      { path: 'index_dev.html', component: AppComponent },
-      { path: 'app', component: AppComponent },
+      { path: 'index_dev.html', component: AppComponent, title: 'Runbox Mail' },
+      { path: 'app', component: AppComponent, title: 'Runbox Mail' },
       { path: '',
         component: AppComponent,
+        title: 'Runbox Mail',
         children: [
           {
             path: 'compose',
-            component: DraftDeskComponent
+            component: DraftDeskComponent,
+            title: 'Runbox Compose'
           },
           {
             path: 'overview',
-            component: StartDeskComponent
+            component: StartDeskComponent,
+            title: 'Runbox Overview'
           },
           {
             path: 'welcome',
-            component: WelcomeDeskComponent
+            component: WelcomeDeskComponent,
+            title: 'Runbox Welcome'
           }
         ]
       },
-      { path: 'start', component: OverviewComponent },
-      { path: 'help', component: HelpComponent },
-      { path: 'dev',                loadChildren: () => import('./dev/dev.module').then(m => m.DevModule) },
-      { path: 'dkim',               loadChildren: () => import('./dkim/dkim.module').then(m => m.DkimModule) },
-      { path: 'calendar',           loadChildren: () => import('./calendar-app/calendar-app.module').then(m => m.CalendarAppModule) },
-      { path: 'changelog',          loadChildren: () => import('./changelog/changelog.module').then(m => m.ChangelogModule) },
-      { path: 'contacts',           loadChildren: () => import('./contacts-app/contacts-app.module').then(m => m.ContactsAppModule) },
-      { path: 'onscreen',           loadChildren: () => import('./onscreen/onscreen.module').then(m => m.OnscreenModule) },
+      { path: 'start', component: OverviewComponent, title: 'Runbox Start' },
+      { path: 'help', component: HelpComponent, title: 'Runbox Help' },
+      { path: 'dev', title: 'Runbox Dev', loadChildren: () => import('./dev/dev.module').then(m => m.DevModule) },
+      { path: 'dkim', title: 'Runbox DKIM', loadChildren: () => import('./dkim/dkim.module').then(m => m.DkimModule) },
+      { path: 'calendar', title: 'Runbox Calendar', loadChildren: () => import('./calendar-app/calendar-app.module').then(m => m.CalendarAppModule) },
+      { path: 'changelog', title: 'Runbox Changelog', loadChildren: () => import('./changelog/changelog.module').then(m => m.ChangelogModule) },
+      { path: 'contacts', title: 'Runbox Contacts', loadChildren: () => import('./contacts-app/contacts-app.module').then(m => m.ContactsAppModule) },
+      { path: 'onscreen', title: 'Runbox Onscreen', loadChildren: () => import('./onscreen/onscreen.module').then(m => m.OnscreenModule) },
       { path: 'identities',         redirectTo: '/account/identities' },
       { path: 'account-security',   redirectTo: '/account/security'   },
       // can't handle it with a simple redirectTo because it'd lose the query params
       // (https://github.com/angular/angular/issues/13315)
-      { path: 'domainregistration', component: DomainRegisterRedirectComponent },
+      { path: 'domainregistration', component: DomainRegisterRedirectComponent, title: 'Runbox Domain Registration' },
     ]
   },
-  { path: 'login', component: LoginComponent }
+  { path: 'login', component: LoginComponent, title: 'Runbox Login' }
 ];
 
 @NgModule({
@@ -213,4 +217,3 @@ export class AppModule {
     );
   }
 }
-


### PR DESCRIPTION
## Summary
- add Angular route title metadata for the main Runbox sub-app routes
- cover Mail, Compose, Overview, Welcome, Calendar, Contacts, Account, Help, DKIM, Changelog, Onscreen, Domain Registration, and Login routes
- use Angular 16 native route titles instead of adding a custom router listener

Closes #284

## Verification
- git diff --check
- node --check src/app/app.module.ts

## Not run
- npm/ng build or tests: the local system Node/npm install is broken on this machine, and the bundled runtime available here includes node but not npm.