### PR TITLE
fix(calendar): use 24-hour picker times

### DIFF
--- a/src/app/calendar-app/calendar-app.module.spec.ts
+++ b/src/app/calendar-app/calendar-app.module.spec.ts
@@ -1,0 +1,38 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2018 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import moment from 'moment';
+import { MOMENT_FORMATS } from './calendar-app.module';
+
+describe('CalendarAppModule', () => {
+    it('uses 24-hour time for calendar date-time picker inputs', () => {
+        const date = moment({
+            year: 2026,
+            month: 0,
+            date: 1,
+            hour: 14,
+            minute: 5,
+        });
+
+        expect(date.format(MOMENT_FORMATS.fullPickerInput)).toContain('14:05');
+        expect(date.format(MOMENT_FORMATS.timePickerInput)).toBe('14:05');
+        expect(MOMENT_FORMATS.parseInput).toContain('HH:mm');
+        expect(date.format(MOMENT_FORMATS.fullPickerInput)).not.toContain('PM');
+    });
+});

--- a/src/app/calendar-app/calendar-app.module.ts
+++ b/src/app/calendar-app/calendar-app.module.ts
@@ -60,10 +60,10 @@ import { CalendarEventCardComponent } from './calendar-event-card.component';
 
 // See https://momentjs.com/docs/#/displaying/format/
 export const MOMENT_FORMATS = {
-    parseInput: 'l LT',
-    fullPickerInput: 'l LT',
+    parseInput: 'l HH:mm',
+    fullPickerInput: 'l HH:mm',
     datePickerInput: 'l',
-    timePickerInput: 'LT',
+    timePickerInput: 'HH:mm',
     monthYearLabel: 'MMM YYYY',
     dateA11yLabel: 'LL',
     monthYearA11yLabel: 'MMMM YYYY',


### PR DESCRIPTION
Fixes #1432.

Summary:
- switch calendar date-time picker display/parsing from locale `LT` time to explicit `HH:mm`
- keep the date portion locale-aware via `l`
- add focused regression coverage for the exported calendar picker formats

Validation:
- `npx ng test runbox7 --watch=false --include src/app/calendar-app/calendar-app.module.spec.ts` (`1 SUCCESS`)
- `npx ng test runbox7 --watch=false --include "src/app/calendar-app/**/*.spec.ts"` (`32 SUCCESS`)
- `npx ng test runbox7 --watch=false` (`246 SUCCESS`, `2 skipped`; existing unrelated Angular/Karma console errors still printed)
- `npm run lint -- --quiet`
- `npx tsc -p tsconfig.json --noEmit`
- `git diff --check` / `git diff --cached --check` (only the existing Windows LF-to-CRLF warning before staging; staged diff is clean)
- `npm run policy` (exits 0; existing historical commit-message warnings)
- `npx ng build --configuration production --base-href=/app/ runbox7` (exits 0; existing dependency and unused-file warnings)

AI disclosure:
I used AI assistance to inspect the issue, implement the fix, and prepare tests. I reviewed the changes and validation output before submitting.
