### PR TITLE
fix(account): hide inactive storage renewals

### DIFF
--- a/src/app/account-app/account-renewals.component.spec.ts
+++ b/src/app/account-app/account-renewals.component.spec.ts
@@ -1,0 +1,56 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { canRenewActiveProduct } from './account-renewals.component';
+
+describe('canRenewActiveProduct', () => {
+    it('should not allow storage add-on renewals', () => {
+        expect(canRenewActiveProduct({
+            pid: 301,
+            type: 'addon',
+            subtype: 'emailaddon',
+            name: 'Additional Email Storage Space',
+        })).toBe(false);
+    });
+
+    it('should allow normal product renewals', () => {
+        expect(canRenewActiveProduct({
+            pid: 1010,
+            type: 'subscription',
+            subtype: 'medium',
+            name: 'Runbox Medium',
+        })).toBe(true);
+    });
+
+    it('should leave trial and domain products out of regular renewals', () => {
+        expect(canRenewActiveProduct({
+            pid: 1000,
+            type: 'subscription',
+            subtype: 'trial',
+            name: 'Trial',
+        })).toBe(false);
+
+        expect(canRenewActiveProduct({
+            pid: 601,
+            type: 'addon',
+            subtype: 'domain',
+            name: 'Domain registration',
+        })).toBe(false);
+    });
+});

--- a/src/app/account-app/account-renewals.component.ts
+++ b/src/app/account-app/account-renewals.component.ts
@@ -37,7 +37,16 @@ const columnsDefault = ['renewal_name', 'quantity', 'price', 'active_from', 'act
 const columnsMobile = ['renewal_name'];
 
 // TODO define it as an interface
-type ActiveProduct = any;
+export type ActiveProduct = any;
+
+export function canRenewActiveProduct(p: ActiveProduct): boolean {
+    const isStorageAddon = p.type === 'addon'
+        && typeof p.name === 'string'
+        && p.name.toLowerCase().includes('storage');
+
+    // no renewals for trials; domains handled separately
+    return (p.pid !== 1000) && (p.subtype !== 'domain') && !isStorageAddon;
+}
 
 @Component({
     selector: 'app-account-renewals-component',
@@ -88,8 +97,7 @@ export class AccountRenewalsComponent {
                     p.expired_over_2_years = true;
                 }
 
-                // no renewals for trials; domains handled separately
-                p.can_renew = (p.pid !== 1000) && (p.subtype !== 'domain');
+                p.can_renew = canRenewActiveProduct(p);
 
                 return p;
             });
@@ -114,10 +122,10 @@ export class AccountRenewalsComponent {
     }
 
     renew(p: ActiveProduct) {
-        if (p.subtype !== 'domain') {
-            this.cart.add(new ProductOrder(p.pid, p.type, p.quantity, p.apid));
-        } else {
+        if (p.subtype === 'domain') {
             this.renewDomain(p);
+        } else if (p.can_renew) {
+            this.cart.add(new ProductOrder(p.pid, p.type, p.quantity, p.apid));
         }
     }
 


### PR DESCRIPTION
Closes #1298

## Summary

- centralize renewal eligibility for active products in `canRenewActiveProduct`
- mark storage add-ons such as Additional Email Storage Space as not regularly renewable
- guard the `renew()` handler so non-renewable products cannot be added to the cart through the regular renewal path
- keep domain products on the existing domain-renewal flow

## Tests

- Confirmed the new spec is red before the implementation because `canRenewActiveProduct` was missing.
- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/account-app/account-renewals.component.spec.ts`
- `npx ng test --watch=false --browsers=FirefoxHeadless --include="src/app/account-app/**/*.spec.ts"`
- `npx tsc -p tsconfig.json --noEmit`
- `git diff --check origin/master..HEAD`
- `npm run lint` (exits 0 with existing warnings)
- `npm run policy` (exits 0; prints existing historical commit-message warnings)
- `npx ng test --watch=false --browsers=FirefoxHeadless` (248 SUCCESS, 2 skipped, with existing unrelated console noise)
- `node src/build/pre-build.js && npx ng build runbox7 --configuration production --base-href /app/ && node src/build/post-build.js` (passes with existing warnings)

The production build regenerated `src/app/changelog/changes.ts`; I did not include that generated churn in this PR.

## AI disclosure

I used OpenAI Codex as an implementation assistant for this change. I reviewed the issue, source changes, tests, and validation output before submitting.
