### PR TITLE
Show when the message list was last updated

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -242,6 +242,12 @@
               <mat-icon svgIcon="close"></mat-icon>
             </button>
           </mat-form-field>
+          <span
+            class="messageListLastUpdated"
+            *ngIf="messagelistservice.lastUpdatedSubject | async as lastUpdated"
+            matTooltip="Last message list update">
+            Last updated: {{ lastUpdated | date:'HH:mm:ss' }}
+          </span>
         </ng-template>
 	    
         <button mat-icon-button (click)="updateViewMode('conversations')" *ngIf="!searchtextfieldfocused && viewmode==='singleconversation'"

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -10,6 +10,19 @@
     vertical-align: middle !important;
 }
 
+.messageListLastUpdated {
+    color: rgba(0, 0, 0, 0.54);
+    font-size: 12px;
+    margin-left: 8px;
+    white-space: nowrap;
+}
+
+@media (max-width: 599px) {
+    .messageListLastUpdated {
+        display: none;
+    }
+}
+
 .contextToolButtonsRegular {
     position: absolute;
     display: flex;

--- a/src/app/rmmapi/messagelist.service.spec.ts
+++ b/src/app/rmmapi/messagelist.service.spec.ts
@@ -20,7 +20,7 @@
 import { MessageListService } from './messagelist.service';
 import { FolderListEntry } from '../common/folderlistentry';
 
-import { Subject, Observable, AsyncSubject, firstValueFrom } from 'rxjs';
+import { Subject, Observable, AsyncSubject, firstValueFrom, of } from 'rxjs';
 import { filter, take } from 'rxjs/operators';
 
 describe('MessageListService', () => {
@@ -75,6 +75,30 @@ describe('MessageListService', () => {
                 expect(Array.isArray(messages)).toBe(true);
                 done();
             });
+        });
+
+        it('lastUpdatedSubject should emit when folder messages are fetched', (done) => {
+            const msglistservice = new MessageListService({
+                messageFlagChangeSubject: new Subject(),
+                getFolderList: () => new Observable(),
+                listAllMessages: () => of([
+                    {
+                        id: 123,
+                        folder: 'Inbox',
+                        deletedFlag: false,
+                    }
+                ])
+            } as any);
+
+            msglistservice.lastUpdatedSubject.pipe(
+                filter(lastUpdated => lastUpdated !== null),
+                take(1)
+            ).subscribe(lastUpdated => {
+                expect(lastUpdated instanceof Date).toBe(true);
+                done();
+            });
+
+            msglistservice.fetchFolderMessages(true);
         });
 
         it('folderListSubject should update when folders are loaded', (done) => {

--- a/src/app/rmmapi/messagelist.service.ts
+++ b/src/app/rmmapi/messagelist.service.ts
@@ -50,6 +50,7 @@ export interface FolderMessageCountMap {
 @Injectable()
 export class MessageListService {
     messagesInViewSubject: BehaviorSubject<MessageInfo[]> = new BehaviorSubject([]);
+    lastUpdatedSubject: BehaviorSubject<Date | null> = new BehaviorSubject(null);
     folderListSubject: BehaviorSubject<FolderListEntry[]> = new BehaviorSubject([]);
     folderMessageCountSubject: ReplaySubject<FolderMessageCountMap> = new ReplaySubject(1);
 
@@ -117,8 +118,13 @@ export class MessageListService {
                 // Message counts update
                 this.folderMessageCountSubject.next(this.folderCounts);
                 // current folder contents update
-                this.messagesInViewSubject.next(this.folderMessageLists[this.currentFolder]);
+                this.updateMessagesInView(this.folderMessageLists[this.currentFolder]);
             });
+    }
+
+    private updateMessagesInView(messages: MessageInfo[]) {
+        this.messagesInViewSubject.next(messages);
+        this.lastUpdatedSubject.next(new Date());
     }
 
     public setCurrentFolder(folder: string) {
@@ -283,7 +289,7 @@ export class MessageListService {
         // messagelist data, then updates the backend, so applyChanges
         // won't have anything to do unless its pulling changes
         // made from outside of runbox7 (eg via IMAP)
-        this.messagesInViewSubject.next(this.folderMessageLists[this.currentFolder]);
+        this.updateMessagesInView(this.folderMessageLists[this.currentFolder]);
         this.refreshFolderList();
     }
 
@@ -322,7 +328,7 @@ export class MessageListService {
         // Message counts update
         this.folderMessageCountSubject.next(this.folderCounts);
         // current folder contents update
-        this.messagesInViewSubject.next(this.folderMessageLists[this.currentFolder]);
+        this.updateMessagesInView(this.folderMessageLists[this.currentFolder]);
     }
 
     // Non-index users (or trash/spam) - move to other folder
@@ -398,7 +404,7 @@ export class MessageListService {
       console.log('msl moveMessages updating folderCounts');
         this.folderMessageCountSubject.next(this.folderCounts);
         // current folder contents update
-        this.messagesInViewSubject.next(this.folderMessageLists[this.currentFolder]);
+        this.updateMessagesInView(this.folderMessageLists[this.currentFolder]);
     }
 
     public fetchFolderMessages(resetContents = false) {
@@ -433,7 +439,7 @@ export class MessageListService {
                     }
                     res.forEach((m: MessageInfo) => this.messagesById[m.id] = m);
                 }
-                this.messagesInViewSubject.next(this.folderMessageLists[this.currentFolder]);
+                this.updateMessagesInView(this.folderMessageLists[this.currentFolder]);
                 this.fetchInProgress = false;
             });
     }


### PR DESCRIPTION
## Summary
- track when the visible message list is refreshed
- show the refresh time next to the mail search field on non-mobile toolbars
- cover the timestamp emission when folder messages are fetched

Fixes #1545

## Tests
- npm run lint -- --quiet
- npx ng test runbox7 --watch=false --include src/app/rmmapi/messagelist.service.spec.ts

## AI assistance disclosure
I used ChatGPT/Codex to help prepare this patch.