### PR TITLE
fix(calendar): show account timezone in side menu

### DIFF
--- a/src/app/calendar-app/calendar-app.component.html
+++ b/src/app/calendar-app/calendar-app.component.html
@@ -131,6 +131,12 @@
                 <p mat-line>Settings</p>
             </mat-list-item>
 
+            <mat-list-item routerLink="/account/details" (click)="mobileQuery.matches && sidemenu.close()" class="calendarMenuButton timezoneInfo">
+                <mat-icon mat-list-icon svgIcon="earth"></mat-icon>
+                <p mat-line>Account time zone</p>
+                <p mat-line class="timezoneName">{{ calendarservice.accountTimezone || 'Not set' }}</p>
+            </mat-list-item>
+
             <a mat-list-item target="_blank" href="https://help.runbox.com/using-a-calendar-client-with-caldav/" class="calendarMenuButton">
                 <mat-icon mat-list-icon svgIcon="sync"></mat-icon>
                 <p mat-line>CalDAV Sync Guide</p>

--- a/src/app/calendar-app/calendar-app.component.scss
+++ b/src/app/calendar-app/calendar-app.component.scss
@@ -18,6 +18,13 @@
     }
 }
 
+.timezoneInfo {
+    .timezoneName {
+        opacity: 0.75;
+        word-break: break-word;
+    }
+}
+
 .updateInfo {
     &:hover {
         background-color: #fff;

--- a/src/app/calendar-app/calendar-app.component.spec.ts
+++ b/src/app/calendar-app/calendar-app.component.spec.ts
@@ -228,6 +228,16 @@ END:VCALENDAR
         expect(icon.style.color).toBe('pink');
     });
 
+    it('should display the account time zone in the side menu', () => {
+        fixture.detectChanges();
+
+        const timezoneInfo = fixture.debugElement.nativeElement.querySelector('.timezoneInfo');
+        expect(timezoneInfo).toBeDefined();
+        expect(timezoneInfo.attributes['routerLink'].value).toBe('/account/details');
+        expect(timezoneInfo.innerText).toContain('Account time zone');
+        expect(timezoneInfo.innerText).toContain('Europe/London');
+    });
+
     it('should display events', () => {
         mockData['events'] = simpleEvents;
         component.calendarservice.syncCaldav(true);

--- a/src/app/calendar-app/calendar.service.ts
+++ b/src/app/calendar-app/calendar.service.ts
@@ -63,6 +63,7 @@ export class CalendarService implements OnDestroy {
     activities      = new BackgroundActivityService<Activity>();
 
     me: RunboxMe    = new RunboxMe();
+    accountTimezone = '';
 
     userTimezoneLoaded = new AsyncSubject<ICAL.Timezone>();
 
@@ -74,7 +75,8 @@ export class CalendarService implements OnDestroy {
         // VTIMEZONE for their events to use
         this.rmmapi.me.subscribe(me => {
             this.me = me;
-            this.loadVTimezone(this.me.timezone);
+            this.accountTimezone = this.me.timezone;
+            this.loadVTimezone(this.accountTimezone);
         });
 
         // We need the user's timezone to display their events:


### PR DESCRIPTION
Summary:
- Display the account time zone in the Calendar side menu with a link to Account Details.
- Preserve the raw account time zone separately from the internal VTIMEZONE id used for event calculations.
- Cover the side-menu display and link with a focused CalendarAppComponent spec.

Tests:
- npm run test -- --watch=false --progress=false --browsers=FirefoxHeadless --include=src/app/calendar-app/calendar-app.component.spec.ts
- npm run lint -- --quiet
- npx tsc -p tsconfig.json --noEmit
- npm run policy (passes; reports existing upstream commit-message warnings)

Fixes #1828

Disclosure:
I used AI assistance to inspect the codebase, make this small change, and run local tests. I reviewed the diff before submitting. I did not use a live Runbox account or production data.