### PR TITLE
Keep one main subscription in the cart

### DIFF
--- a/src/app/account-app/cart.service.spec.ts
+++ b/src/app/account-app/cart.service.spec.ts
@@ -48,7 +48,6 @@ describe('CartService', () => {
 
         const order = new ProductOrder(401,'subscription', new Decimal(3), 402);
         await cart.add(order);
-        console.log(await firstValueFrom(cart.items));
         expect(await cart.contains(401, 402)).toBe(true, 'cart contains the renewal product');
         expect(await cart.contains(401)).toBe(false, 'cart does not contain the new product');
     });
@@ -102,5 +101,49 @@ describe('CartService', () => {
         await cart.add(new ProductOrder(404, 'subscription', new Decimal(1)));
         expect(await cart.contains(403)).toBe(true, 'cart contains added products');
         expect(await cart.contains(404)).toBe(false, 'cart does not contain 2nd subscription');
+    });
+
+    it('should only add one unit of a main subscription product', async () => {
+        localStorage.clear();
+        const cart = new CartService(storage);
+
+        await cart.add(new ProductOrder(403, 'subscription', new Decimal(3)));
+        const items = await firstValueFrom(cart.items);
+
+        expect(items.length).toBe(1);
+        expect(items[0].pid).toBe(403);
+        expect(items[0].quantity.equals(new Decimal(1))).toBe(true);
+    });
+
+    it('should clean multiple main subscription products loaded from storage', async () => {
+        localStorage.clear();
+        localStorage.setItem('42:shoppingCart', JSON.stringify([
+            { pid: 403, type: 'subscription', quantity: 2 },
+            { pid: 404, type: 'subscription', quantity: 1 },
+            { pid: 405, type: 'add-on', quantity: 1 },
+        ]));
+
+        const cart = new CartService(storage);
+        const items = await firstValueFrom(cart.items);
+
+        expect(items.length).toBe(2);
+        expect(items[0].pid).toBe(403);
+        expect(items[0].quantity.equals(new Decimal(1))).toBe(true);
+        expect(items[1].pid).toBe(405);
+        expect(await cart.contains(404)).toBe(false, 'cart drops the 2nd subscription');
+    });
+
+    it('should preserve renewal quantities loaded from storage', async () => {
+        localStorage.clear();
+        localStorage.setItem('42:shoppingCart', JSON.stringify([
+            { pid: 403, type: 'subscription', quantity: 3, apid: 420 },
+        ]));
+
+        const cart = new CartService(storage);
+        const items = await firstValueFrom(cart.items);
+
+        expect(items.length).toBe(1);
+        expect(items[0].quantity.equals(new Decimal(3))).toBe(true);
+        expect(await cart.contains(403, 420)).toBe(true, 'cart still contains the renewal');
     });
 });

--- a/src/app/account-app/cart.service.ts
+++ b/src/app/account-app/cart.service.ts
@@ -35,7 +35,7 @@ export class CartService {
         private storage: StorageService,
     ) {
         this.storage.get('shoppingCart').then(cart => {
-          const items = cart ? cart.map(i => new ProductOrder(i.pid, i.type, new Decimal(i.quantity), i.apid)) : [];
+          const items = this.cleanItems(cart ? cart.map(i => new ProductOrder(i.pid, i.type, new Decimal(i.quantity), i.apid)) : []);
             this.items.next(items);
         });
 
@@ -46,22 +46,56 @@ export class CartService {
 
     async add(p: ProductOrder): Promise<void> {
         const items = await firstValueFrom(this.items);
+        const order = this.cleanOrder(p);
 
         for (const i of items) {
             // Cannot order multiples of subscription products
-            if (i.type === 'subscription' && p.type === 'subscription') {
+            if (i.type === 'subscription' && order.type === 'subscription') {
                 return;
             }
             // if an item like this is already ordered, increase the quantity
-            if (i.isSameProduct(p) ) {
-                i.quantity = p.quantity.plus(i.quantity);
+            if (i.isSameProduct(order) ) {
+                i.quantity = order.quantity.plus(i.quantity);
                 this.items.next(items);
                 return;
             }
         }
         // no product like this yet if we got this far down
-        items.push(p);
+        items.push(order);
         this.items.next(items);
+    }
+
+    private cleanItems(items: ProductOrder[]): ProductOrder[] {
+        const cleaned: ProductOrder[] = [];
+        let hasSubscription = false;
+
+        for (const item of items) {
+            const order = this.cleanOrder(item);
+
+            if (order.type === 'subscription') {
+                if (hasSubscription) {
+                    continue;
+                }
+                hasSubscription = true;
+            }
+
+            const existing = cleaned.find(i => i.isSameProduct(order));
+            if (existing && order.type !== 'subscription') {
+                existing.quantity = existing.quantity.plus(order.quantity);
+            } else {
+                cleaned.push(order);
+            }
+        }
+
+        return cleaned;
+    }
+
+    private cleanOrder(order: ProductOrder): ProductOrder {
+        if (order.type === 'subscription' && order.apid === undefined && order.quantity.gt(1)) {
+            return new ProductOrder(order.pid, order.type, new Decimal(1), order.apid);
+        }
+
+        return new ProductOrder(order.pid, order.type, order.quantity, order.apid);
     }
 
     clear() {


### PR DESCRIPTION
Fixes #1699.

## Summary
- Normalize main account subscription orders so one add can only contribute a quantity of 1.
- Clean persisted shopping carts on load so an older/bad cart keeps the first subscription order and drops extra subscription products instead of replacing the existing choice.
- Preserve renewal orders with `apid` and their quantities when loading from storage.

## Tests
- `npm run lint -- --quiet`
- `npx ng test runbox7 --watch=false --include src/app/account-app/cart.service.spec.ts`

## AI assistance disclosure
I used AI assistance to inspect the issue, draft the patch, and run validation. I reviewed the changes before submitting this PR.