### PR TITLE
fix(app): use bundled Runbox 7 favicon

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -5,7 +5,7 @@
     <title>Runbox 7</title>
     <base href="/">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
-    <link rel="icon" type="image/x-icon" href="/_img/index/logobox.png">
+    <link rel="icon" type="image/png" sizes="192x192" href="assets/icons/icon-192x192.png">
     <link rel="apple-touch-icon" sizes="180x180" href="assets/icons/icon-180x180.png">
     <link rel="manifest" href="manifest.json">
     <meta name="theme-color" content="#1976d2">


### PR DESCRIPTION
Updates the Runbox 7 web app favicon to use the bundled current Runbox 7 icon instead of the older external `/_img/index/logobox.png` asset.

Closes #922.

## Verification

- `npm.cmd run lint` passed with existing warnings only
- `npm.cmd run policy` passed with existing commit-history warnings only
- `npx.cmd ng build --configuration production --base-href=/app/ runbox7` passed
- Confirmed generated `dist/index.html` references `assets/icons/icon-192x192.png`
- Confirmed `dist/assets/icons/icon-192x192.png` exists

## Bounty

This addresses Runbox 7 good-first-issue #922, which appears eligible for the Runbox 7 Feature and Bug Bounty Program's minor-feature reward tier.

## AI assistance disclosure

I used Codex to inspect the issue, prepare the patch, and summarize test results. I reviewed the generated changes before submission.