### PR TITLE
fix(app): warn when folder deletion is blocked by rules

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,0 +1,92 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { EMPTY, of } from 'rxjs';
+import { AppComponent, isFolderDeleteBlockedByRule } from './app.component';
+
+describe('isFolderDeleteBlockedByRule', () => {
+  it('identifies successful delete responses blocked by filter rules', () => {
+    expect(isFolderDeleteBlockedByRule({
+      status: 'success',
+      result: {
+        msg: 'folder_has_rule'
+      }
+    })).toBeTrue();
+  });
+
+  it('ignores successful delete responses without a filter-rule block', () => {
+    expect(isFolderDeleteBlockedByRule({
+      status: 'success',
+      result: {}
+    })).toBeFalse();
+  });
+});
+
+describe('AppComponent folder deletion', () => {
+  const createComponent = (deleteFolderResponse: unknown) => {
+    const snackBar = {
+      open: jasmine.createSpy('open').and.returnValue({
+        onAction: () => EMPTY
+      })
+    };
+    const messagelistservice = {
+      refreshFolderList: jasmine.createSpy('refreshFolderList')
+    };
+    const rmmapi = {
+      deleteFolder: jasmine.createSpy('deleteFolder').and.returnValue(of(deleteFolderResponse))
+    };
+    const component = {
+      messagelistservice,
+      rmmapi,
+      snackBar
+    } as any as AppComponent;
+
+    return { component, messagelistservice, rmmapi, snackBar };
+  };
+
+  it('warns without refreshing the folder list when a filter rule blocks deletion', () => {
+    const { component, messagelistservice, rmmapi, snackBar } = createComponent({
+      status: 'success',
+      result: {
+        msg: 'folder_has_rule'
+      }
+    });
+
+    AppComponent.prototype.deleteFolder.call(component, 123);
+
+    expect(rmmapi.deleteFolder).toHaveBeenCalledWith(123);
+    expect(snackBar.open).toHaveBeenCalledWith(
+      'Folder cannot be deleted while a filter rule saves mail to it. Remove the rule first, then try again.',
+      'Open filters'
+    );
+    expect(messagelistservice.refreshFolderList).not.toHaveBeenCalled();
+  });
+
+  it('refreshes the folder list after a completed deletion', () => {
+    const { component, messagelistservice, snackBar } = createComponent({
+      status: 'success',
+      result: {}
+    });
+
+    AppComponent.prototype.deleteFolder.call(component, 123);
+
+    expect(snackBar.open).not.toHaveBeenCalled();
+    expect(messagelistservice.refreshFolderList).toHaveBeenCalled();
+  });
+});

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -55,7 +55,7 @@ describe('AppComponent folder deletion', () => {
       messagelistservice,
       rmmapi,
       snackBar
-    } as any as AppComponent;
+    };
 
     return { component, messagelistservice, rmmapi, snackBar };
   };

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -76,6 +76,13 @@ const LOCAL_STORAGE_SHOW_UNREAD_ONLY = 'rmm7mailViewerShowUnreadOnly';
 const LOCAL_STORAGE_SHOW_POPULAR_RECIPIENTS = 'showPopularRecipients';
 const LOCAL_STORAGE_INDEX_PROMPT = 'localSearchPromptDisplayed';
 const TOOLBAR_LIST_BUTTON_WIDTH = 30;
+const FOLDER_HAS_RULE_MESSAGE = 'folder_has_rule';
+
+export function isFolderDeleteBlockedByRule(response: unknown): boolean {
+  const deleteResponse = response as { status?: string, result?: { msg?: string } };
+  return deleteResponse?.status === 'success'
+    && deleteResponse?.result?.msg === FOLDER_HAS_RULE_MESSAGE;
+}
 
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
@@ -569,7 +576,18 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
 
   deleteFolder(folderId: number) {
     this.rmmapi.deleteFolder(folderId).subscribe(
-      () => this.messagelistservice.refreshFolderList()
+      res => {
+        if (isFolderDeleteBlockedByRule(res)) {
+          const snackbarRef = this.snackBar.open(
+            'Folder cannot be deleted while a filter rule saves mail to it. Remove the rule first, then try again.',
+            'Open filters'
+          );
+          snackbarRef.onAction().subscribe(() => window.open('/mail/rules', 'rmm6'));
+          return;
+        }
+
+        this.messagelistservice.refreshFolderList();
+      }
     );
   }
 


### PR DESCRIPTION
Closes #1347

## Summary

- detect the successful `folder_has_rule` delete response as a blocked folder deletion
- show a snackbar explaining that a filter rule still saves mail to the folder
- provide an `Open filters` snackbar action that opens `/mail/rules`
- skip the folder-list refresh when the folder was not actually deleted

## Tests

- Confirmed the new focused spec is red before the implementation because `isFolderDeleteBlockedByRule` was missing.
- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/app.component.spec.ts`
- `npx tsc -p tsconfig.json --noEmit`
- `git diff --check origin/master..HEAD`
- `npx ng test --watch=false --browsers=FirefoxHeadless` (249 SUCCESS, 2 skipped, with existing unrelated console noise)
- `npm run lint` (exits 0 with 770 existing warnings)
- `npm run policy` (exits 0; prints existing historical commit-message warnings)
- `node src/build/pre-build.js && npx ng build runbox7 --configuration production --base-href /app/ && node src/build/post-build.js` (passes with existing warnings)

The production build regenerated `src/app/changelog/changes.ts`; I did not include that generated churn in this PR.

## AI disclosure

I used OpenAI Codex as an implementation assistant for this change. I reviewed the issue, source changes, tests, and validation output before submitting.
