### PR TITLE
fix(calendar): show monthly recurrence selections

### DIFF
--- a/src/app/calendar-app/event-editor-dialog.component.html
+++ b/src/app/calendar-app/event-editor-dialog.component.html
@@ -79,12 +79,12 @@
           </ng-container>
         </p>
         <ng-container *ngIf="recurring_frequency === 'MONTHLY' || recurring_frequency === 'YEARLY'" style="margin-top: 10px;display: flex;">
-          <p style="display: flex; justify-content: space-between; align-items: center;">
+          <p class="calendarRecurrenceRuleRow">
             on the
-            <mat-select style="width:auto;" (selectionChange)="updateMonthlyNth($event)" [(value)]="recur_by_monthyeardays" multiple [disabled]="!event_recurs">
+            <mat-select class="calendarRecurrenceNthSelect" (selectionChange)="updateMonthlyNth($event)" [(value)]="recur_by_monthyeardays" multiple [disabled]="!event_recurs">
               <mat-option *ngFor="let mnthday of month_year_days" [value]="mnthday.val" ngDefaultControl>{{ mnthday.name }}</mat-option>
             </mat-select>
-            <mat-select style="width:auto;" (selectionChange)="updateWeekday($event)" [(value)]="recur_by_weekdays" multiple [disabled]="!event_recurs">
+            <mat-select class="calendarRecurrenceWeekdaySelect" (selectionChange)="updateWeekday($event)" [(value)]="recur_by_weekdays" multiple [disabled]="!event_recurs">
               <mat-option value="day">day</mat-option>
               <mat-option *ngFor="let wday of weekdays"[value]="wday.val" ngDefaultControl>{{ wday.name }}</mat-option>
             </mat-select>
@@ -93,7 +93,7 @@
             </span>
             <span *ngIf="recurring_frequency === 'YEARLY'">
               of
-              <mat-select style="width:auto;" (selectionChange)="updateMonths($event)" [(value)]="recur_by_months" multiple [disabled]="!event_recurs">
+              <mat-select class="calendarRecurrenceMonthSelect" (selectionChange)="updateMonths($event)" [(value)]="recur_by_months" multiple [disabled]="!event_recurs">
                 <mat-option *ngFor="let month of year_months" [value]="month.val" ngDefaultControl>{{ month.name }}</mat-option>
               </mat-select>
           </span>

--- a/src/app/calendar-app/event-editor-dialog.component.scss
+++ b/src/app/calendar-app/event-editor-dialog.component.scss
@@ -1,0 +1,19 @@
+.calendarRecurrenceRuleRow {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    justify-content: flex-start;
+}
+
+.calendarRecurrenceNthSelect {
+    width: 88px;
+}
+
+.calendarRecurrenceWeekdaySelect {
+    width: 116px;
+}
+
+.calendarRecurrenceMonthSelect {
+    width: 128px;
+}

--- a/src/app/calendar-app/event-editor-dialog.component.spec.ts
+++ b/src/app/calendar-app/event-editor-dialog.component.spec.ts
@@ -1,0 +1,115 @@
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ErrorHandler } from '@angular/core';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA, MatLegacyDialog as MatDialog, MatLegacyDialogRef as MatDialogRef } from '@angular/material/legacy-dialog';
+import { MatLegacySelectHarness } from '@angular/material/legacy-select/testing';
+import { MatLegacyTabGroupHarness } from '@angular/material/legacy-tabs/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { of } from 'rxjs';
+
+import { CalendarAppModule } from './calendar-app.module';
+import { CalendarSettings } from './calendar-settings';
+import { EventEditorDialogComponent } from './event-editor-dialog.component';
+import { RunboxCalendar } from './runbox-calendar';
+import { RunboxCalendarEvent } from './runbox-calendar-event';
+
+describe('EventEditorDialogComponent', () => {
+    let component: EventEditorDialogComponent;
+    let fixture: ComponentFixture<EventEditorDialogComponent>;
+    let loader: HarnessLoader;
+
+    async function selectWithValueText(text: string): Promise<MatLegacySelectHarness> {
+        const selects = await loader.getAllHarnesses(MatLegacySelectHarness);
+        for (const select of selects) {
+            if ((await select.getValueText()).trim() === text) {
+                return select;
+            }
+        }
+        throw new Error(`Select with value text "${text}" not found`);
+    }
+
+    beforeEach(waitForAsync(() => {
+        TestBed.configureTestingModule({
+            imports: [
+                CalendarAppModule,
+                NoopAnimationsModule,
+            ],
+            providers: [
+                { provide: MAT_DIALOG_DATA, useValue: {
+                    calendars: [
+                        new RunboxCalendar({
+                            id: 'test-calendar',
+                            displayname: 'Test Calendar',
+                            color: 'pink',
+                            syncToken: 'testsync',
+                        }),
+                    ],
+                    event: RunboxCalendarEvent.newEmpty('Europe/London'),
+                    is_new: true,
+                    settings: new CalendarSettings({}),
+                } },
+                { provide: MatDialog, useValue: {
+                    open: () => ({
+                        afterClosed: () => of(false),
+                    }),
+                } },
+                { provide: MatDialogRef, useValue: {
+                    close: () => undefined,
+                } },
+                { provide: ErrorHandler, useValue: {
+                    handleError: () => undefined,
+                } },
+            ],
+        }).compileComponents();
+    }));
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(EventEditorDialogComponent);
+        component = fixture.componentInstance;
+        loader = TestbedHarnessEnvironment.loader(fixture);
+        spyOn(console, 'log');
+        fixture.detectChanges();
+    });
+
+    it('should display changed monthly recurrence selector values', async () => {
+        component.event_recurs = true;
+        component.recurring_frequency = 'MONTHLY';
+        component.recur_by_monthyeardays = ['1'];
+        component.recur_by_weekdays = ['day'];
+        fixture.detectChanges();
+
+        const tabs = await loader.getHarness(MatLegacyTabGroupHarness);
+        await tabs.selectTab({ label: 'Recurrence' });
+
+        const nthSelect = await selectWithValueText('1st');
+        expect((await (await nthSelect.host()).getDimensions()).width).toBeGreaterThan(70);
+        await nthSelect.clickOptions({ text: '2nd' });
+        expect(component.recur_by_monthyeardays).toEqual(['1', '2']);
+        expect(await nthSelect.getValueText()).toContain('2nd');
+
+        const weekdaySelect = await selectWithValueText('day');
+        expect((await (await weekdaySelect.host()).getDimensions()).width).toBeGreaterThan(90);
+        await weekdaySelect.clickOptions({ text: 'Monday' });
+        expect(component.recur_by_weekdays).toEqual(['MO']);
+        expect(await weekdaySelect.getValueText()).toContain('Monday');
+    });
+});

--- a/src/app/calendar-app/event-editor-dialog.component.ts
+++ b/src/app/calendar-app/event-editor-dialog.component.ts
@@ -32,6 +32,7 @@ import ICAL from 'ical.js';
 @Component({
     selector: 'app-calendar-event-editor-dialog',
     templateUrl: 'event-editor-dialog.component.html',
+    styleUrls: ['event-editor-dialog.component.scss'],
 })
 export class EventEditorDialogComponent {
     event: RunboxCalendarEvent;


### PR DESCRIPTION
## Summary
- Give the monthly/yearly recurrence sentence selects explicit scoped widths so selected nth, weekday, and month values are visible instead of collapsing to arrow-only controls.
- Let the recurrence row wrap when the dialog is narrow, while preserving the existing recurrence selection behavior.
- Add a focused event-editor dialog spec that covers the rendered select widths and verifies changed monthly recurrence selections are displayed.

Fixes #1324

## Testing
- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/calendar-app/event-editor-dialog.component.spec.ts`
- `npx tsc -p tsconfig.json --noEmit`
- `git diff --check origin/master..HEAD`
- `npm run lint` (passes with the existing 770 warnings)
- `npm run policy` (passes; reports existing historical commit-message warnings)
- `npx ng test --watch=false --browsers=FirefoxHeadless` (246 success, 2 skipped)
- `node src/build/pre-build.js`
- `npx ng build runbox7 --configuration production --base-href /app/`
- `node src/build/post-build.js`

## AI Assistance
This PR was implemented with assistance from OpenAI's Codex. I reviewed the issue and screenshots, selected the approach, ran the validation commands, and checked the final diff.
