### PR TITLE
fix(mailviewer): hide empty overflow menu

### DIFF
--- a/src/app/mailviewer/singlemailviewer.component.html
+++ b/src/app/mailviewer/singlemailviewer.component.html
@@ -77,7 +77,7 @@
         matTooltip="Original HTML" [href]="'/rest/v1/email/'+messageId+'/html'" target="_blank">
         <mat-icon svgIcon="alert"></mat-icon>
       </a>
-      <button mat-icon-button *ngIf="morebuttonindex < 12" [matMenuTriggerFor]="moreMailActionsMenu" matTooltip="More message actions">
+      <button mat-icon-button *ngIf="hasHiddenToolbarActions()" [matMenuTriggerFor]="moreMailActionsMenu" matTooltip="More message actions">
         <mat-icon svgIcon="dots-vertical"></mat-icon>
       </button>
 
@@ -176,16 +176,16 @@
           <mat-icon svgIcon="block"></mat-icon>
           <span>Block Sender/Domain</span>
         </button>
-        <a *ngIf="morebuttonindex<9" mat-menu-item
+        <a *ngIf="morebuttonindex<10" mat-menu-item
           [href]="'/rest/v1/email/'+messageId+'/raw'" target="_blank">
           <mat-icon svgIcon="code-tags"></mat-icon>
           <span>View source</span>
         </a>
-        <button mat-menu-item *ngIf="mailContentHTML && morebuttonindex<10" [matMenuTriggerFor]="htmlSettingsMenu">
+        <button mat-menu-item *ngIf="mailContentHTML && morebuttonindex<11" [matMenuTriggerFor]="htmlSettingsMenu">
           <mat-icon svgIcon="cog"></mat-icon>
           <span>HTML settings</span>
         </button>
-	<a *ngIf="mailContentHTML && morebuttonindex<11" mat-menu-item
+	<a *ngIf="mailContentHTML && morebuttonindex<12" mat-menu-item
           [href]="'/rest/v1/email/'+messageId+'/html'" target="_blank">
           <mat-icon svgIcon="alert"></mat-icon>
 	  <span>Original HTML</span>

--- a/src/app/mailviewer/singlemailviewer.component.spec.ts
+++ b/src/app/mailviewer/singlemailviewer.component.spec.ts
@@ -215,6 +215,29 @@ describe('SingleMailViewerComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  it('does not show overflow menu for plaintext messages when every plaintext toolbar action fits', () => {
+    component.mailContentHTML = null;
+
+    component.morebuttonindex = 9;
+    expect(component.hasHiddenToolbarActions()).toBeTrue();
+
+    component.morebuttonindex = 10;
+    expect(component.hasHiddenToolbarActions()).toBeFalse();
+  });
+
+  it('keeps overflow menu visible when HTML-only toolbar actions are hidden', () => {
+    component.mailContentHTML = '<p>HTML content</p>';
+
+    component.morebuttonindex = 10;
+    expect(component.hasHiddenToolbarActions()).toBeTrue();
+
+    component.morebuttonindex = 11;
+    expect(component.hasHiddenToolbarActions()).toBeTrue();
+
+    component.morebuttonindex = 12;
+    expect(component.hasHiddenToolbarActions()).toBeFalse();
+  });
+
   it('show mail', fakeAsync(() => {
       expect(component).toBeTruthy();
 

--- a/src/app/mailviewer/singlemailviewer.component.ts
+++ b/src/app/mailviewer/singlemailviewer.component.ts
@@ -60,6 +60,8 @@ const resizerHeightKey = 'rmm7resizerheight';
 const resizerPercentageKey = 'rmm7resizerpercentage';
 
 const TOOLBAR_BUTTON_WIDTH = 30;
+const PLAINTEXT_TOOLBAR_ACTION_COUNT = 10;
+const HTML_TOOLBAR_ACTION_COUNT = 12;
 
 
 type Mail = any;
@@ -331,6 +333,15 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
       this.attachmentAreaCols = Math.floor(toolbarwidth / 150) + 1;
     }
   }
+
+  /**
+   * Returns true while the overflow menu contains at least one toolbar action.
+   */
+  public hasHiddenToolbarActions(): boolean {
+    const actionCount = this.mailContentHTML ? HTML_TOOLBAR_ACTION_COUNT : PLAINTEXT_TOOLBAR_ACTION_COUNT;
+    return this.morebuttonindex < actionCount;
+  }
+
   public changeOrientation(orientation: string) {
     this.orientationChangeRequest.emit(orientation);
   }


### PR DESCRIPTION
## Summary
- hide the mail viewer overflow button when a plaintext message has no hidden toolbar actions
- keep the overflow button visible for hidden HTML-only actions
- correct the overflow thresholds for View source, HTML settings, and Original HTML

## Tests
- RED: `npm test -- --watch=false --browsers=ChromeHeadless --include=src/app/mailviewer/singlemailviewer.component.spec.ts` failed with missing `hasHiddenToolbarActions`
- GREEN: `FIREFOX_BIN="/Users/moosaalinaseer/Library/Caches/ms-playwright/firefox-1522/firefox/Nightly.app/Contents/MacOS/firefox" npm test -- --watch=false --include=src/app/mailviewer/singlemailviewer.component.spec.ts` -> 10 SUCCESS
- `npm run lint -- runbox7` -> 0 errors, existing warnings only
- `npm run build` -> passed with existing warnings

## AI disclosure
This PR was developed with AI assistance from OpenAI Codex, with changes reviewed and verified locally before submission.

Fixes #656