### PR TITLE
fix(compose): send after active draft save

### DIFF
--- a/src/app/compose/compose.component.spec.ts
+++ b/src/app/compose/compose.component.spec.ts
@@ -1,0 +1,173 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { Location } from '@angular/common';
+import { UntypedFormBuilder } from '@angular/forms';
+import { Router } from '@angular/router';
+import { BehaviorSubject, of, Subject } from 'rxjs';
+
+import { MailAddressInfo } from '../common/mailaddressinfo';
+import { DialogService } from '../dialog/dialog.service';
+import { MessageListService } from '../rmmapi/messagelist.service';
+import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
+import { Identity } from '../profiles/profile.service';
+import { PreferencesService } from '../common/preferences.service';
+import { RecipientsService } from './recipients.service';
+import { ComposeComponent } from './compose.component';
+import { DraftDeskService, DraftFormModel } from './draftdesk.service';
+
+describe('ComposeComponent submit', () => {
+    const identity = Identity.fromObject({
+        email: 'sender@example.com',
+        from_name: 'Sender',
+        id: 7,
+        folder: 'sent',
+    });
+
+    const createComponent = (draftSaveResponse = of({ mid: 12 })) => {
+        const formBuilder = new UntypedFormBuilder();
+        const router = jasmine.createSpyObj<Router>('Router', ['navigate']);
+        const snackBar = jasmine.createSpyObj('MatSnackBar', ['open']);
+        const rmmapi = {
+            me: of({ username: 'tester' }),
+            saveDraft: jasmine.createSpy('saveDraft').and.returnValue(of(['1', 'Message sent', '12'])),
+            deleteCachedMessageContents: jasmine.createSpy('deleteCachedMessageContents'),
+        };
+        const draftDeskservice = {
+            fromsSubject: new BehaviorSubject<Identity[]>([identity]),
+            isEditing: -1,
+            composingNewDraft: null,
+            shouldReturnToPreviousPage: false,
+        };
+        const messageListService = jasmine.createSpyObj<MessageListService>('MessageListService', ['refreshFolderList']);
+        const http = jasmine.createSpyObj('HttpClient', ['post']);
+        http.post.and.returnValue(draftSaveResponse);
+        const location = jasmine.createSpyObj<Location>('Location', ['back', 'prepareExternalUrl']);
+        const dialogService = jasmine.createSpyObj<DialogService>('DialogService', [
+            'openProgressDialog',
+            'closeProgressDialog',
+        ]);
+        const recipientService = {
+            recentlyUsed: new BehaviorSubject<MailAddressInfo[]>([]),
+        };
+        const preferenceService = {
+            prefGroup: 'compose',
+            preferences: new BehaviorSubject(new Map<string, string>()),
+            set: jasmine.createSpy('set'),
+        };
+
+        const component = new ComposeComponent(
+            router,
+            snackBar,
+            rmmapi as unknown as RunboxWebmailAPI,
+            draftDeskservice as unknown as DraftDeskService,
+            messageListService,
+            http as any,
+            formBuilder,
+            location,
+            dialogService,
+            recipientService as unknown as RecipientsService,
+            preferenceService as unknown as PreferencesService,
+            {} as any,
+        );
+
+        component.model = DraftFormModel.create(
+            12,
+            identity,
+            'recipient@example.com',
+            'Queued send',
+        );
+        component.model.msg_body = 'Message body';
+        component.formGroup = formBuilder.group(component.model);
+
+        return {
+            component,
+            dialogService,
+            http,
+            rmmapi,
+            router,
+            snackBar,
+        };
+    };
+
+    it('sends after the current draft save completes when Send is clicked mid-save', () => {
+        const draftSave = new Subject<any>();
+        const {
+            component,
+            dialogService,
+            http,
+            rmmapi,
+            router,
+        } = createComponent(draftSave);
+
+        component.submit(false);
+        expect(component.savingInProgress).toBeTrue();
+        expect(http.post).toHaveBeenCalled();
+
+        component.submit(true);
+        expect(rmmapi.saveDraft).not.toHaveBeenCalled();
+
+        draftSave.next({ mid: '12' });
+        draftSave.complete();
+
+        expect(rmmapi.saveDraft).toHaveBeenCalledTimes(1);
+        expect(rmmapi.saveDraft.calls.mostRecent().args[1]).toBeTrue();
+        expect(dialogService.openProgressDialog).toHaveBeenCalled();
+        expect(dialogService.closeProgressDialog).toHaveBeenCalled();
+        expect(router.navigate).toHaveBeenCalledWith(['/']);
+        expect(component.savingInProgress).toBeFalse();
+    });
+
+    it('does not leave savingInProgress set after invalid send recipients', () => {
+        const {
+            component,
+            dialogService,
+            rmmapi,
+            snackBar,
+        } = createComponent();
+        component.model.to = [new MailAddressInfo(null, 'invalid-recipient')];
+
+        component.submit(true);
+
+        expect(component.savingInProgress).toBeFalse();
+        expect(rmmapi.saveDraft).not.toHaveBeenCalled();
+        expect(dialogService.openProgressDialog).not.toHaveBeenCalled();
+        expect(snackBar.open).toHaveBeenCalledWith(
+            'Error sending: Cannot send email: TO field contains invalid email addresses',
+            'Dismiss',
+        );
+    });
+
+    it('does not leave savingInProgress set after a handled send error response', () => {
+        const {
+            component,
+            dialogService,
+            rmmapi,
+            snackBar,
+        } = createComponent();
+        rmmapi.saveDraft.and.returnValue(of(['0', 'Send failed']));
+
+        component.submit(true);
+
+        expect(component.savingInProgress).toBeFalse();
+        expect(dialogService.openProgressDialog).toHaveBeenCalled();
+        expect(dialogService.closeProgressDialog).toHaveBeenCalled();
+        expect(snackBar.open).toHaveBeenCalledWith('Send failed', 'Dismiss');
+    });
+});

--- a/src/app/compose/compose.component.ts
+++ b/src/app/compose/compose.component.ts
@@ -72,6 +72,7 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
     public editing = false;
     public isUnsaved = false;
     public savingInProgress = false;
+    private sendAfterCurrentSave = false;
     // public uploadprogress: number = null;
     public uploadingFiles: File[] = [];
     public uploadRequest: Subscription = null;
@@ -690,10 +691,16 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
         const isTemplate = Boolean(this.isTemplate ?? this.model.tid);
 
         if (this.savingInProgress) {
+            if (send) {
+                this.sendAfterCurrentSave = true;
+            }
             return;
         }
 
         this.savingInProgress = true;
+        if (send) {
+            this.sendAfterCurrentSave = false;
+        }
 
         if (send) {
             let validemails = false;
@@ -718,8 +725,10 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
                     `Error sending: ${this.saveErrorMessage}`,
                     'Dismiss'
                 );
+                this.savingInProgress = false;
                 return;
             }
+            this.saveErrorMessage = null;
             this.dialogService.openProgressDialog();
         }
         this.model.from = this.formGroup.value.from;
@@ -756,6 +765,8 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
             }
             if (!from) {
                 this.snackBar.open('You must set from address', 'OK', {duration: 1000});
+                this.savingInProgress = false;
+                this.dialogService.closeProgressDialog();
                 return;
             }
             // Use old form based API for sending as JSON api doesn't support this
@@ -767,6 +778,7 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
                 .subscribe((res) => {
                     if (res[0] === '0') {
                         this.snackBar.open(res[1], 'Dismiss');
+                        this.savingInProgress = false;
                         this.dialogService.closeProgressDialog();
                         return;
                     }
@@ -774,6 +786,7 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
                     this.model.mid = parseInt(res[2], 10);
                     this.rmmapi.deleteCachedMessageContents(this.model.mid);
                     this.snackBar.open(res[1], null, { duration: 3000 });
+                    this.saveErrorMessage = null;
 
                     this.draftDeskservice.isEditing = -1;
                     this.draftDeleted.emit(this.model.mid);
@@ -850,7 +863,7 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
                     this.saved = new Date();
                     this.saveErrorMessage = null;
 
-                    this.savingInProgress = false;
+                    this.finishSaving();
                     if (send) {
                         this.draftDeleted.emit(this.model.mid);
                         this.snackBar.open(res.status_msg, null, { duration: 3000 });
@@ -862,9 +875,18 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
                                 .map(fieldname =>
                                     `field ${fieldname}: ${err.field_errors[fieldname][0]}`);
                     }
-                    this.savingInProgress = false;
                     this.saveErrorMessage = `Error saving draft: ${msg}`;
+                    this.finishSaving();
                 });
+        }
+    }
+
+    private finishSaving() {
+        this.savingInProgress = false;
+
+        if (this.sendAfterCurrentSave) {
+            this.sendAfterCurrentSave = false;
+            this.submit(true);
         }
     }
 


### PR DESCRIPTION
Fixes #1727.

Summary:
- remember a Send click made while a draft save/autosave is already in progress
- replay the send after the current save finishes, so the click is not dropped
- clear saving state on invalid-recipient, missing-from, and handled send-error returns
- add focused compose submit regression coverage

Validation:
- `npx ng test runbox7 --watch=false --include src/app/compose/compose.component.spec.ts` (`3 SUCCESS`)
- `npx ng test runbox7 --watch=false` (`248 SUCCESS`, `2 skipped`; existing unrelated Angular/Karma console errors still printed)
- `npm run lint -- --quiet`
- `npx tsc -p tsconfig.json --noEmit`
- `git diff --check` (only the existing Windows LF-to-CRLF warning)
- `npm run policy` (exits 0; existing historical commit-message warnings)
- `npx ng build runbox7 --configuration production --base-href=/app/` (exits 0; existing dependency and unused-file warnings)

AI disclosure:
I used AI assistance to inspect the issue, implement the fix, and prepare tests. I reviewed the changes and validation output before submitting.
