### PR TITLE
Constrain avatar size in printed messages

### DIFF
--- a/src/app/mailviewer/singlemailviewer.component.spec.ts
+++ b/src/app/mailviewer/singlemailviewer.component.spec.ts
@@ -231,6 +231,15 @@ describe('SingleMailViewerComponent', () => {
       expect(component.mailObj.attachments[1].downloadURL.indexOf('blob:')).toBe(0);
     }));
 
+  it('adds avatar sizing to printed messages', () => {
+    const printStyles = component.printableMessageStyles();
+
+    expect(printStyles).toContain('app-avatar-bar img');
+    expect(printStyles).toContain('width: 32px');
+    expect(printStyles).toContain('max-width: 32px');
+    expect(printStyles).toContain('max-height: 32px');
+  });
+
   describe('mailto: link interceptor', () => {
     let messageContentsElement: HTMLElement;
     let mailtoLink: HTMLAnchorElement;

--- a/src/app/mailviewer/singlemailviewer.component.ts
+++ b/src/app/mailviewer/singlemailviewer.component.ts
@@ -688,6 +688,26 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
     }
   }
 
+  printableMessageStyles() {
+    return `
+      <style>
+        app-avatar-bar > div {
+          display: flex;
+          align-items: center;
+        }
+
+        app-avatar-bar img {
+          width: 32px;
+          height: 32px;
+          max-width: 32px;
+          max-height: 32px;
+          border-radius: 32px;
+          object-fit: cover;
+        }
+      </style>
+    `;
+  }
+
   print() {
     // Can't access print view inside iFrame, so we need to
     // temporary hide buttons while the view is rendering
@@ -713,7 +733,7 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
       );
     }
     this.printFrame.nativeElement.onload = () => this.printFrame.nativeElement.contentWindow.print();
-    this.printFrame.nativeElement.src = URL.createObjectURL(new Blob([printablecontent],
+    this.printFrame.nativeElement.src = URL.createObjectURL(new Blob([this.printableMessageStyles(), printablecontent],
         { type: 'text/html' }
       )
     );


### PR DESCRIPTION
## Summary

Fixes #1824 by adding print-only styles for the avatar bar before the message HTML is loaded into the print iframe. The printed iframe receives raw `innerHTML`, so Angular component styles from `app-avatar-bar` are not present there; without those styles, avatar images can render at their intrinsic size.

The added styles only target `app-avatar-bar`, leaving message body images unchanged.

## Validation

- `npx eslint src/app/mailviewer/singlemailviewer.component.ts src/app/mailviewer/singlemailviewer.component.spec.ts` (passes with existing warnings)
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npx ng build --base-href=/app/ runbox7` (passes with existing project warnings)

I could not run the Karma browser test locally because Firefox/Chrome/Edge are not available on PATH in this environment.

## Disclosure

I used AI assistance to inspect the print path and draft this small patch, then validated the changed code with the commands above.