### PR TITLE
fix(mail): show previous login notice

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -38,7 +38,7 @@ import { MessageListService } from './rmmapi/messagelist.service';
 import { MessageInfo } from './common/messageinfo';
 import { MessageList } from './common/messagelist';
 import { FolderListEntry } from './common/folderlistentry';
-import { RunboxWebmailAPI, MessageFlagChange } from './rmmapi/rbwebmail';
+import { RunboxWebmailAPI, MessageFlagChange, LoginInfo, getPreviousSuccessfulLogin } from './rmmapi/rbwebmail';
 import { DraftDeskService } from './compose/draftdesk.service';
 import { RMM7MessageActions } from './mailviewer/rmm7messageactions';
 import { FolderListComponent, CreateFolderEvent, RenameFolderEvent, MoveFolderEvent } from './folder/folder.module';
@@ -75,6 +75,7 @@ const LOCAL_STORAGE_KEEP_PANE = 'keepMessagePaneOpen';
 const LOCAL_STORAGE_SHOW_UNREAD_ONLY = 'rmm7mailViewerShowUnreadOnly';
 const LOCAL_STORAGE_SHOW_POPULAR_RECIPIENTS = 'showPopularRecipients';
 const LOCAL_STORAGE_INDEX_PROMPT = 'localSearchPromptDisplayed';
+const SESSION_STORAGE_LAST_LOGIN_NOTICE = 'rmm7lastLoginNoticeShown';
 const TOOLBAR_LIST_BUTTON_WIDTH = 30;
 
 @Component({
@@ -446,6 +447,65 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
         });
       }
     });
+
+    this.showPreviousLoginNotice();
+  }
+
+  private showPreviousLoginNotice(): void {
+    this.rmmapi.me.pipe(
+      take(1),
+      mergeMap(me => this.rmmapi.getLastLogins({ status: 1, service: 'web' }).pipe(
+        map(logins => ({ uid: me.uid, login: getPreviousSuccessfulLogin(logins) }))
+      ))
+    ).subscribe({
+      next: ({ uid, login }) => {
+        if (!login) {
+          return;
+        }
+
+        const storageKey = this.lastLoginNoticeStorageKey(uid);
+        const noticeId = this.lastLoginNoticeId(uid, login);
+        if (this.getSessionStorageItem(storageKey) === noticeId) {
+          return;
+        }
+
+        this.setSessionStorageItem(storageKey, noticeId);
+        this.snackBar.open(this.previousLoginMessage(login), 'Dismiss', {
+          duration: 7000,
+        });
+      },
+      error: () => undefined,
+    });
+  }
+
+  private previousLoginMessage(login: LoginInfo): string {
+    const loginTime = login.created ? ` at ${login.created}` : '';
+    const loginIp = login.ip ? ` from ${login.ip}` : '';
+    return `Previous successful login${loginTime}${loginIp}.`;
+  }
+
+  private lastLoginNoticeStorageKey(uid: number): string {
+    return `${SESSION_STORAGE_LAST_LOGIN_NOTICE}:${uid}`;
+  }
+
+  private lastLoginNoticeId(uid: number, login: LoginInfo): string {
+    return [uid, login.service || '', login.created || '', login.ip || ''].join('|');
+  }
+
+  private getSessionStorageItem(key: string): string | null {
+    try {
+      return sessionStorage.getItem(key);
+    } catch (_error) {
+      return null;
+    }
+  }
+
+  private setSessionStorageItem(key: string, value: string): void {
+    try {
+      sessionStorage.setItem(key, value);
+    } catch (_error) {
+      // The notice can still be shown if session storage is unavailable.
+    }
   }
 
   ngAfterViewInit() {

--- a/src/app/rmmapi/rbwebmail.spec.ts
+++ b/src/app/rmmapi/rbwebmail.spec.ts
@@ -18,7 +18,7 @@
 // ---------- END RUNBOX LICENSE ----------
 
 import { TestBed } from '@angular/core/testing';
-import { RunboxWebmailAPI } from './rbwebmail';
+import { getPreviousSuccessfulLogin, RunboxWebmailAPI } from './rbwebmail';
 import { FolderListEntry } from '../common/folderlistentry';
 import { MatLegacyDialogModule as MatDialogModule } from '@angular/material/legacy-dialog';
 import { MatLegacySnackBarModule as MatSnackBarModule } from '@angular/material/legacy-snack-bar';
@@ -116,6 +116,60 @@ describe('RBWebMail', () => {
         messageContents = await firstValueFrom(messageContentsObservable);
         expect(messageContents.id).toBe(123);
         expect(messageContents.subject).toBe('test3');
+    });
+
+    it('should fetch last logins', async () => {
+        const rmmapi = TestBed.inject(RunboxWebmailAPI);
+        const lastLogins = [
+            {
+                service: 'web',
+                login: 'testuser',
+                ip: '192.0.2.10',
+                created: '2026-06-10 10:00:00',
+                success: 1,
+            },
+        ];
+
+        const lastLoginsPromise = firstValueFrom(rmmapi.getLastLogins({ status: 1, service: 'web' }));
+        const httpTestingController = TestBed.inject(HttpTestingController);
+        const req = httpTestingController.expectOne('/rest/v1/acl/logins?status=1&service=web');
+        req.flush({
+            status: 'success',
+            last_logins: lastLogins,
+        });
+
+        expect(await lastLoginsPromise).toEqual(lastLogins);
+    });
+
+    it('should select the previous successful login', () => {
+        const currentLogin = {
+            service: 'web',
+            login: 'testuser',
+            ip: '192.0.2.10',
+            created: '2026-06-10 10:00:00',
+            success: 1,
+        };
+        const failedLogin = {
+            service: 'web',
+            login: 'testuser',
+            ip: '192.0.2.11',
+            created: '2026-06-10 09:50:00',
+            success: 0,
+        };
+        const previousLogin = {
+            service: 'web',
+            login: 'testuser',
+            ip: '192.0.2.12',
+            created: '2026-06-09 10:00:00',
+            success: '1',
+        };
+
+        expect(getPreviousSuccessfulLogin([
+            currentLogin,
+            failedLogin,
+            previousLogin,
+        ])).toEqual(previousLogin);
+        expect(getPreviousSuccessfulLogin([currentLogin])).toBeNull();
     });
 
     it('should flatten folder tree structure', async () => {

--- a/src/app/rmmapi/rbwebmail.ts
+++ b/src/app/rmmapi/rbwebmail.ts
@@ -126,6 +126,23 @@ export class RunboxMe {
     }
 }
 
+export interface LoginInfo {
+    service: string;
+    login: string;
+    ip: string;
+    hostname?: string;
+    created: string;
+    success: number | string | boolean;
+}
+
+export function getPreviousSuccessfulLogin(logins: LoginInfo[]): LoginInfo | null {
+    const successfulLogins = (logins || []).filter(login =>
+        login.success === 1 || login.success === '1' || login.success === true
+    );
+
+    return successfulLogins.length > 1 ? successfulLogins[1] : null;
+}
+
 export class MessageTextpart {
     type: string;
     textAsHtml: string;
@@ -339,6 +356,22 @@ export class RunboxWebmailAPI {
 
     public updateLastOn(): Observable<any> {
         return this.http.put('/rest/v1/last_on', {});
+    }
+
+    public getLastLogins(params: { [param: string]: string | number | boolean } = {}): Observable<LoginInfo[]> {
+        const queryParams = new URLSearchParams();
+        Object.keys(params).forEach((key) => {
+            const value = params[key];
+            if (value !== undefined && value !== null && value !== '') {
+                queryParams.set(key, String(value));
+            }
+        });
+        const queryString = queryParams.toString();
+        const url = '/rest/v1/acl/logins' + (queryString ? '?' + queryString : '');
+
+        return this.http.get(url).pipe(
+            map((res: any) => res.status === 'success' ? (res.last_logins || []) : [])
+        );
     }
 
     public listDeletedMessagesSince(sincechangeddate: Date): Observable<number[]> {


### PR DESCRIPTION
## Summary
- Add a typed helper for /rest/v1/acl/logins and select the previous successful web login from the returned list.
- Show a once-per-session snackbar in the Mail screen with the previous login timestamp and IP address.
- Cover the new login helper and previous-login selection rule with unit tests.

Fixes #1845

## Tests
- 
pm run test -- --watch=false --progress=false --browsers=FirefoxHeadless --include=src/app/rmmapi/rbwebmail.spec.ts
- 
px tsc -p src/tsconfig.app.json --noEmit
- 
pm run lint -- --quiet
- 
pm run policy (exits 0; existing historical commit-message warnings are still printed)

## AI Disclosure
- AI assistance used: OpenAI Codex helped inspect the codebase, implement the change, write tests, and run local verification commands.