### PR TITLE
Handle shopping cart payment start errors

### DIFF
--- a/src/app/account-app/shopping-cart.component.html
+++ b/src/app/account-app/shopping-cart.component.html
@@ -112,7 +112,7 @@
             logo="assets/payment/Stripe.png"
             logo_alt="Credit card and PayPal logos"
 	        disable_payment="{{total <= 0}}"
-            (clicked)="initiatePayment('stripe')"
+            (clicked)="startPayment('stripe')"
           >
             <h4>
                 Pay with a card, PayPal, Apple Pay, and others.
@@ -126,7 +126,7 @@
             logo="assets/payment/Cryptocurrencies.png"
             logo_alt="Cryptocurrency logos"
 	        disable_payment="{{total <= 0}}"
-            (clicked)="initiatePayment('coinbase')"
+            (clicked)="startPayment('coinbase')"
           >
             <h4>
                  Pay with cryptocurrencies to Coinbase
@@ -141,7 +141,7 @@
             <mat-panel-title style="text-align: center"> Other payment methods </mat-panel-title>
           </mat-expansion-panel-header>
       	  <p>
-            <button id="payDirectly" mat-raised-button (click)="initiatePayment('giro')" color="primary">
+            <button id="payDirectly" mat-raised-button (click)="startPayment('giro')" color="primary">
 	            Bank Transfer, or Cash Payment
             </button>
           </p>
@@ -152,6 +152,13 @@
             Please note that your subscription won't activate until the payment is received by Runbox.
           </p>
       	</mat-expansion-panel>
+    </div>
+
+    <div *ngIf="paymentError" style="text-align: center;">
+        {{ paymentError }} <br>
+        <a routerLink="/compose" [queryParams]="{ to: 'support@runbox.com' }">
+            support@runbox.com
+        </a>
     </div>
 </div>
 

--- a/src/app/account-app/shopping-cart.component.spec.ts
+++ b/src/app/account-app/shopping-cart.component.spec.ts
@@ -1,0 +1,133 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2019 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { Decimal } from 'decimal.js-light';
+import { of, Subject, throwError } from 'rxjs';
+
+import { ProductOrder } from './product-order';
+import { ShoppingCartComponent } from './shopping-cart.component';
+
+Decimal.set({ precision: 20, rounding: Decimal.ROUND_HALF_EVEN });
+
+describe('ShoppingCartComponent', () => {
+    let cart: any;
+    let dialog: any;
+    let mobileQuery: any;
+    let paymentsService: any;
+    let rmmapi: any;
+    let route: any;
+    let router: any;
+
+    function createComponent(): ShoppingCartComponent {
+        const component = new ShoppingCartComponent(
+            cart,
+            dialog,
+            mobileQuery,
+            paymentsService,
+            rmmapi,
+            route,
+            router,
+        );
+
+        const product = {
+            pid: 101,
+            name: 'Runbox Mini',
+            price: new Decimal(10),
+            currency: 'USD',
+            type: 'subscription',
+        };
+        component.items = [{
+            ...new ProductOrder(101, 'subscription', new Decimal(1)),
+            product,
+        } as any];
+
+        return component;
+    }
+
+    beforeEach(() => {
+        cart = {
+            clear: jasmine.createSpy('clear'),
+            items: of([]),
+        };
+        dialog = {
+            open: jasmine.createSpy('open').and.returnValue({
+                afterClosed: () => of(false),
+            }),
+        };
+        mobileQuery = {
+            matches: false,
+            changed: new Subject<boolean>(),
+        };
+        paymentsService = {
+            products: of([]),
+        };
+        rmmapi = {
+            me: of({ is_trial: false }),
+            orderProducts: jasmine.createSpy('orderProducts').and.returnValue(of({ tid: 123 })),
+        };
+        route = {
+            queryParams: of({}),
+        };
+        router = {
+            navigateByUrl: jasmine.createSpy('navigateByUrl').and.returnValue(Promise.resolve(true)),
+        };
+    });
+
+    it('shows a payment error when order creation fails', async () => {
+        const component = createComponent();
+        const error = new Error('order failed');
+        spyOn(console, 'error');
+        rmmapi.orderProducts.and.returnValue(throwError(() => error));
+
+        await component.startPayment('stripe');
+
+        expect(component.paymentError).toBe('Could not start the payment. Try again later, or contact Runbox Support.');
+        expect(console.error).toHaveBeenCalledWith('Failed to initiate stripe payment', error);
+        expect(dialog.open).not.toHaveBeenCalled();
+    });
+
+    it('clears stale payment errors when payment starts successfully', async () => {
+        const component = createComponent();
+        component.paymentError = 'Previous payment error';
+
+        await component.startPayment('stripe');
+
+        expect(component.paymentError).toBeUndefined();
+        expect(rmmapi.orderProducts).toHaveBeenCalledWith(
+            jasmine.any(Array),
+            'stripe',
+            'USD',
+            undefined,
+        );
+        expect(dialog.open).toHaveBeenCalled();
+    });
+
+    it('shows a payment error when the giro receipt route cannot be opened', async () => {
+        const component = createComponent();
+        const error = new Error('navigation failed');
+        spyOn(console, 'error');
+        router.navigateByUrl.and.returnValue(Promise.reject(error));
+
+        await component.startPayment('giro');
+
+        expect(component.paymentError).toBe('Could not start the payment. Try again later, or contact Runbox Support.');
+        expect(console.error).toHaveBeenCalledWith('Failed to initiate giro payment', error);
+        expect(cart.clear).not.toHaveBeenCalled();
+    });
+});

--- a/src/app/account-app/shopping-cart.component.ts
+++ b/src/app/account-app/shopping-cart.component.ts
@@ -63,6 +63,7 @@ export class ShoppingCartComponent implements OnInit {
     domregHash: string;
 
     orderError: CartError;
+    paymentError: string;
     // needed so that templates can refer to enum values through `errors.ERROR_CODE`
     errors = CartError;
 
@@ -240,41 +241,53 @@ export class ShoppingCartComponent implements OnInit {
         this.cart.add(new ProductOrder(p.pid, p.type, new Decimal(1)));
     }
 
+    async startPayment(method: string) {
+        this.paymentError = undefined;
+
+        try {
+            await this.initiatePayment(method);
+        } catch (e) {
+            console.error(`Failed to initiate ${method} payment`, e);
+            this.paymentError = 'Could not start the payment. Try again later, or contact Runbox Support.';
+        }
+    }
+
     async initiatePayment(method: string) {
         const items = this.items.map(i => {
             return { pid: i.pid, apid: i.apid, quantity: i.quantity };
         });
         const currency = this.items[0].product.currency;
-        this.rmmapi.orderProducts(items, method, currency, this.domregHash).subscribe(tx => {
-            let dialogRef: MatDialogRef<any>;
-            if (method === 'stripe') {
-                dialogRef = this.dialog.open(StripePaymentDialogComponent, {
-                    'height': '90%',
-                    data: { tx }
-                });
-            } else if (method === 'coinbase') {
-                dialogRef = this.dialog.open(BitpayPaymentDialogComponent, {
-                    data: { tx }
-                });
-            } else if (method === 'paypal') {
-                dialogRef = this.dialog.open(PaypalPaymentDialogComponent, {
-                    'height': '300px',
-                    'width': '500px',
-                    data: { tx }
-                });
-            } else if (method === 'giro') {
-                this.router.navigateByUrl('/account/receipt/' + tx.tid);
-                if (!this.fromUrl) {
-                    this.cart.clear();
-                }
-                return;
-            }
 
-            dialogRef.afterClosed().subscribe(paid => {
-                if (paid && !this.fromUrl) {
-                    this.cart.clear();
-                }
+        const tx = await firstValueFrom(this.rmmapi.orderProducts(items, method, currency, this.domregHash));
+
+        let dialogRef: MatDialogRef<any>;
+        if (method === 'stripe') {
+            dialogRef = this.dialog.open(StripePaymentDialogComponent, {
+                'height': '90%',
+                data: { tx }
             });
+        } else if (method === 'coinbase') {
+            dialogRef = this.dialog.open(BitpayPaymentDialogComponent, {
+                data: { tx }
+            });
+        } else if (method === 'paypal') {
+            dialogRef = this.dialog.open(PaypalPaymentDialogComponent, {
+                'height': '300px',
+                'width': '500px',
+                data: { tx }
+            });
+        } else if (method === 'giro') {
+            await this.router.navigateByUrl('/account/receipt/' + tx.tid);
+            if (!this.fromUrl) {
+                this.cart.clear();
+            }
+            return;
+        }
+
+        dialogRef.afterClosed().subscribe(paid => {
+            if (paid && !this.fromUrl) {
+                this.cart.clear();
+            }
         });
     }
 }


### PR DESCRIPTION
Fixes #562.

## Summary
- route the payment buttons through a template-facing `startPayment()` wrapper that catches failures
- await `orderProducts()` with `firstValueFrom()` so HTTP/order-creation errors are caught instead of disappearing inside an unhandled subscription
- show a clear cart-page payment-start error with a Runbox Support link while leaving the payment choices visible for retry
- add focused component coverage for order creation failure, successful Stripe start, and giro navigation failure

## Tests
- `npm run test -- --watch=false --progress=false --browsers=FirefoxHeadless --include=src/app/account-app/shopping-cart.component.spec.ts`
- `npm run lint -- --quiet`
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `git diff --check`
- `npm run policy` exited 0; it still prints existing historical commit-message warnings from the repository history