### PR TITLE
Move settings sidebar legacy tooltips aside

### DIFF
--- a/src/app/account-app/account-app.component.html
+++ b/src/app/account-app/account-app.component.html
@@ -29,21 +29,21 @@
                     </p>
                 </mat-expansion-panel-header>
                 <a href="/mail/fetch" target="rmm6">
-                    <mat-list-item [matTooltip]="rmm6tooltip">
+                    <mat-list-item [matTooltip]="rmm6tooltip" matTooltipPosition="right">
                         <p mat-line>
                             <mat-icon mat-list-icon svgIcon="cloud-download"></mat-icon> <span>Retrieve</span>
                         </p>
                     </mat-list-item>
                 </a>
                 <a href="/mail/rules" target="rmm6">
-                    <mat-list-item [matTooltip]="rmm6tooltip">
+                    <mat-list-item [matTooltip]="rmm6tooltip" matTooltipPosition="right">
                         <p mat-line>
                             <mat-icon mat-list-icon svgIcon="filter-variant"></mat-icon> <span>Filter</span>
                         </p>
                     </mat-list-item>
                 </a>
                 <a href="/mail/access" target="rmm6">
-                    <mat-list-item [matTooltip]="rmm6tooltip">
+                    <mat-list-item [matTooltip]="rmm6tooltip" matTooltipPosition="right">
                         <p mat-line>
                             <mat-icon mat-list-icon svgIcon="download"></mat-icon> <span>Access</span>
                         </p>
@@ -59,21 +59,21 @@
                     </p>
                 </mat-expansion-panel-header>
                 <a href="/mail/account_domain" target="rmm6">
-                    <mat-list-item [matTooltip]="rmm6tooltip">
+                    <mat-list-item [matTooltip]="rmm6tooltip" matTooltipPosition="right">
                         <p mat-line>
                             <mat-icon mat-list-icon svgIcon="email"></mat-icon> <span>Email Hosting</span>
                         </p>
                     </mat-list-item>
                 </a>
                 <a href="/mail/account_domain_hosting" target="rmm6">
-                    <mat-list-item [matTooltip]="rmm6tooltip">
+                    <mat-list-item [matTooltip]="rmm6tooltip" matTooltipPosition="right">
                         <p mat-line>
                             <mat-icon mat-list-icon svgIcon="domain"></mat-icon> <span>Domain Hosting</span>
                         </p>
                     </mat-list-item>
                 </a>
                 <a href="/mail/account_webhosting" target="rmm6">
-                    <mat-list-item [matTooltip]="rmm6tooltip">
+                    <mat-list-item [matTooltip]="rmm6tooltip" matTooltipPosition="right">
                         <p mat-line>
                             <mat-icon mat-list-icon svgIcon="earth"></mat-icon> <span>Web Hosting</span>
                         </p>
@@ -109,7 +109,7 @@
                     </p>
                 </mat-list-item>
                 <a href="/mail/account_account" target="rmm6" *ngIf="isMainAccount">
-                    <mat-list-item [matTooltip]="rmm6tooltip">
+                    <mat-list-item [matTooltip]="rmm6tooltip" matTooltipPosition="right">
                         <p mat-line>
                             <mat-icon mat-list-icon svgIcon="account-supervisor"></mat-icon> <span>Sub-Accounts</span>
                         </p>

--- a/src/app/account-app/account-app.component.spec.ts
+++ b/src/app/account-app/account-app.component.spec.ts
@@ -1,0 +1,89 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2021 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { CommonModule } from '@angular/common';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { MatLegacyButtonModule as MatButtonModule } from '@angular/material/legacy-button';
+import { MatLegacyListModule as MatListModule } from '@angular/material/legacy-list';
+import { MatLegacyTooltipModule as MatTooltipModule, MatLegacyTooltip as MatTooltip } from '@angular/material/legacy-tooltip';
+import { MatBadgeModule } from '@angular/material/badge';
+import { MatExpansionModule } from '@angular/material/expansion';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { RouterTestingModule } from '@angular/router/testing';
+import { By } from '@angular/platform-browser';
+import { of } from 'rxjs';
+
+import { AccountAppComponent } from './account-app.component';
+import { CartService } from './cart.service';
+import { MobileQueryService } from '../mobile-query.service';
+import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
+
+describe('AccountAppComponent', () => {
+    let component: AccountAppComponent;
+    let fixture: ComponentFixture<AccountAppComponent>;
+
+    beforeEach(waitForAsync(() => {
+        TestBed.configureTestingModule({
+            declarations: [
+                AccountAppComponent,
+            ],
+            imports: [
+                CommonModule,
+                MatBadgeModule,
+                MatButtonModule,
+                MatExpansionModule,
+                MatListModule,
+                MatTooltipModule,
+                NoopAnimationsModule,
+                RouterTestingModule,
+            ],
+            providers: [
+                { provide: CartService, useValue: {
+                    items: of([]),
+                } },
+                { provide: MobileQueryService, useValue: {
+                    matches: false,
+                } },
+                { provide: RunboxWebmailAPI, useValue: {
+                    me: of({ owner: false }),
+                } },
+            ],
+            schemas: [
+                NO_ERRORS_SCHEMA,
+            ],
+        }).compileComponents();
+    }));
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(AccountAppComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('places legacy Runbox 6 sidebar tooltips to the right of menu items', () => {
+        const tooltips = fixture.debugElement
+            .queryAll(By.directive(MatTooltip))
+            .map(element => element.injector.get(MatTooltip))
+            .filter(tooltip => tooltip.message === component.rmm6tooltip);
+
+        expect(tooltips.length).toBe(7);
+        expect(tooltips.every(tooltip => tooltip.position === 'right')).toBeTrue();
+    });
+});


### PR DESCRIPTION
## Summary
- Place the legacy Runbox 6 settings-sidebar tooltips to the right of their menu items.
- Add a regression spec that checks each legacy sidebar link uses that placement.

Closes #1853

## Verification
- `npm run test -- --watch=false --progress=false --browsers=FirefoxHeadless --include src/app/account-app/account-app.component.spec.ts` (fails on current `master` before the template change, passes after)
- `npm run test -- --watch=false --progress=false --browsers=FirefoxHeadless` (246 success, 2 skipped; command exited 0)
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npm run lint` (exits 0; existing warnings remain)
- `npm run policy` (exits 0; existing historical commit-message notices remain)

Not run: `npm run build`, because the build script performs git checkout/reset operations.

## Notes
- The regression test is committed separately from the implementation.
- This PR was prepared with AI-assisted source review, implementation, and test drafting, with local validation run before submission.