### PR TITLE
Show email address on sender hover

### DIFF
--- a/src/app/common/messagelist.spec.ts
+++ b/src/app/common/messagelist.spec.ts
@@ -1,0 +1,80 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2022 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { MessageInfo } from './messageinfo';
+import { MessageList } from './messagelist';
+import { MailAddressInfo } from './mailaddressinfo';
+
+describe('MessageList', () => {
+    const getMessageList = (fromAddress: string, toAddress: string) => new MessageList([
+        new MessageInfo(
+            1,
+            new Date(),
+            new Date(),
+            'Inbox',
+            false,
+            false,
+            false,
+            MailAddressInfo.parse(fromAddress),
+            MailAddressInfo.parse(toAddress),
+            [],
+            [],
+            'Test subject',
+            'Test message',
+            42,
+            false
+        )
+    ]);
+
+    it('shows the sender email address in the From column tooltip', () => {
+        const messageList = getMessageList(
+            '"Runbox Support" <support@example.com>',
+            '"Customer" <customer@example.com>'
+        );
+        const columns = messageList.getCanvasTableColumns({ selectedFolder: 'Inbox' });
+        const fromColumn = columns.find((column) => column.name === 'From');
+
+        expect(fromColumn.getValue(0)).toBe('Runbox Support');
+        expect((fromColumn.tooltipText as (rowIndex: number) => string)(0)).toBe('support@example.com');
+    });
+
+    it('shows the recipient email address in the Sent folder To column tooltip', () => {
+        const messageList = getMessageList(
+            '"Runbox User" <user@example.com>',
+            '"Customer" <customer@example.com>'
+        );
+        const columns = messageList.getCanvasTableColumns({ selectedFolder: 'Sent' });
+        const toColumn = columns.find((column) => column.name === 'To');
+
+        expect(toColumn.getValue(0)).toBe('Customer');
+        expect((toColumn.tooltipText as (rowIndex: number) => string)(0)).toBe('customer@example.com');
+    });
+
+    it('does not add a duplicate tooltip when the email address is already visible', () => {
+        const messageList = getMessageList(
+            'support@example.com',
+            'customer@example.com'
+        );
+        const columns = messageList.getCanvasTableColumns({ selectedFolder: 'Inbox' });
+        const fromColumn = columns.find((column) => column.name === 'From');
+
+        expect(fromColumn.getValue(0)).toBe('support@example.com');
+        expect((fromColumn.tooltipText as (rowIndex: number) => string)(0)).toBeNull();
+    });
+});

--- a/src/app/common/messagelist.ts
+++ b/src/app/common/messagelist.ts
@@ -62,6 +62,25 @@ export class MessageList extends MessageDisplay {
     '';
   }
 
+  getFromColumnTooltipValueForRow(rowIndex: number): string {
+    return this.getMailAddressTooltipValueForRow(rowIndex, 'from');
+  }
+
+  getToColumnTooltipValueForRow(rowIndex: number): string {
+    return this.getMailAddressTooltipValueForRow(rowIndex, 'to');
+  }
+
+  private getMailAddressTooltipValueForRow(rowIndex: number, addressListKey: 'from' | 'to'): string {
+    const rowobj = this.rows[rowIndex];
+    const addressInfo = rowobj[addressListKey] && rowobj[addressListKey].length > 0 ?
+      rowobj[addressListKey][0] :
+      null;
+
+    return addressInfo && addressInfo.name && addressInfo.address && addressInfo.name !== addressInfo.address ?
+      addressInfo.address :
+      null;
+  }
+
   // filter visible rows by whatever options the frontend has
   filterBy(options: Map<string, any>) {
     this.rows = this._rows;
@@ -97,6 +116,9 @@ export class MessageList extends MessageDisplay {
         getValue: (rowIndex: number): any => app.selectedFolder === 'Sent'
           ? this.getToColumnValueForRow(rowIndex)
           : this.getFromColumnValueForRow(rowIndex),
+        tooltipText: (rowIndex: number): string => app.selectedFolder === 'Sent'
+          ? this.getToColumnTooltipValueForRow(rowIndex)
+          : this.getFromColumnTooltipValueForRow(rowIndex),
         draggable: true
       },
       {

--- a/src/app/websocketsearch/websocketsearchmaillist.spec.ts
+++ b/src/app/websocketsearch/websocketsearchmaillist.spec.ts
@@ -1,0 +1,60 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2020 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { WebSocketSearchMailList } from './websocketsearchmaillist';
+
+describe('WebSocketSearchMailList', () => {
+    it('shows the sender email address in the From column tooltip', () => {
+        const messageList = new WebSocketSearchMailList([
+            {
+                id: 1,
+                dateTime: '20260609',
+                subject: 'Test subject',
+                fromName: 'Runbox Support',
+                fromAddr: 'support@example.com',
+                seen: false,
+                size: 42
+            }
+        ]);
+        const columns = messageList.getCanvasTableColumns({});
+        const fromColumn = columns.find((column) => column.name === 'From');
+
+        expect(fromColumn.getValue(0)).toBe('Runbox Support');
+        expect((fromColumn.tooltipText as (rowIndex: number) => string)(0)).toBe('support@example.com');
+    });
+
+    it('does not add a duplicate tooltip when the email address is already visible', () => {
+        const messageList = new WebSocketSearchMailList([
+            {
+                id: 1,
+                dateTime: '20260609',
+                subject: 'Test subject',
+                fromName: 'support@example.com',
+                fromAddr: 'support@example.com',
+                seen: false,
+                size: 42
+            }
+        ]);
+        const columns = messageList.getCanvasTableColumns({});
+        const fromColumn = columns.find((column) => column.name === 'From');
+
+        expect(fromColumn.getValue(0)).toBe('support@example.com');
+        expect((fromColumn.tooltipText as (rowIndex: number) => string)(0)).toBeNull();
+    });
+});

--- a/src/app/websocketsearch/websocketsearchmaillist.ts
+++ b/src/app/websocketsearch/websocketsearchmaillist.ts
@@ -51,6 +51,13 @@ export class WebSocketSearchMailList extends MessageDisplay {
     }
   }
 
+  getFromColumnTooltipValueForRow(rowIndex: number): string {
+    const row = this.getRow(rowIndex);
+    return row.fromName && row.fromAddr && row.fromName !== row.fromAddr ?
+      row.fromAddr :
+      null;
+  }
+
     public getCanvasTableColumns(app: any): CanvasTableColumn[] {
         const columns: CanvasTableColumn[] = [
             {
@@ -75,6 +82,7 @@ export class WebSocketSearchMailList extends MessageDisplay {
                 cacheKey: 'from',
                 sortColumn: null,
                 getValue: (rowIndex: number): string => this.getRow(rowIndex).fromName,
+                tooltipText: (rowIndex: number): string => this.getFromColumnTooltipValueForRow(rowIndex),
             },
             {
                 name: 'Subject',


### PR DESCRIPTION
Fixes #1852.

Summary:
- Adds email-address tooltip callbacks for the message-list From column when a display name is shown.
- Keeps the Sent-folder To column consistent by showing the recipient address on hover when a recipient display name is shown.
- Adds the same sender-address hover behavior for websocket search result rows.
- Avoids duplicate hover text when the visible value is already the email address.

Tests:
- The first commit contains only the specs, so it can be cherry-picked separately from the implementation. In that intermediate state, the targeted specs fail because the columns do not provide `tooltipText` callbacks.
- `npm run test -- --watch=false --progress=false --browsers=FirefoxHeadless --include=src/app/common/messagelist.spec.ts --include=src/app/websocketsearch/websocketsearchmaillist.spec.ts`
- `npm run test -- --watch=false --progress=false --browsers=FirefoxHeadless` (`250 SUCCESS`, `2 skipped`)
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npm run lint` (exits successfully; existing warning set remains)
- `npm run policy` (exits successfully; it still prints historical commit-message notices from existing repository history)

AI assistance:
OpenAI Codex was used for local code search, implementation drafting, and validation notes for this PR. I reviewed the resulting patch and test output before submission.