### PR TITLE
feat(account): delete all trusted browsers

### DIFF
--- a/src/app/account-security/account.security.module.ts
+++ b/src/app/account-security/account.security.module.ts
@@ -41,6 +41,7 @@ import { MatLegacyTableModule as MatTableModule } from '@angular/material/legacy
 import { MatLegacyTabsModule as MatTabsModule } from '@angular/material/legacy-tabs';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatLegacyTooltipModule as MatTooltipModule } from '@angular/material/legacy-tooltip';
+import { DialogModule } from '../dialog/dialog.module';
 import {
     ModalPasswordComponent,
     ModalUnlockcodeComponent,
@@ -86,6 +87,7 @@ import { AccountPasswordComponent } from './account-password.component';
         MatTabsModule,
         MatToolbarModule,
         MatTooltipModule,
+        DialogModule,
         MenuModule,
         QRCodeModule,
         RunboxComponentModule,

--- a/src/app/account-security/two-factor-authentication.component.html
+++ b/src/app/account-security/two-factor-authentication.component.html
@@ -205,6 +205,12 @@
                     <div><button mat-raised-button class="primaryContentButton"
                             [disabled]="is_btn_trust_browser_disabled" (click)="device_trust_create()">Trust this
                             Browser</button></div>
+                    <div>
+                        <button mat-raised-button class="primaryContentButton"
+                            *ngIf="rmm.account_security.device.results && rmm.account_security.device.results.length > 0"
+                            [disabled]="is_busy_delete_all_devices"
+                            (click)="device_delete_all()">Delete all</button>
+                    </div>
                     <div>Suggestion: "Firefox on PC"</div>
                 </div>
             </div>

--- a/src/app/account-security/two-factor-authentication.component.ts
+++ b/src/app/account-security/two-factor-authentication.component.ts
@@ -22,8 +22,10 @@ import { MatLegacySnackBar as MatSnackBar } from '@angular/material/legacy-snack
 import { MatLegacyDialog as MatDialog } from '@angular/material/legacy-dialog';
 import { MobileQueryService } from '../mobile-query.service';
 import { RMM } from '../rmm';
-import { timeout, share } from 'rxjs/operators';
+import { from } from 'rxjs';
+import { timeout, share, concatMap, finalize } from 'rxjs/operators';
 import { ModalUnlockcodeComponent, ModalPasswordComponent } from './account.security.component';
+import { ConfirmDialog } from '../dialog/dialog.module';
 
 @Component({
     selector: 'app-two-factor-authentication',
@@ -43,6 +45,7 @@ export class TwoFactorAuthenticationComponent implements OnInit {
     trusted_browser_columns_mobile = ['name', 'status'];
     is_busy_otp_update = false;
     is_busy_unlock_code_update = false;
+    is_busy_delete_all_devices = false;
     modal_password_ref;
 
     constructor(public snackBar: MatSnackBar, public dialog: MatDialog, public mobileQuery: MobileQueryService, public rmm: RMM) {
@@ -304,6 +307,44 @@ export class TwoFactorAuthenticationComponent implements OnInit {
                     this.show_error(res.error || res.errors.join(''), 'Dismiss');
                 }
             });
+    }
+
+    device_delete_all() {
+        if (!this.rmm.account_security.user_password) {
+            this.show_modal_password();
+            return;
+        }
+        const devices = this.rmm.account_security.device.results || [];
+        if (devices.length === 0) {
+            return;
+        }
+
+        const confirmDialog = this.dialog.open(ConfirmDialog);
+        confirmDialog.componentInstance.title = 'Delete all trusted browsers?';
+        confirmDialog.componentInstance.question = 'This will remove every trusted browser from your account.';
+        confirmDialog.componentInstance.noOptionTitle = 'cancel';
+        confirmDialog.componentInstance.yesOptionTitle = 'delete all';
+        confirmDialog.afterClosed().subscribe((confirmed) => {
+            if (!confirmed) {
+                return;
+            }
+            this.is_busy_delete_all_devices = true;
+            from(devices).pipe(
+                concatMap(device => this.rmm.account_security.device.update({
+                    password: this.rmm.account_security.user_password,
+                    action: 'delete_device',
+                    id: device.id,
+                }, false)),
+                finalize(() => {
+                    this.is_busy_delete_all_devices = false;
+                    this.rmm.account_security.device.list();
+                })
+            ).subscribe((res) => {
+                if (res.status === 'error') {
+                    this.show_error(res.error || res.errors.join(''), 'Dismiss');
+                }
+            });
+        });
     }
 
     unlock_code_generate() {

--- a/src/app/rmm/account-security-device.ts
+++ b/src/app/rmm/account-security-device.ts
@@ -53,14 +53,16 @@ export class AccountSecurityDevice {
         return req;
     }
 
-    update(data): Observable<any> {
+    update(data, refresh = true): Observable<any> {
         this.is_busy = true;
         data = data || {
         };
         const req = this.app.ua.http.put('/ajax/ajax_mfa_device', data).pipe(timeout(60000), share());
         req.subscribe(
           reply => {
-            this.list();
+            if (refresh) {
+                this.list();
+            }
             this.is_busy = false;
             if ( reply['status'] === 'error' ) {
                 this.app.show_error( reply['error'].join( '' ), 'Dismiss' );


### PR DESCRIPTION
Fixes #848.

## Summary
- Adds a Delete all action to the Trusted Browsers section when entries exist.
- Requires confirmation before deleting every trusted browser.
- Reuses the existing device delete endpoint and skips per-device list refreshes during batch deletion, refreshing once at the end.

## Validation
- `git diff --check`

Note: I could not run the Angular test/lint scripts locally because npm is not available in this environment.