### PR TITLE
fix(identities): keep cancel edits out of preview

### DIFF
--- a/src/app/profiles/profiles.lister.ts
+++ b/src/app/profiles/profiles.lister.ts
@@ -46,7 +46,7 @@ export class ProfilesListerComponent {
     edit(item): void {
         this.dialog_ref = this.dialog.open(ProfilesEditorModalComponent, {
             width: '600px',
-            data: item,
+            data: { ...item },
         });
 
         this.dialog_ref.componentInstance.is_update = true;


### PR DESCRIPTION
## Summary
- pass a copy of the selected identity into the edit dialog
- keep unsaved edits from changing the identity card behind the dialog

## Verification
- git diff --check
- verified with a copy/mutation check that changing dialog data leaves the original identity unchanged

Closes #1571