### PR TITLE
fix(mail): clarify sender list action labels

### DIFF
--- a/src/app/mailviewer/singlemailviewer.component.html
+++ b/src/app/mailviewer/singlemailviewer.component.html
@@ -83,13 +83,13 @@
 
       <mat-menu #senderRulesMenu>
         <button mat-menu-item (click)="messageActionsHandler.allowSender(mailObj.from[0].address)">
-          Allow Sender
+          {{allowSenderMenuLabel}}
         </button>
         <button mat-menu-item (click)="messageActionsHandler.blockSender(mailObj.from[0].address)">
-          Block Sender Email
+          {{blockSenderEmailMenuLabel}}
         </button>
         <button mat-menu-item (click)="messageActionsHandler.blockSender(mailObj.from[0].domain)">
-          Block Sender Domain
+          {{blockSenderDomainMenuLabel}}
         </button>
         <a mat-menu-item
            [href]="'/mail/rules'" target="rmm6">

--- a/src/app/mailviewer/singlemailviewer.component.spec.ts
+++ b/src/app/mailviewer/singlemailviewer.component.spec.ts
@@ -231,6 +231,12 @@ describe('SingleMailViewerComponent', () => {
       expect(component.mailObj.attachments[1].downloadURL.indexOf('blob:')).toBe(0);
     }));
 
+  it('should describe sender rule actions as allowlist and blocklist updates', () => {
+    expect((component as any).allowSenderMenuLabel).toBe('Add sender to allowlist');
+    expect((component as any).blockSenderEmailMenuLabel).toBe('Add sender email to blocklist');
+    expect((component as any).blockSenderDomainMenuLabel).toBe('Add sender domain to blocklist');
+  });
+
   describe('mailto: link interceptor', () => {
     let messageContentsElement: HTMLElement;
     let mailtoLink: HTMLAnchorElement;

--- a/src/app/mailviewer/singlemailviewer.component.ts
+++ b/src/app/mailviewer/singlemailviewer.component.ts
@@ -115,6 +115,9 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
   public savedForThisSender = false;
   public savedAlways = false;
   public showAllHeaders = false;
+  public readonly allowSenderMenuLabel = 'Add sender to allowlist';
+  public readonly blockSenderEmailMenuLabel = 'Add sender email to blocklist';
+  public readonly blockSenderDomainMenuLabel = 'Add sender domain to blocklist';
 
   contacts: Contact[] = [];
 


### PR DESCRIPTION
Fixes #1698.

## Summary
- add explicit allowlist/blocklist wording for the sender rules menu
- keep the existing allow/block actions unchanged
- cover the action labels with a focused component spec

## Tests
- npx tsc -p src/tsconfig.spec.json --noEmit
- npx eslint src/app/mailviewer/singlemailviewer.component.ts src/app/mailviewer/singlemailviewer.component.spec.ts
- npm run lint (passes with existing warnings)
- npm run policy (passes; reports existing historical commit-message notes)
- npm run build (passes with existing Angular/CommonJS warnings)
- npm run test -- --watch=false --browsers=ChromeHeadless --include=src/app/mailviewer/singlemailviewer.component.spec.ts (blocked: ChromeHeadless launcher is not registered in this checkout)

Used OpenAI Codex to inspect the issue, implement the patch, and run local validation.