### PR TITLE
fix(login): prevent mobile focus zoom

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -147,7 +147,7 @@ p {
 }
 
 mat-form-field {
-    /* This is for iOS not to zoom in when focusing on text fields */
+    /* Compact default form fields; the login screen overrides this to avoid iOS focus zoom. */
     font-size: 13px !important;
 }
 
@@ -501,6 +501,11 @@ div.loginScreen {
 
     a {
 	color: mat.get-color-from-palette($rmm-default-primary);
+    }
+
+    mat-form-field {
+        /* iOS Safari zooms focused fields below 16px and can keep the app zoomed after login. */
+        font-size: 16px !important;
     }
 
     #loginArea {


### PR DESCRIPTION
Summary:
- Override login-screen Material form fields to 16px so iOS Safari does not auto-zoom when username, password, or 2FA fields receive focus.
- Keep the compact global form-field default for the rest of the app and clarify the login exception in the stylesheet comment.

Tests:
- npm run lint -- --quiet
- npx tsc -p tsconfig.json --noEmit
- git diff --check
- npx ng build runbox7 --configuration production --base-href=/app/ (passes; existing warnings about theming, unused TS entries, and CommonJS dependencies)
- npm run policy (passes; reports existing upstream commit-message warnings)

Not run:
- Physical iOS/Safari device verification was not available locally.

Fixes #1767

Disclosure:
I used AI assistance to inspect the codebase, make this small stylesheet change, and run local checks. I reviewed the diff before submitting. I did not use a live Runbox account or production data.