### PR TITLE
Clarify full index sync prompt

### DIFF
--- a/src/app/xapian/searchservice.ts
+++ b/src/app/xapian/searchservice.ts
@@ -727,16 +727,18 @@ export class SearchService {
                         0)
                         / (1024 * 1024)
                       );
-                  const totalMessages = partitions.reduce((prev, curr, partitionNdx) => prev +
-                        curr.numberOfMessages,
+                  const remainingMessages = partitions.reduce((prev, curr, partitionNdx) => prev +
+                        (partitionNdx < 1 ? 0 : curr.numberOfMessages),
                         0);
+                  const totalMessages = doccount + remainingMessages;
 
                   dialog.componentInstance.title = 'Continue synchronizing?';
                   dialog.componentInstance.question = `Already synchronized index for
                       ${doccount} of
-                      your most recent messages. To synchronize entire index
-                      (for ${totalMessages} messages),
-                      there's an additional download of ${remainingDownloadMB} MB.`;
+                      your most recent messages. To synchronize the entire index
+                      (of ${totalMessages} messages), there is an additional
+                      download of ${remainingDownloadMB} MB for another
+                      ${remainingMessages} messages.`;
                   dialog.afterClosed()
                     .subscribe(res => {
                       userHasAcceptedDownloadAllPartitions = res;


### PR DESCRIPTION
Fixes #1763

## Summary
- Clarify the follow-up prompt shown when synchronizing the full index
- Show the final total as already synchronized plus remaining messages
- Make it clear the additional download applies to the remaining messages

## Testing
- node src/build/gen-env.js
- node node_modules/typescript/bin/tsc -p src/tsconfig.app.json --noEmit
- npm run lint (passes with existing warnings)