### PR TITLE
Fix recurring event time updates from later occurrences

### DIFF
--- a/src/app/calendar-app/runbox-calendar-event.spec.ts
+++ b/src/app/calendar-app/runbox-calendar-event.spec.ts
@@ -275,6 +275,48 @@ describe('RunboxCalendarEvent', () => {
         expect(sut.toIcal()).toContain('DTSTART:20210201T100000');
     });
 
+    it('should update all recurring event times from a later occurrence', () => {
+        const sut = new RunboxCalendarEvent(
+            'testcal/unittestcase-all-times', new ICAL.Event(new ICAL.Component([
+                'vevent', [
+                  [ 'dtstart', {}, 'date-time',  '2021-01-25T09:00:00' ],
+                  [ 'dtend',   {}, 'date-time',  '2021-01-25T10:00:00' ],
+                  [ 'summary', {}, 'text',  'Weekly event' ],
+                  [ 'uid',     {}, 'text',  'unittestcase-all-times' ],
+                  [ 'rrule',   {}, 'recur', {
+                      'freq': 'WEEKLY',
+                      'byhour': [9],
+                      'byminute': [0],
+                      'bysecond': [0],
+                  } ],
+                ]
+            ])),
+            ICAL.Time.fromDateTimeString('2021-02-01T09:00:00'),
+            ICAL.Time.fromDateTimeString('2021-02-01T10:00:00'),
+            'Europe/London'
+        );
+
+        sut.updateEvent(
+            moment('2021-02-01T10:00:00'),
+            moment('2021-02-01T11:00:00'),
+            false,
+            sut.calendar,
+            RecurSaveType.ALL_OCCURENCES,
+            'Weekly event', undefined, undefined,
+            true,
+            sut.recurringFrequency,
+            sut.recurInterval,
+            ['MO'], [], [],
+        );
+
+        expect(sut.toIcal()).toContain('DTSTART:20210125T100000');
+        expect(sut.toIcal()).toContain('DTEND:20210125T110000');
+        expect(sut.toIcal()).toContain('BYHOUR=10');
+        expect(sut.toIcal()).toContain('BYMINUTE=0');
+        expect(sut.toIcal()).toContain('BYSECOND=0');
+        expect(sut.toIcal()).not.toContain('RECURRENCE-ID');
+    });
+
     it('should be possible to add a special case to a recurring event (with timezone)', () => {
          // mostly taken straight out of the jCal spec: https://tools.ietf.org/html/rfc7265#page-30
       const jcal = ICAL.parse(

--- a/src/app/calendar-app/runbox-calendar-event.ts
+++ b/src/app/calendar-app/runbox-calendar-event.ts
@@ -454,6 +454,62 @@ export class RunboxCalendarEvent implements CalendarEvent {
         // regenerate this.event to sort out the exceptions/recurrences?
     }
 
+    private isEditingRecurrenceStart(): boolean {
+        return this._dtstart.toJSDate().toString() === this.recurStart.toString();
+    }
+
+    private keepRecurrenceDateWithSelectedTime(base: ICAL.Time, selected: ICAL.Time): ICAL.Time {
+        const updated = base.clone();
+        updated.hour = selected.hour;
+        updated.minute = selected.minute;
+        updated.second = selected.second;
+        updated.isDate = selected.isDate;
+        updated.zone = selected.zone;
+        return updated;
+    }
+
+    private updateBaseRecurringEventTime(dtstart: moment.Moment, dtend: moment.Moment): void {
+        const selectedStart = this.momentToIcalTime(
+            dtstart,
+            this.event.startDate ? this.event.startDate.zone : null
+        );
+        const baseStart = this.keepRecurrenceDateWithSelectedTime(this.event.startDate, selectedStart);
+
+        this._dtstart = baseStart;
+        this.event.startDate = baseStart;
+
+        if (dtend) {
+            const selectedEnd = this.momentToIcalTime(
+                dtend,
+                this.event.endDate ? this.event.endDate.zone : selectedStart.zone
+            );
+            const baseEnd = baseStart.clone();
+            baseEnd.addDuration(selectedEnd.subtractDate(selectedStart));
+            baseEnd.isDate = selectedEnd.isDate;
+
+            this._dtend = baseEnd;
+            this.event.endDate = baseEnd;
+        }
+    }
+
+    private updateRecurringRuleTime(start: ICAL.Time): void {
+        const recur = this.event.component.getFirstPropertyValue('rrule');
+        if (!recur || start.isDate) {
+            return;
+        }
+
+        if (recur.getComponent('byhour').length) {
+            recur.setComponent('byhour', [start.hour]);
+        }
+        if (recur.getComponent('byminute').length) {
+            recur.setComponent('byminute', [start.minute]);
+        }
+        if (recur.getComponent('bysecond').length) {
+            recur.setComponent('bysecond', [start.second]);
+        }
+        this.event.component.updatePropertyWithValue('rrule', recur);
+    }
+
     // set values from edit dialog, inc logic for recurring
     // parts + exception creation.
     updateEvent(
@@ -484,8 +540,14 @@ export class RunboxCalendarEvent implements CalendarEvent {
                 location);
         } else {
             this._allDay     = allDay;
-            this.dtstart     = dtstart;
-            this.dtend       = dtend;
+            if (this.recurs
+                && recur_save_type === RecurSaveType.ALL_OCCURENCES
+                && !this.isEditingRecurrenceStart()) {
+                this.updateBaseRecurringEventTime(dtstart, dtend);
+            } else {
+                this.dtstart = dtstart;
+                this.dtend   = dtend;
+            }
             this.calendar    = calendar;
             if (title) {
                 this.title       = title;
@@ -550,6 +612,7 @@ export class RunboxCalendarEvent implements CalendarEvent {
                         }
                     }
                 }
+                this.updateRecurringRuleTime(this.event.startDate);
             }
         }
     }


### PR DESCRIPTION
Fixes #1384.

## Summary

- Apply an "all occurrences" time edit made from a later recurring instance back to the recurring event's original `DTSTART` date, instead of dropping the update because the edited instance date differs from the recurrence anchor.
- Preserve the selected start/end duration when updating the base recurring `DTSTART`/`DTEND`.
- Keep existing simple `BYHOUR`, `BYMINUTE`, and `BYSECOND` RRULE parts synchronized with the new start time so regenerated occurrences display at the updated time.
- Add a regression test that edits the second occurrence of a weekly event, verifies the base event moves from 09:00-10:00 to 10:00-11:00, updates the time-based RRULE parts, and does not create a `RECURRENCE-ID` exception.

## Testing

- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/calendar-app/runbox-calendar-event.spec.ts`
- `npx tsc -p tsconfig.json --noEmit`
- `git diff --check origin/master..HEAD`
- `npm run policy`
  - Current commits are OK; the command still reports existing historical commit-message warnings.
- `npm run lint`
  - Exits 0 with the repository's existing 770 warnings.
- `npx ng test --watch=false --browsers=FirefoxHeadless`
  - 246 success, 2 skipped, with existing console noise.
- `node src/build/pre-build.js`
- `npx ng build runbox7 --configuration production --base-href /app/`
- `node src/build/post-build.js`
  - Production build passes with existing Angular/CommonJS warnings.

## Disclosure

AI assistance was used to investigate the recurrence update path and draft this change. I reviewed the patch and ran the validation above before submitting.
