### PR TITLE
fix(mail): keep sender column tied to row folder

### DIFF
--- a/src/app/common/messagelist.spec.ts
+++ b/src/app/common/messagelist.spec.ts
@@ -1,0 +1,56 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { MessageList } from './messagelist';
+
+describe('MessageList', () => {
+  it('uses the row folder when choosing from or to values', () => {
+    const rows = [
+      {
+        id: 1,
+        folder: 'Inbox',
+        from: [{ name: 'Inbox Sender', address: 'sender@example.test' }],
+        to: [{ name: 'Inbox Recipient', address: 'recipient@example.test' }],
+        seenFlag: true,
+      },
+      {
+        id: 2,
+        folder: 'Sent',
+        from: [{ name: 'Sent Sender', address: 'me@example.test' }],
+        to: [{ name: 'Sent Recipient', address: 'sent@example.test' }],
+        seenFlag: true,
+      },
+      {
+        id: 3,
+        folder: 'Sent.Archive',
+        from: [{ name: 'Subsent Sender', address: 'me@example.test' }],
+        to: [{ name: 'Subsent Recipient', address: 'subsent@example.test' }],
+        seenFlag: true,
+      },
+    ];
+
+    const list = new MessageList(rows);
+    const columns = list.getCanvasTableColumns({ selectedFolder: 'Sent' });
+    const fromOrToColumn = columns.find(column => column.cacheKey === 'from');
+
+    expect(fromOrToColumn.getValue(0)).toBe('Inbox Sender');
+    expect(fromOrToColumn.getValue(1)).toBe('Sent Recipient');
+    expect(fromOrToColumn.getValue(2)).toBe('Subsent Recipient');
+  });
+});

--- a/src/app/common/messagelist.ts
+++ b/src/app/common/messagelist.ts
@@ -62,6 +62,15 @@ export class MessageList extends MessageDisplay {
     '';
   }
 
+  isSentFolder(folder: string): boolean {
+    return folder === 'Sent' || folder.startsWith('Sent.');
+  }
+
+  isSentFolderForRow(rowIndex: number): boolean {
+    const folder = this.rows[rowIndex]?.folder || '';
+    return this.isSentFolder(folder);
+  }
+
   // filter visible rows by whatever options the frontend has
   filterBy(options: Map<string, any>) {
     this.rows = this._rows;
@@ -91,10 +100,10 @@ export class MessageList extends MessageDisplay {
         draggable: true
       },
       {
-        name: app.selectedFolder === 'Sent' ? 'To' : 'From',
+        name: this.isSentFolder(app.selectedFolder || '') ? 'To' : 'From',
         cacheKey: 'from',
         sortColumn: null,
-        getValue: (rowIndex: number): any => app.selectedFolder === 'Sent'
+        getValue: (rowIndex: number): any => this.isSentFolderForRow(rowIndex)
           ? this.getToColumnValueForRow(rowIndex)
           : this.getFromColumnValueForRow(rowIndex),
         draggable: true

--- a/src/app/xapian/searchmessagedisplay.spec.ts
+++ b/src/app/xapian/searchmessagedisplay.spec.ts
@@ -1,0 +1,61 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { SearchMessageDisplay } from './searchmessagedisplay';
+
+describe('SearchMessageDisplay', () => {
+  it('uses the row folder when choosing from or to values', () => {
+    const docs = {
+      10: {
+        folder: 'Inbox',
+        from: 'Inbox Sender',
+        recipients: ['Inbox Recipient'],
+        subject: 'Inbox subject',
+        textcontent: '',
+        seen: true,
+      },
+      20: {
+        folder: 'Sent',
+        from: 'Sent Sender',
+        recipients: ['Sent Recipient'],
+        subject: 'Sent subject',
+        textcontent: '',
+        seen: true,
+      },
+    };
+    const searchService = {
+      getDocData: (id: number) => docs[id],
+      getMessageIdFromDocId: (id: number) => id,
+      api: {
+        getStringValue: () => '202601010000',
+      },
+    };
+
+    const display = new SearchMessageDisplay(searchService, [[10], [20]]);
+    const sentColumns = display.getCanvasTableColumns({
+      selectedFolder: 'Sent',
+      displayFolderColumn: false,
+      viewmode: 'list',
+    });
+    const fromOrToColumn = sentColumns.find(column => column.cacheKey === 'from');
+
+    expect(fromOrToColumn.getValue(0)).toBe('Inbox Sender');
+    expect(fromOrToColumn.getValue(1)).toBe('Sent Recipient');
+  });
+});

--- a/src/app/xapian/searchmessagedisplay.ts
+++ b/src/app/xapian/searchmessagedisplay.ts
@@ -54,6 +54,15 @@ export class SearchMessageDisplay extends MessageDisplay {
   filterBy(options: Map<string, any>) {
   }
 
+  private isSentFolder(folder: string): boolean {
+    return folder === 'Sent' || folder.startsWith('Sent.');
+  }
+
+  private isSentFolderForRow(rowIndex: number): boolean {
+    const folder = this.searchService.getDocData(this.getRowId(rowIndex)).folder || '';
+    return this.isSentFolder(folder);
+  }
+
   // columns
   // app is a Component (currently)
   public getCanvasTableColumns(app: any): CanvasTableColumn[] {
@@ -75,12 +84,14 @@ export class SearchMessageDisplay extends MessageDisplay {
         getValue: (rowIndex): string => this.searchService.api.getStringValue(this.getRowId(rowIndex), 2),
         getFormattedValue: (datestring) => MessageTableRowTool.formatTimestampFromStringWithoutSeparators(datestring)
       },
-      (app.selectedFolder.indexOf('Sent') === 0 && !app.displayFolderColumn) ? {
+      (this.isSentFolder(app.selectedFolder || '') && !app.displayFolderColumn) ? {
         name: 'To',
         draggable: true,
         cacheKey: 'from',
         sortColumn: null,
-        getValue: (rowIndex): string => this.searchService.getDocData(this.getRowId(rowIndex)).recipients.join(', '),
+        getValue: (rowIndex): string => this.isSentFolderForRow(rowIndex)
+          ? this.searchService.getDocData(this.getRowId(rowIndex)).recipients.join(', ')
+          : this.searchService.getDocData(this.getRowId(rowIndex)).from,
       } :
         {
           name: 'From',
@@ -88,7 +99,9 @@ export class SearchMessageDisplay extends MessageDisplay {
           cacheKey: 'from',
           sortColumn: 0,
           getValue: (rowIndex): string => {
-            return this.searchService.getDocData(this.getRowId(rowIndex)).from;
+            return this.isSentFolderForRow(rowIndex)
+              ? this.searchService.getDocData(this.getRowId(rowIndex)).recipients.join(', ')
+              : this.searchService.getDocData(this.getRowId(rowIndex)).from;
           },
         },
       {


### PR DESCRIPTION
## Summary
- Fixes #1825 by choosing From/To values from each row's actual folder instead of the currently selected folder.
- Covers both normal message lists and Xapian search results so stale rows do not briefly redraw with the wrong sender/recipient field while switching into or out of Sent folders.
- Adds focused regression tests in separate test commit.

## Validation
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npx eslint src/app/common/messagelist.spec.ts src/app/xapian/searchmessagedisplay.spec.ts`
- `npm run lint` (passes with existing warnings)
- `npm run build` (passes with existing warnings)
- `npm run policy` (exits 0; reports existing historical commit-message warnings)

Karma browser specs could not be executed in this environment because Firefox is not installed and ChromeHeadless is not registered in this repo's Karma config.

## AI disclosure
This contribution was prepared with AI assistance and manually reviewed before submission.