### PR TITLE
Optionally show sender email in message list

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -347,6 +347,17 @@
                 Inline previews
               </mat-checkbox>
             </mat-list-item>
+            <mat-list-item>
+              <mat-checkbox [(ngModel)]="showFromEmailColumn"
+                            matLine
+                            (change)="saveFromEmailColumnSetting()"
+                            (click)="$event.stopPropagation()"
+                            class="tableViewOptionsMenuElement"
+                            >
+                <mat-icon  svgIcon="email" class="tableViewOptionsMenuElement" matTooltip="Show sender email address"></mat-icon>
+                Sender email
+              </mat-checkbox>
+            </mat-list-item>
             <!-- currently only supporting threading for local index -->
             <mat-list-item>
               <mat-checkbox [(ngModel)]="conversationGroupingCheckbox"

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -71,6 +71,7 @@ const LOCAL_STORAGE_SETTING_MAILVIEWER_ON_RIGHT_SIDE_IF_MOBILE = 'mailViewerOnRi
 const LOCAL_STORAGE_SETTING_MAILVIEWER_ON_RIGHT_SIDE = 'mailViewerOnRightSide';
 const LOCAL_STORAGE_VIEWMODE = 'rmm7mailViewerViewMode';
 const LOCAL_STORAGE_SHOWCONTENTPREVIEW = 'rmm7mailViewerContentPreview';
+const LOCAL_STORAGE_SHOW_FROM_EMAIL_COLUMN = 'rmm7mailViewerShowFromEmailColumn';
 const LOCAL_STORAGE_KEEP_PANE = 'keepMessagePaneOpen';
 const LOCAL_STORAGE_SHOW_UNREAD_ONLY = 'rmm7mailViewerShowUnreadOnly';
 const LOCAL_STORAGE_SHOW_POPULAR_RECIPIENTS = 'showPopularRecipients';
@@ -96,6 +97,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
   preferences: Map<string, any> = new Map();
   viewmode = 'messages';
   keepMessagePaneOpen = true;
+  showFromEmailColumn = false;
   conversationGroupingCheckbox = false;
   conversationGroupingToolTip = 'Threaded conversation view';
   unreadMessagesOnlyCheckbox = false;
@@ -302,6 +304,8 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
         this.canvastable.columnWidths = prefs.get(`${this.preferenceService.prefGroup}:canvasNamedColumnWidthsBySet`) || {};
       }
       this.keepMessagePaneOpen = prefs.get(`${this.preferenceService.prefGroup}:${LOCAL_STORAGE_KEEP_PANE}`) === 'true';
+      const previousShowFromEmailColumn = this.showFromEmailColumn;
+      this.showFromEmailColumn = prefs.get(`${this.preferenceService.prefGroup}:${LOCAL_STORAGE_SHOW_FROM_EMAIL_COLUMN}`) === 'true';
       this.unreadMessagesOnlyCheckbox = prefs.get(`${DefaultPrefGroups.Global}:${LOCAL_STORAGE_SHOW_UNREAD_ONLY}`) === 'true';
       this.viewmode = prefs.get(`${this.preferenceService.prefGroup}:${LOCAL_STORAGE_VIEWMODE}`);
       this.conversationGroupingCheckbox = !this.unreadMessagesOnlyCheckbox && this.viewmode === 'conversations';
@@ -327,6 +331,10 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
       this.avatarSource = prefs.get(`${this.preferenceService.prefGroup}:avatarSource`);
 
       this.preferences = prefs;
+
+      if (previousShowFromEmailColumn !== this.showFromEmailColumn && this.canvastable && this.canvastable.rows) {
+        this.resetColumns();
+      }
     });
     // localSearchIndexPrompted isnt a "preference" (users cant change it back)
     // and we want it to prompt for eeach new device:
@@ -676,6 +684,12 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     const setting = this.canvastable.showContentTextPreview ? 'true' : 'false';
     this.preferenceService.set(this.preferenceService.prefGroup, LOCAL_STORAGE_SHOWCONTENTPREVIEW, setting);
 //    localStorage.setItem(LOCAL_STORAGE_SHOWCONTENTPREVIEW, setting);
+  }
+
+  saveFromEmailColumnSetting(): void {
+    const setting = this.showFromEmailColumn ? 'true' : 'false';
+    this.preferenceService.set(this.preferenceService.prefGroup, LOCAL_STORAGE_SHOW_FROM_EMAIL_COLUMN, setting);
+    this.resetColumns();
   }
 
   public trainSpam(params) {
@@ -1229,11 +1243,16 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
   }
 
   resetColumns() {
-    if (this.canvastable && this.canvastable.rows) {
+    if (!this.canvastable) {
+      return;
+    }
+    if (this.canvastable.rows) {
       this.canvastable.columns = this.canvastable.rows.getCanvasTableColumns(this);
     }
-    this.canvastable.rowWrapModeWrapColumn = 3;
-    this.canvastable.rowWrapModeDefaultSelectedColumn = 3;
+    const subjectColumnIndex = this.canvastable.columns.findIndex(column => column.cacheKey === 'subject');
+    const rowWrapColumn = subjectColumnIndex > -1 ? subjectColumnIndex : 3;
+    this.canvastable.rowWrapModeWrapColumn = rowWrapColumn;
+    this.canvastable.rowWrapModeDefaultSelectedColumn = rowWrapColumn;
     this.autoAdjustColumnWidths();
   }
 

--- a/src/app/canvastable/canvastable.ts
+++ b/src/app/canvastable/canvastable.ts
@@ -156,6 +156,7 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
     'Date':    110,
     'To':      300,
     'From':    300,
+    'From Email': 220,
     'Subject': 300,
     'Size':    80,
     'Count':   80,

--- a/src/app/common/messagelist.spec.ts
+++ b/src/app/common/messagelist.spec.ts
@@ -1,0 +1,64 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2022 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { MailAddressInfo } from './mailaddressinfo';
+import { MessageList } from './messagelist';
+
+describe('MessageList', () => {
+  function message() {
+    return {
+      id: 1,
+      messageDate: new Date('2026-06-09T12:00:00Z'),
+      seenFlag: false,
+      answeredFlag: false,
+      flaggedFlag: false,
+      from: [new MailAddressInfo('Sender Name', 'sender@example.com')],
+      to: [new MailAddressInfo('Recipient Name', 'recipient@example.com')],
+      subject: 'Sender address',
+      plaintext: 'Body',
+      size: 1024,
+      attachment: false
+    };
+  }
+
+  function columns(selectedFolder: string, showFromEmailColumn: boolean) {
+    const messageList = new MessageList([message()]);
+    return messageList.getCanvasTableColumns({ selectedFolder, showFromEmailColumn });
+  }
+
+  it('adds the From Email column after From when enabled', () => {
+    const tableColumns = columns('Inbox', true);
+    const columnNames = tableColumns.map(column => column.name);
+    const fromEmailColumn = tableColumns.find(column => column.cacheKey === 'fromEmail');
+
+    expect(columnNames.slice(1, 5)).toEqual(['Date', 'From', 'From Email', 'Subject']);
+    expect(fromEmailColumn.getValue(0)).toBe('sender@example.com');
+  });
+
+  it('keeps the From Email column hidden by default', () => {
+    expect(columns('Inbox', false).find(column => column.cacheKey === 'fromEmail')).toBeUndefined();
+  });
+
+  it('does not add the From Email column when Sent displays To', () => {
+    const tableColumns = columns('Sent', true);
+
+    expect(tableColumns.find(column => column.cacheKey === 'fromEmail')).toBeUndefined();
+    expect(tableColumns.find(column => column.cacheKey === 'from').name).toBe('To');
+  });
+});

--- a/src/app/common/messagelist.ts
+++ b/src/app/common/messagelist.ts
@@ -54,6 +54,11 @@ export class MessageList extends MessageDisplay {
     '';
   }
 
+  getFromEmailColumnValueForRow(rowIndex: number): string {
+    const rowobj = this.rows[rowIndex];
+    return rowobj.from && rowobj.from.length > 0 ? rowobj.from[0].address : '';
+  }
+
   getToColumnValueForRow(rowIndex: number): string {
     const rowobj = this.rows[rowIndex];
     return rowobj.to && rowobj.to.length > 0 ?
@@ -71,6 +76,7 @@ export class MessageList extends MessageDisplay {
   }
 
   public getCanvasTableColumns(app: any): CanvasTableColumn[] {
+    const showToColumn = app.selectedFolder === 'Sent';
     const columns: CanvasTableColumn[] = [
       {
         sortColumn: null,
@@ -91,14 +97,27 @@ export class MessageList extends MessageDisplay {
         draggable: true
       },
       {
-        name: app.selectedFolder === 'Sent' ? 'To' : 'From',
+        name: showToColumn ? 'To' : 'From',
         cacheKey: 'from',
         sortColumn: null,
-        getValue: (rowIndex: number): any => app.selectedFolder === 'Sent'
+        getValue: (rowIndex: number): any => showToColumn
           ? this.getToColumnValueForRow(rowIndex)
           : this.getFromColumnValueForRow(rowIndex),
         draggable: true
-      },
+      }
+    ];
+
+    if (app.showFromEmailColumn && !showToColumn) {
+      columns.push({
+        name: 'From Email',
+        cacheKey: 'fromEmail',
+        sortColumn: null,
+        getValue: (rowIndex: number): string => this.getFromEmailColumnValueForRow(rowIndex),
+        draggable: true
+      });
+    }
+
+    columns.push(
       {
         name: 'Subject',
         cacheKey: 'subject',
@@ -153,7 +172,7 @@ export class MessageList extends MessageDisplay {
         getFormattedValue: (val) => val ? '\uE153' : '',
         tooltipText: 'Flagged'
       }
-    ];
+    );
 
     return columns;
   }

--- a/src/app/xapian/searchmessagedisplay.spec.ts
+++ b/src/app/xapian/searchmessagedisplay.spec.ts
@@ -1,0 +1,79 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2022 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { SearchMessageDisplay } from './searchmessagedisplay';
+
+describe('SearchMessageDisplay', () => {
+  function searchMessageDisplay(fromEmailAddress = 'sender@example.com') {
+    const searchService = {
+      api: {
+        getStringValue: () => '202606091200',
+        getNumericValue: () => 1024
+      },
+      getDocData: () => ({
+        id: 'Q1',
+        from: 'Sender Name',
+        fromEmailAddress,
+        subject: 'Sender address',
+        recipients: ['Recipient Name <recipient@example.com>'],
+        textcontent: 'Body'
+      }),
+      getMessageIdFromDocId: () => 1
+    };
+
+    return new SearchMessageDisplay(searchService, [[1]]);
+  }
+
+  function columns(selectedFolder: string, showFromEmailColumn: boolean, displayFolderColumn = false) {
+    return searchMessageDisplay().getCanvasTableColumns({
+      selectedFolder,
+      showFromEmailColumn,
+      displayFolderColumn,
+      viewmode: 'messages'
+    });
+  }
+
+  it('adds the From Email column after From when enabled', () => {
+    const tableColumns = columns('Inbox', true);
+    const columnNames = tableColumns.map(column => column.name);
+    const fromEmailColumn = tableColumns.find(column => column.cacheKey === 'fromEmail');
+
+    expect(columnNames.slice(1, 5)).toEqual(['Date', 'From', 'From Email', 'Subject']);
+    expect(fromEmailColumn.getValue(0)).toBe('sender@example.com');
+  });
+
+  it('falls back to the From display value when indexed sender email data is unavailable', () => {
+    const tableColumns = searchMessageDisplay('').getCanvasTableColumns({
+      selectedFolder: 'Inbox',
+      showFromEmailColumn: true,
+      displayFolderColumn: false,
+      viewmode: 'messages'
+    });
+    const fromEmailColumn = tableColumns.find(column => column.cacheKey === 'fromEmail');
+
+    expect(fromEmailColumn.getValue(0)).toBe('Sender Name');
+  });
+
+  it('does not add the From Email column when Sent displays To', () => {
+    const tableColumns = columns('Sent', true);
+
+    expect(tableColumns.find(column => column.cacheKey === 'fromEmail')).toBeUndefined();
+    expect(tableColumns.find(column => column.cacheKey === 'from').name).toBe('To');
+  });
+});

--- a/src/app/xapian/searchmessagedisplay.ts
+++ b/src/app/xapian/searchmessagedisplay.ts
@@ -54,9 +54,15 @@ export class SearchMessageDisplay extends MessageDisplay {
   filterBy(options: Map<string, any>) {
   }
 
+  getFromEmailColumnValueForRow(rowIndex: number): string {
+    const docData = this.searchService.getDocData(this.getRowId(rowIndex));
+    return docData.fromEmailAddress || docData.from;
+  }
+
   // columns
   // app is a Component (currently)
   public getCanvasTableColumns(app: any): CanvasTableColumn[] {
+    const showToColumn = app.selectedFolder.indexOf('Sent') === 0 && !app.displayFolderColumn;
     const columns: CanvasTableColumn[] = [
       {
         sortColumn: null,
@@ -75,7 +81,7 @@ export class SearchMessageDisplay extends MessageDisplay {
         getValue: (rowIndex): string => this.searchService.api.getStringValue(this.getRowId(rowIndex), 2),
         getFormattedValue: (datestring) => MessageTableRowTool.formatTimestampFromStringWithoutSeparators(datestring)
       },
-      (app.selectedFolder.indexOf('Sent') === 0 && !app.displayFolderColumn) ? {
+      showToColumn ? {
         name: 'To',
         draggable: true,
         cacheKey: 'from',
@@ -91,6 +97,19 @@ export class SearchMessageDisplay extends MessageDisplay {
             return this.searchService.getDocData(this.getRowId(rowIndex)).from;
           },
         },
+    ];
+
+    if (app.showFromEmailColumn && !showToColumn) {
+      columns.push({
+        name: 'From Email',
+        draggable: true,
+        cacheKey: 'fromEmail',
+        sortColumn: null,
+        getValue: (rowIndex): string => this.getFromEmailColumnValueForRow(rowIndex),
+      });
+    }
+
+    columns.push(
       {
           name: 'Subject',
           cacheKey: 'subject',
@@ -105,7 +124,7 @@ export class SearchMessageDisplay extends MessageDisplay {
           },
           // tooltipText: 'Tip: Drag subject to a folder to move message(s)'
         }
-    ];
+    );
 
     if (app.viewmode === 'conversations') {
       // Array containing row (conversation) objects waiting to be counted

--- a/src/app/xapian/searchservice.ts
+++ b/src/app/xapian/searchservice.ts
@@ -54,6 +54,7 @@ export const XAPIAN_GLASS_WR = 'xapianglasswr';
 export class SearchIndexDocumentData {
   id: string;
   from: string;
+  fromEmailAddress?: string;
   subject: string;
   recipients: string[];
   textcontent: string;
@@ -853,6 +854,7 @@ export class SearchService {
             id: docdataparts[0],
             from: docdataparts[1],
             subject: docdataparts[2],
+            fromEmailAddress: docdataparts[3] || '',
             recipients: [],
             textcontent: null
           };
@@ -882,6 +884,8 @@ export class SearchService {
                 } else if (s.indexOf('XRECIPIENT') === 0) {
                   const recipient = s.substring('XRECIPIENT:'.length);
                   this.currentDocData.recipients.push(recipient);
+                } else if (s.indexOf('XFROMEMAIL:') === 0) {
+                  this.currentDocData.fromEmailAddress = s.substring('XFROMEMAIL:'.length);
                 }
               });
           } catch (e) {


### PR DESCRIPTION
Closes #1678.

Summary:
- Add a display menu checkbox for showing sender email addresses.
- Insert a From Email column after From in folder and indexed search message lists.
- Keep row wrapping and default row selection pointed at the Subject column when the extra column is visible.
- Read sender email data from indexed document data/terms when available.

Tests:
- npx ng test runbox7 --watch=false --include src/app/common/messagelist.spec.ts --include src/app/xapian/searchmessagedisplay.spec.ts
- npm run lint -- --quiet