### PR TITLE
Show auth errors before expired account prompts

### DIFF
--- a/src/app/login/login.component.spec.ts
+++ b/src/app/login/login.component.spec.ts
@@ -1,0 +1,66 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { LoginComponent } from './login.component';
+
+describe('LoginComponent', () => {
+    let component: LoginComponent;
+
+    beforeEach(() => {
+        component = new LoginComponent({} as any, {} as any, {} as any, {} as any, {} as any);
+    });
+
+    function handleLoginError(response: any) {
+        (component as any).handleLoginError(response);
+    }
+
+    function resetLoginErrors() {
+        (component as any).login_errors_reset();
+    }
+
+    it('shows authentication errors before expired subscription renewal prompts', () => {
+        handleLoginError({
+            code: 401,
+            error: 'Incorrect username or password',
+            user_status: '4',
+        });
+
+        expect(component.login_error_html).toContain('Incorrect username or password');
+        expect(component.accountExpiredSubscription).toBeFalse();
+    });
+
+    it('still shows expired subscription prompts when no authentication error is present', () => {
+        handleLoginError({
+            user_status: '4',
+        });
+
+        expect(component.accountExpiredSubscription).toBeTrue();
+        expect(component.login_error_html).toBeUndefined();
+    });
+
+    it('clears account-status prompts before the next login attempt', () => {
+        handleLoginError({
+            user_status: '4',
+        });
+
+        resetLoginErrors();
+
+        expect(component.accountExpiredSubscription).toBeFalse();
+    });
+});

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -133,6 +133,11 @@ export class LoginComponent implements OnInit {
         };
         if (!loginresonseobj.is_2fa_enabled && loginresonseobj.code && error_msgs_1fa[loginresonseobj.code]) {
             this.login_error_html = '<p>' + error_msgs_1fa[loginresonseobj.code] + '</p>';
+            return;
+        }
+        if (loginresonseobj.error) {
+            this.login_error_html = '<p>' + (loginresonseobj.error || 'Error occurred') + '</p>';
+            return;
         }
         if (loginresonseobj.user_status === '1') {
             this.accountSuspended = true;
@@ -146,8 +151,6 @@ export class LoginComponent implements OnInit {
             this.accountCanceled = true;
         } else if (loginresonseobj.user_status > 5) {
             this.accountClosed = true;
-        } else if (loginresonseobj.error) {
-            this.login_error_html = '<p>' + (loginresonseobj.error || 'Error occurred') + '</p>';
         } else {
             this.accountError = true;
         }
@@ -176,5 +179,11 @@ export class LoginComponent implements OnInit {
 
     private login_errors_reset() {
         this.login_error_html = undefined;
+        this.accountSuspended = false;
+        this.accountExpiredTrial = false;
+        this.accountExpiredSubscription = false;
+        this.accountCanceled = false;
+        this.accountClosed = false;
+        this.accountError = false;
     }
 }


### PR DESCRIPTION
Fixes #1554.

## What changed

- Shows explicit authentication errors before account-status prompts when a login response includes both.
- Clears account-status prompts before each new login attempt so stale expired/suspended/canceled messages do not remain visible after the next response.
- Adds focused regression coverage for the expired-subscription + wrong-password response path.

## Validation

- Before the implementation commit, `npx ng test --include="src/app/login/login.component.spec.ts" --watch=false --browsers=FirefoxHeadless` failed with the new regression expectations: `2 FAILED`, `1 SUCCESS`.
- After the implementation commit, the same targeted command passed: `3 SUCCESS`.
- `node run-ci-tests.js lint unit` passed: full unit suite `248 SUCCESS`, `2 skipped`; lint exited 0 with the existing repository warning set.
- `npx tsc --noEmit` passed.
- `npm run policy` exited 0; it still reports historical commit-message notices from existing repository history, not from these commits.

I did not run `npm run build` because the build script performs git checkout/reset operations on generated/config files.

## Notes

- The regression test is committed separately from the implementation.
- This PR was prepared with AI assistance from OpenAI/Codex for source review, implementation drafting, and validation notes. I reviewed the patch, commits, and test output before submitting.