### PR TITLE
Show cart feedback after subscription renewal

### DIFF
--- a/src/app/account-app/account-renewals.component.ts
+++ b/src/app/account-app/account-renewals.component.ts
@@ -113,9 +113,25 @@ export class AccountRenewalsComponent {
         });
     }
 
-    renew(p: ActiveProduct) {
+    async renew(p: ActiveProduct) {
         if (p.subtype !== 'domain') {
-            this.cart.add(new ProductOrder(p.pid, p.type, p.quantity, p.apid));
+            await this.cart.add(new ProductOrder(p.pid, p.type, p.quantity, p.apid));
+
+            if (await this.cart.contains(p.pid, p.apid)) {
+                p.ordered = true;
+                this.snackbar.open(
+                    'Added subscription renewal to your shopping cart.',
+                    'View cart',
+                    { duration: 5000 }
+                ).onAction().subscribe(() => {
+                    this.router.navigateByUrl('/account/cart');
+                });
+            } else {
+                this.snackbar.open(
+                    'Your shopping cart already contains another subscription. Remove it before adding this renewal.',
+                    'Okay'
+                );
+            }
         } else {
             this.renewDomain(p);
         }


### PR DESCRIPTION
## Summary
- show a snackbar after a subscription renewal is added to the cart
- add a direct View cart action from that snackbar
- show a clearer message when another subscription in the cart prevents adding this renewal

Fixes #1434

## Tests
- npm run lint -- --quiet
- npx ng test runbox7 --watch=false --include src/app/account-app/cart.service.spec.ts

## AI assistance disclosure
I used ChatGPT/Codex to help prepare this patch.