### PR TITLE
fix(index): clarify total messages in sync prompt

### DIFF
--- a/src/app/xapian/searchservice.ts
+++ b/src/app/xapian/searchservice.ts
@@ -726,15 +726,16 @@ export class SearchService {
                         0)
                         / (1024 * 1024)
                       );
-                  const totalMessages = partitions.reduce((prev, curr, partitionNdx) => prev +
-                        curr.numberOfMessages,
+                  const remainingMessages = partitions.reduce((prev, curr, partitionNdx) => prev +
+                        (partitionNdx < 1 ? 0 : curr.numberOfMessages),
                         0);
+                  const totalMessages = doccount + remainingMessages;
 
                   dialog.componentInstance.title = 'Continue synchronizing?';
                   dialog.componentInstance.question = `Already synchronized index for
                       ${doccount} of
-                      your most recent messages. To synchronize entire index
-                      (for ${totalMessages} messages),
+                      your most recent messages. To synchronize the entire index
+                      (${totalMessages} messages total),
                       there's an additional download of ${remainingDownloadMB} MB.`;
                   dialog.afterClosed()
                     .subscribe(res => {


### PR DESCRIPTION
## Summary
- clarify the additional index sync prompt so the parenthesized message count is shown as the total index size
- compute the total from the already synchronized count plus the remaining partitions still requiring confirmation

## Verification
- git diff --check
- verified the issue example numbers produce 83442 messages total and 31 MB remaining

Closes #1763