### PR TITLE
Use app favicon

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -17,6 +17,7 @@
             "tsConfig": "src/tsconfig.app.json",
             "polyfills": "src/polyfills.ts",
             "assets": [
+              "src/favicon.ico",
               "src/assets",
               {
                 "glob": "xapianasm*",
@@ -127,6 +128,7 @@
               "src/styles.scss"
             ],
             "assets": [
+              "src/favicon.ico",
               "src/assets",
               {
                 "glob": "xapianasm*",

--- a/src/index.html
+++ b/src/index.html
@@ -5,7 +5,7 @@
     <title>Runbox 7</title>
     <base href="/">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
-    <link rel="icon" type="image/x-icon" href="/_img/index/logobox.png">
+    <link rel="icon" type="image/x-icon" href="favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="assets/icons/icon-180x180.png">
     <link rel="manifest" href="manifest.json">
     <meta name="theme-color" content="#1976d2">


### PR DESCRIPTION
Fixes #922.

The app shell was still loading the favicon from the old site logo at `/_img/index/logobox.png`. This points the page at the app favicon instead and adds `src/favicon.ico` to the Angular build assets so the file is emitted.

Validation:
- `node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('angular.json','utf8')); if(!fs.existsSync('src/favicon.ico')) process.exit(1); console.log('angular.json ok; favicon exists');"`
- `git diff --check`

I did not run a full Angular build locally because dependencies are not installed in this checkout.