### PR TITLE
Add three-year sub-account renewal option

### DIFF
--- a/src/app/account-app/account-renewals.component.html
+++ b/src/app/account-app/account-renewals.component.html
@@ -90,7 +90,8 @@
             <ng-container matColumnDef="renew">
                 <th mat-header-cell *matHeaderCellDef> Renew Now </th>
                 <td mat-cell *matCellDef="let p">
-                    <app-account-renewals-renew-now-button-component [p]="p" [usage]="q_usage" (clicked)="renew(p)"
+                    <app-account-renewals-renew-now-button-component [p]="p" [usage]="q_usage"
+                        [threeYearProduct]="p.three_year_renewal_product" (clicked)="renew(p, $event)"
                         *ngIf="!(p.type === 'addon' && p.name.toLowerCase().includes('storage'))">
                     </app-account-renewals-renew-now-button-component>
                 </td>
@@ -144,7 +145,8 @@
                             <tr>
                                 <td> Renew Now </td>
                                 <td>
-                                    <app-account-renewals-renew-now-button-component [p]="p" (clicked)="renew(p)">
+                                    <app-account-renewals-renew-now-button-component [p]="p" [usage]="q_usage"
+                                        [threeYearProduct]="p.three_year_renewal_product" (clicked)="renew(p, $event)">
                                     </app-account-renewals-renew-now-button-component>
                                 </td>
                             </tr>

--- a/src/app/account-app/account-renewals.component.spec.ts
+++ b/src/app/account-app/account-renewals.component.spec.ts
@@ -1,0 +1,103 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { Decimal } from 'decimal.js-light';
+
+import { findThreeYearSubaccountProduct } from './account-renewals.component';
+import { Product } from './product';
+
+function subaccountProduct(pid: number, price: number, diskQuota: number, type = 'addon'): Product {
+    return new Product({
+        pid,
+        price,
+        id: `subaccount-${pid}`,
+        type,
+        subtype: 'subaccount',
+        name: `Sub-account ${pid}`,
+        description: 'Test sub-account',
+        currency: 'USD',
+        quotas: {},
+        sub_product_quota: {
+            Disk: {
+                type: 'bytes',
+                quota: diskQuota,
+            },
+        },
+    });
+}
+
+describe('findThreeYearSubaccountProduct', () => {
+    const diskQuota = 1024 * 1024 * 1024;
+    const activeSubaccount = {
+        pid: 100,
+        type: 'addon',
+        subtype: 'subaccount',
+        price: new Decimal(10),
+        sub_product_quota: {
+            Disk: {
+                quota: diskQuota,
+            },
+        },
+    };
+
+    it('finds a same-quota product priced as a three-year renewal', () => {
+        const oneYearProduct = subaccountProduct(100, 10, diskQuota);
+        const threeYearProduct = subaccountProduct(300, 24, diskQuota);
+        const differentQuotaProduct = subaccountProduct(301, 24, diskQuota * 2);
+
+        expect(findThreeYearSubaccountProduct(activeSubaccount, [
+            oneYearProduct,
+            differentQuotaProduct,
+            threeYearProduct,
+        ])).toBe(threeYearProduct);
+    });
+
+    it('does not match other product types', () => {
+        const subscriptionProduct = subaccountProduct(300, 24, diskQuota, 'subscription');
+
+        expect(findThreeYearSubaccountProduct(activeSubaccount, [
+            subscriptionProduct,
+        ])).toBeUndefined();
+    });
+
+    it('uses the catalog price for the active product when it is available', () => {
+        const quantityAdjustedActiveSubaccount = {
+            ...activeSubaccount,
+            price: new Decimal(20),
+        };
+        const oneYearProduct = subaccountProduct(100, 10, diskQuota);
+        const threeYearProduct = subaccountProduct(300, 24, diskQuota);
+
+        expect(findThreeYearSubaccountProduct(quantityAdjustedActiveSubaccount, [
+            oneYearProduct,
+            threeYearProduct,
+        ])).toBe(threeYearProduct);
+    });
+
+    it('does not match non-sub-account active products', () => {
+        const activeMainSubscription = {
+            ...activeSubaccount,
+            subtype: 'mini',
+        };
+
+        expect(findThreeYearSubaccountProduct(activeMainSubscription, [
+            subaccountProduct(300, 24, diskQuota),
+        ])).toBeUndefined();
+    });
+});

--- a/src/app/account-app/account-renewals.component.ts
+++ b/src/app/account-app/account-renewals.component.ts
@@ -24,6 +24,8 @@ import { MatLegacySnackBar as MatSnackBar } from '@angular/material/legacy-snack
 
 import { CartService } from './cart.service';
 import { MobileQueryService } from '../mobile-query.service';
+import { PaymentsService } from './payments.service';
+import { Product } from './product';
 import { ProductOrder } from './product-order';
 import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
 import { SubAccountRenewalDialogComponent } from './sub-account-renewal-dialog';
@@ -31,6 +33,7 @@ import { DataUsageInterface } from '../rmm/account-storage';
 import { AsyncSubject } from 'rxjs';
 import { RMM } from '../rmm';
 
+import { Decimal } from 'decimal.js-light';
 import moment from 'moment';
 
 const columnsDefault = ['renewal_name', 'quantity', 'price', 'active_from', 'active_until', 'hints', 'recur', 'renew'];
@@ -39,6 +42,53 @@ const columnsMobile = ['renewal_name'];
 // TODO define it as an interface
 type ActiveProduct = any;
 
+function getSubaccountDiskQuota(product: ActiveProduct | Product): number | undefined {
+    return product?.sub_product_quota?.Disk?.quota;
+}
+
+function getProductPrice(product: ActiveProduct | Product): Decimal | undefined {
+    if (product?.price === undefined || product.price === null) {
+        return undefined;
+    }
+    return new Decimal(product.price);
+}
+
+export function findThreeYearSubaccountProduct(activeProduct: ActiveProduct, products: Product[]): Product | undefined {
+    if (activeProduct?.subtype !== 'subaccount') {
+        return undefined;
+    }
+
+    const currentProduct = products.find(product => product.pid === activeProduct.pid) || activeProduct;
+    const activeDiskQuota = getSubaccountDiskQuota(currentProduct);
+    const activePrice = getProductPrice(currentProduct);
+    if (activeDiskQuota === undefined || activePrice === undefined) {
+        return undefined;
+    }
+
+    const minimumThreeYearPrice = activePrice.times(2);
+    const maximumThreeYearPrice = activePrice.times(3.1);
+
+    return products
+        .filter(product => product.subtype === 'subaccount')
+        .filter(product => product.type === activeProduct.type)
+        .filter(product => product.pid !== activeProduct.pid)
+        .filter(product => getSubaccountDiskQuota(product) === activeDiskQuota)
+        .filter(product => {
+            const productPrice = getProductPrice(product);
+            return productPrice
+                && productPrice.greaterThanOrEqualTo(minimumThreeYearPrice)
+                && productPrice.lessThanOrEqualTo(maximumThreeYearPrice);
+        })
+        .sort((a, b) => {
+            const priceA = getProductPrice(a);
+            const priceB = getProductPrice(b);
+            if (priceA === undefined || priceB === undefined) {
+                return 0;
+            }
+            return priceB.comparedTo(priceA);
+        })[0];
+}
+
 @Component({
     selector: 'app-account-renewals-component',
     templateUrl: './account-renewals.component.html',
@@ -46,6 +96,7 @@ type ActiveProduct = any;
 export class AccountRenewalsComponent {
     active_products: ActiveProduct[] = [];
     all_products: ActiveProduct[] = [];
+    available_products: Product[] = [];
     current_subscription: number;
 
     loadedProducts = false;
@@ -64,9 +115,15 @@ export class AccountRenewalsComponent {
         private router: Router,
         private snackbar: MatSnackBar,
         private rmm: RMM,
+        private paymentsservice: PaymentsService,
     ) {
         this.rmmapi.me.subscribe(me => {
             this.current_subscription = me.subscription;
+        });
+
+        this.paymentsservice.products.subscribe(products => {
+            this.available_products = products;
+            this.updateThreeYearRenewalProducts();
         });
 
         // User's current usage:
@@ -95,11 +152,10 @@ export class AccountRenewalsComponent {
             });
 
             this.sortAndFilterProducts();
+            this.updateThreeYearRenewalProducts();
             
             this.cart.items.subscribe(_ => {
-                for (const p of this.active_products) {
-                    this.cart.contains(p.pid, p.apid).then(ordered => p.ordered = ordered);
-                }
+                this.updateOrderedStates();
             });
             this.loadedProducts = true;
         });
@@ -113,9 +169,10 @@ export class AccountRenewalsComponent {
         });
     }
 
-    renew(p: ActiveProduct) {
+    renew(p: ActiveProduct, renewalProduct?: Product) {
         if (p.subtype !== 'domain') {
-            this.cart.add(new ProductOrder(p.pid, p.type, p.quantity, p.apid));
+            const product = renewalProduct || p;
+            this.cart.add(new ProductOrder(product.pid, product.type, p.quantity, p.apid));
         } else {
             this.renewDomain(p);
         }
@@ -164,6 +221,25 @@ export class AccountRenewalsComponent {
                 return 0;
             }
         });
+    }
+
+    updateThreeYearRenewalProducts() {
+        for (const p of this.all_products) {
+            p.three_year_renewal_product = findThreeYearSubaccountProduct(p, this.available_products);
+        }
+        this.updateOrderedStates();
+    }
+
+    updateOrderedStates() {
+        for (const p of this.active_products) {
+            const containsDefaultRenewal = this.cart.contains(p.pid, p.apid);
+            const containsThreeYearRenewal = p.three_year_renewal_product
+                ? this.cart.contains(p.three_year_renewal_product.pid, p.apid)
+                : Promise.resolve(false);
+            Promise.all([containsDefaultRenewal, containsThreeYearRenewal]).then(
+                ([defaultRenewalOrdered, threeYearRenewalOrdered]) => p.ordered = defaultRenewalOrdered || threeYearRenewalOrdered,
+            );
+        }
     }
 
     toggleAutorenew(p: ActiveProduct) {
@@ -218,6 +294,9 @@ Warning: You are close to your quotas for this product
     <button mat-raised-button (click)="clicked.emit()" *ngIf="!p.ordered" color="primary" id="renewButton">
         Renew  <mat-icon svgIcon="cart" color="accent"></mat-icon>
     </button>
+    <button mat-raised-button (click)="clicked.emit(threeYearProduct)" *ngIf="!p.ordered && threeYearProduct" color="accent" id="renewThreeYearButton">
+        Renew for 3 years <mat-icon svgIcon="cart"></mat-icon>
+    </button>
     <span *ngIf="p.ordered">
         Added to shopping cart
     </span>
@@ -235,7 +314,8 @@ Warning: You are close to your quotas for this product
 export class AccountRenewalsRenewNowButtonComponent implements OnInit {
     @Input() p: ActiveProduct;
     @Input() usage: DataUsageInterface;
-    @Output() clicked: EventEmitter<void> = new EventEmitter();
+    @Input() threeYearProduct?: Product;
+    @Output() clicked: EventEmitter<Product | undefined> = new EventEmitter();
 
     close_to_quota = [];
     close_percentage = 90;


### PR DESCRIPTION
Fixes #1741.

## Summary
- Find the matching three-year sub-account renewal product from the existing upgrades catalog using sub-account type, disk quota, and three-year price range.
- Add a secondary `Renew for 3 years` action on the subscriptions renewal button when that matching product is available.
- Add the selected renewal PID to the cart with the active product's `apid` and quantity, and mark the row as ordered if either renewal option is already in the cart.

## Tests
- `npm run lint -- --quiet`
- `npx ng test runbox7 --watch=false --include src/app/account-app/account-renewals.component.spec.ts`

## AI assistance disclosure
I used AI assistance to inspect the issue, draft the patch, and run validation. I reviewed the changes before submitting this PR.