### PR TITLE
fix(mail): hide empty more actions menu

### DIFF
--- a/src/app/mailviewer/singlemailviewer.component.html
+++ b/src/app/mailviewer/singlemailviewer.component.html
@@ -77,7 +77,7 @@
         matTooltip="Original HTML" [href]="'/rest/v1/email/'+messageId+'/html'" target="_blank">
         <mat-icon svgIcon="alert"></mat-icon>
       </a>
-      <button mat-icon-button *ngIf="morebuttonindex < 12" [matMenuTriggerFor]="moreMailActionsMenu" matTooltip="More message actions">
+      <button mat-icon-button *ngIf="morebuttonindex < 10 || (mailContentHTML && morebuttonindex < 12)" [matMenuTriggerFor]="moreMailActionsMenu" matTooltip="More message actions">
         <mat-icon svgIcon="dots-vertical"></mat-icon>
       </button>
 
@@ -176,16 +176,16 @@
           <mat-icon svgIcon="block"></mat-icon>
           <span>Block Sender/Domain</span>
         </button>
-        <a *ngIf="morebuttonindex<9" mat-menu-item
+        <a *ngIf="morebuttonindex<10" mat-menu-item
           [href]="'/rest/v1/email/'+messageId+'/raw'" target="_blank">
           <mat-icon svgIcon="code-tags"></mat-icon>
           <span>View source</span>
         </a>
-        <button mat-menu-item *ngIf="mailContentHTML && morebuttonindex<10" [matMenuTriggerFor]="htmlSettingsMenu">
+        <button mat-menu-item *ngIf="mailContentHTML && morebuttonindex<11" [matMenuTriggerFor]="htmlSettingsMenu">
           <mat-icon svgIcon="cog"></mat-icon>
           <span>HTML settings</span>
         </button>
-	<a *ngIf="mailContentHTML && morebuttonindex<11" mat-menu-item
+	<a *ngIf="mailContentHTML && morebuttonindex<12" mat-menu-item
           [href]="'/rest/v1/email/'+messageId+'/html'" target="_blank">
           <mat-icon svgIcon="alert"></mat-icon>
 	  <span>Original HTML</span>


### PR DESCRIPTION
Fixes #656.

This keeps the overflow menu hidden unless at least one action is actually moved into it. It also lines up the overflow entries with their matching toolbar buttons so "View source", "HTML settings", and "Original HTML" move into the menu at the same breakpoints where they disappear from the toolbar.

Checked:
- verified the overflow visibility matrix locally
- git diff --check

I also tried to install dependencies and run the TypeScript check, but the dependency install timed out in this environment, so I could not run the full project suite here.
