### PR TITLE
Fix #1304: add CardDAV guide link to Contacts menu

### DIFF
--- a/src/app/contacts-app/contacts-app.component.html
+++ b/src/app/contacts-app/contacts-app.component.html
@@ -32,6 +32,11 @@
                 <p mat-line>Settings</p>
             </mat-list-item>
 
+            <a mat-list-item target="_blank" href="https://help.runbox.com/runbox-7-contacts/" class="contactListButton">
+                <mat-icon mat-list-icon svgIcon="sync"></mat-icon>
+                <p mat-line>CardDAV Sync Guide</p>
+            </a>
+
             <mat-divider></mat-divider>
 
             <mat-list-item routerLink="/contacts/" class="contactListButton" [ngClass]="!shownGroup ? 'selectedFolder' : ''">

--- a/src/app/contacts-app/contacts-app.component.spec.ts
+++ b/src/app/contacts-app/contacts-app.component.spec.ts
@@ -1,0 +1,135 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { CommonModule } from '@angular/common';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { HttpClient } from '@angular/common/http';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { MatLegacyDialog as MatDialog } from '@angular/material/legacy-dialog';
+import { MatLegacySnackBar as MatSnackBar } from '@angular/material/legacy-snack-bar';
+import { ActivatedRoute } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { of, Subject } from 'rxjs';
+
+import { ContactsAppComponent } from './contacts-app.component';
+import { ContactsService } from './contacts.service';
+import { LogoutService } from '../login/logout.service';
+import { MobileQueryService } from '../mobile-query.service';
+import { UsageReportsService } from '../common/usage-reports.service';
+
+describe('ContactsAppComponent', () => {
+    let fixture: ComponentFixture<ContactsAppComponent>;
+
+    beforeEach(waitForAsync(() => {
+        TestBed.configureTestingModule({
+            declarations: [
+                ContactsAppComponent,
+            ],
+            imports: [
+                CommonModule,
+                MatIconTestingModule,
+                NoopAnimationsModule,
+                RouterTestingModule.withRoutes([]),
+            ],
+            providers: [
+                {
+                    provide: ActivatedRoute,
+                    useValue: {
+                        queryParams: of({}),
+                    },
+                },
+                {
+                    provide: ContactsService,
+                    useValue: {
+                        activities: {
+                            observable: of([]),
+                        },
+                        contactCategories: of([]),
+                        contactsSubject: of([]),
+                        deleteMultiple: () => Promise.resolve(),
+                        errorLog: new Subject(),
+                        informationLog: new Subject(),
+                        migratingContacts: 0,
+                        saveDragHelpers: () => undefined,
+                        showDragHelpers: false,
+                    },
+                },
+                {
+                    provide: HttpClient,
+                    useValue: {
+                        get: () => of(new Blob()),
+                    },
+                },
+                {
+                    provide: LogoutService,
+                    useValue: {
+                        logout: () => undefined,
+                    },
+                },
+                {
+                    provide: MatDialog,
+                    useValue: {
+                        open: () => ({
+                            afterClosed: () => of(null),
+                        }),
+                    },
+                },
+                {
+                    provide: MatSnackBar,
+                    useValue: {
+                        open: () => undefined,
+                    },
+                },
+                {
+                    provide: MobileQueryService,
+                    useValue: {
+                        changed: new Subject<boolean>(),
+                        matches: false,
+                    },
+                },
+                {
+                    provide: UsageReportsService,
+                    useValue: {
+                        report: () => undefined,
+                    },
+                },
+            ],
+            schemas: [
+                NO_ERRORS_SCHEMA,
+            ],
+        }).compileComponents();
+    }));
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(ContactsAppComponent);
+    });
+
+    it('shows a CardDAV sync guide link in the contacts menu', () => {
+        fixture.detectChanges();
+
+        const guideLink: HTMLAnchorElement = fixture.nativeElement.querySelector(
+            'a.contactListButton[href="https://help.runbox.com/runbox-7-contacts/"]',
+        );
+
+        expect(guideLink).withContext('CardDAV guide link is present').not.toBeNull();
+        expect(guideLink?.textContent).toContain('CardDAV Sync Guide');
+    });
+});


### PR DESCRIPTION
## Summary
- Add a `CardDAV Sync Guide` entry to the Contacts side menu, matching the Calendar menu's sync-guide affordance.
- Link the menu item to the Runbox 7 Contacts help page, which documents CardDAV-backed contacts and synchronization.
- Add a focused Contacts shell spec that verifies the guide link is rendered in the menu.

Fixes #1304

## Testing
- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/contacts-app/contacts-app.component.spec.ts`
- `npx tsc -p tsconfig.json --noEmit`
- `git diff --check origin/master..HEAD`
- `npm run lint` (passes with the existing 770 warnings)
- `npx ng test --watch=false --browsers=FirefoxHeadless` (246 success, 2 skipped)
- `npm run policy` (passes; reports existing historical commit-message warnings)
- `node src/build/pre-build.js`
- `npx ng build runbox7 --configuration production --base-href /app/`
- `node src/build/post-build.js`

## AI Assistance
This PR was implemented with assistance from OpenAI's Codex. I reviewed the issue, selected the approach, ran the validation commands, and checked the final diff.
