### PR TITLE
Fix From/To column during folder switches

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -870,10 +870,12 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
       }
     }
     if (displayType === 'messagelist') {
+      const folderContext = args[1] || this.selectedFolder;
       if (this.canvastable.rows instanceof MessageList) {
         this.canvastable.updateRows(args[0]);
+        this.canvastable.rows.setFolderContext(folderContext);
       } else {
-        this.canvastable.rows = new MessageList(...args);
+        this.canvastable.rows = new MessageList(args[0], folderContext);
         // messages updated, check if we need to select a message from the fragment
         this.selectMessageFromFragment(this.fragment);
       }

--- a/src/app/common/messagelist.spec.ts
+++ b/src/app/common/messagelist.spec.ts
@@ -1,0 +1,59 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2022 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { MailAddressInfo } from './mailaddressinfo';
+import { MessageList } from './messagelist';
+
+describe('MessageList', () => {
+  function message() {
+    return {
+      id: 1,
+      messageDate: new Date('2026-06-09T12:00:00Z'),
+      seenFlag: false,
+      answeredFlag: false,
+      flaggedFlag: false,
+      from: [new MailAddressInfo('Sender Name', 'sender@example.com')],
+      to: [new MailAddressInfo('Recipient Name', 'recipient@example.com')],
+      subject: 'Folder switch',
+      plaintext: 'Body',
+      size: 1024,
+      attachment: false
+    };
+  }
+
+  function fromColumn(messageList: MessageList, selectedFolder: string) {
+    return messageList.getCanvasTableColumns({ selectedFolder }).find(column => column.cacheKey === 'from');
+  }
+
+  it('keeps showing From for inbox rows while the selected folder changes to Sent', () => {
+    const messageList = new MessageList([message()], 'Inbox');
+    const column = fromColumn(messageList, 'Sent');
+
+    expect(column.name).toBe('From');
+    expect(column.getValue(0)).toBe('Sender Name');
+  });
+
+  it('keeps showing To for sent rows while the selected folder changes away from Sent', () => {
+    const messageList = new MessageList([message()], 'Sent');
+    const column = fromColumn(messageList, 'Inbox');
+
+    expect(column.name).toBe('To');
+    expect(column.getValue(0)).toBe('Recipient Name');
+  });
+});

--- a/src/app/common/messagelist.ts
+++ b/src/app/common/messagelist.ts
@@ -23,10 +23,21 @@ import { MessageTableRowTool} from '../messagetable/messagetablerow';
 import { CanvasTableColumn } from '../canvastable/canvastablecolumn';
 
 export class MessageList extends MessageDisplay {
+  private folderContext: string;
 
   // MessageDisplay implementations have different numbers of arguments..
   constructor(...args: any[]) {
     super(args[0]);
+    this.setFolderContext(args[1]);
+  }
+
+  setFolderContext(folder: string) {
+    this.folderContext = folder;
+  }
+
+  private isSentFolder(app: any): boolean {
+    const folder = this.folderContext || app.selectedFolder;
+    return !!folder && folder.startsWith('Sent');
   }
 
   getRowSeen(index: number): boolean {
@@ -71,6 +82,7 @@ export class MessageList extends MessageDisplay {
   }
 
   public getCanvasTableColumns(app: any): CanvasTableColumn[] {
+    const isSentFolder = this.isSentFolder(app);
     const columns: CanvasTableColumn[] = [
       {
         sortColumn: null,
@@ -91,10 +103,10 @@ export class MessageList extends MessageDisplay {
         draggable: true
       },
       {
-        name: app.selectedFolder === 'Sent' ? 'To' : 'From',
+        name: isSentFolder ? 'To' : 'From',
         cacheKey: 'from',
         sortColumn: null,
-        getValue: (rowIndex: number): any => app.selectedFolder === 'Sent'
+        getValue: (rowIndex: number): any => isSentFolder
           ? this.getToColumnValueForRow(rowIndex)
           : this.getFromColumnValueForRow(rowIndex),
         draggable: true


### PR DESCRIPTION
Fixes #1825.

## What changed

- Keeps a `MessageList` folder context so rows from the previous folder do not immediately reinterpret their From/To column when `selectedFolder` changes.
- Updates the message-list context when new folder rows are swapped into the canvas table.
- Adds regression coverage for both switch directions: Inbox rows while the selected folder has already changed to Sent, and Sent rows while the selected folder has already changed away from Sent.

## Validation

- Before the implementation commit, `npm run test -- --watch=false --progress=false --browsers=FirefoxHeadless --include=src/app/common/messagelist.spec.ts` failed with the new regression expectations.
- After the implementation commit, the same targeted command passed: `2 SUCCESS`.
- `npm run test -- --watch=false --progress=false --browsers=FirefoxHeadless` passed: `247 SUCCESS`, `2 skipped`.
- `npx tsc -p src/tsconfig.app.json --noEmit` passed.
- `npm run lint` exited 0 with the existing repository warning set.
- `npm run policy` exited 0; it still reports historical commit-message notices from existing repository history, not from these commits.

I did not run `npm run build` because the build script performs git checkout/reset operations on generated/config files.

## AI disclosure

This PR was prepared with AI assistance from OpenAI/Codex. I reviewed the code, commits, and validation results before submitting.
