### PR TITLE
Skip PayPal confirm on cancel returns

### DIFF
--- a/src/app/account-app/paypal-handler.component.spec.ts
+++ b/src/app/account-app/paypal-handler.component.spec.ts
@@ -1,0 +1,87 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { ActivatedRoute } from '@angular/router';
+import { Subject, of } from 'rxjs';
+import { PaypalHandlerComponent } from './paypal-handler.component';
+
+function buildComponent(action: string, queryParams: Record<string, string> = {}) {
+    const routeParams = new Subject<Record<string, string>>();
+    const paypalQueryParams = new Subject<Record<string, string>>();
+    const cart = jasmine.createSpyObj('CartService', ['clear']);
+    const rmmapi = jasmine.createSpyObj('RunboxWebmailAPI', ['confirmPaypalPayment']);
+    const router = jasmine.createSpyObj('Router', ['navigateByUrl']);
+
+    rmmapi.confirmPaypalPayment.and.returnValue(of({ tid: 12345 }));
+
+    new PaypalHandlerComponent(
+        cart,
+        rmmapi,
+        {
+            params: routeParams.asObservable(),
+            queryParams: paypalQueryParams.asObservable()
+        } as Partial<ActivatedRoute> as ActivatedRoute,
+        router
+    );
+
+    routeParams.next({ action });
+    paypalQueryParams.next(queryParams);
+
+    return { cart, rmmapi, router, routeParams, paypalQueryParams };
+}
+
+describe('PaypalHandlerComponent', () => {
+    it('confirms a PayPal payment once and then opens the receipt', () => {
+        const { cart, rmmapi, router, paypalQueryParams } = buildComponent('confirm', {
+            paymentId: 'PAY-123',
+            PayerID: 'PAYER-456'
+        });
+
+        paypalQueryParams.next({
+            paymentId: 'PAY-123',
+            PayerID: 'PAYER-456',
+            ignored: 're-emission'
+        });
+
+        expect(rmmapi.confirmPaypalPayment).toHaveBeenCalledOnceWith('PAY-123', 'PAYER-456');
+        expect(cart.clear).toHaveBeenCalledTimes(1);
+        expect(router.navigateByUrl).toHaveBeenCalledOnceWith('/account/receipt/12345');
+    });
+
+    it('does not confirm payments when PayPal returns to the cancel route', () => {
+        const { cart, rmmapi, router } = buildComponent('cancel', {
+            paymentId: 'PAY-123',
+            PayerID: 'PAYER-456'
+        });
+
+        expect(rmmapi.confirmPaypalPayment).not.toHaveBeenCalled();
+        expect(cart.clear).not.toHaveBeenCalled();
+        expect(router.navigateByUrl).toHaveBeenCalledOnceWith('/account/cart');
+    });
+
+    it('does not call confirm without both PayPal return identifiers', () => {
+        const { cart, rmmapi, router } = buildComponent('confirm', {
+            paymentId: 'PAY-123'
+        });
+
+        expect(rmmapi.confirmPaypalPayment).not.toHaveBeenCalled();
+        expect(cart.clear).not.toHaveBeenCalled();
+        expect(router.navigateByUrl).toHaveBeenCalledOnceWith('/account/cart');
+    });
+});

--- a/src/app/account-app/paypal-handler.component.ts
+++ b/src/app/account-app/paypal-handler.component.ts
@@ -19,6 +19,7 @@
 
 import { Component } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
+import { combineLatest, take } from 'rxjs';
 import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
 import { CartService } from './cart.service';
 
@@ -38,12 +39,21 @@ export class PaypalHandlerComponent {
         private route:  ActivatedRoute,
         private router: Router,
     ) {
-        // TODO: this assumes /paypal/confirm. We should handle /paypal/cancel too
-        this.route.queryParams.subscribe(params => {
+        combineLatest([this.route.params, this.route.queryParams]).pipe(take(1)).subscribe(([routeParams, params]) => {
+            if (routeParams['action'] !== 'confirm') {
+                this.router.navigateByUrl('/account/cart');
+                return;
+            }
+
             // yes, the capitalization of params is inconsistent
             // there's not typo: it's just Paypal :)
             const payment_id = params['paymentId'];
             const payer_id   = params['PayerID'];
+            if (!payment_id || !payer_id) {
+                this.router.navigateByUrl('/account/cart');
+                return;
+            }
+
             this.rmmapi.confirmPaypalPayment(payment_id, payer_id).subscribe(res => {
                 console.log(res);
                 this.cart.clear();


### PR DESCRIPTION
Fixes #1755.

## What changed

- Reads the PayPal return route action before confirming a payment.
- Redirects `/account/paypal/cancel` and incomplete confirm callbacks back to the cart without calling `confirmPaypalPayment`.
- Handles the return observables once so a query-param re-emission cannot repeat PayPal confirmation or cart clearing.
- Adds regression coverage for confirm, cancel, and missing PayPal identifiers.

## Validation

- `npm run test -- --watch=false --progress=false --browsers=FirefoxHeadless --include=src/app/account-app/paypal-handler.component.spec.ts` passed: `3 SUCCESS`.
- `node run-ci-tests.js lint unit` passed: full unit suite `248 SUCCESS`, `2 skipped`; lint exited 0 with the existing repository warning set.
- `npx tsc -p src/tsconfig.app.json --noEmit` passed.
- `npm run policy` exited 0; it still reports historical commit-message notices from existing repository history, not from these commits.

I did not run `npm run build` because the build script performs git checkout/reset operations on generated/config files.

## Notes

- The regression test is committed separately from the implementation.
- This PR was prepared with AI assistance from OpenAI/Codex for source review, implementation drafting, and validation notes. I reviewed the patch, commits, and test output before submitting.