### PR TITLE
Decode MIME encoded mail header text

### DIFF
--- a/src/app/common/mailaddressinfo.spec.ts
+++ b/src/app/common/mailaddressinfo.spec.ts
@@ -77,4 +77,10 @@ describe('MailAddressInfo', () => {
         expect(ma_list[0].nameAndAddress).toBe('"Fred B" <fred@foo.bar.baz.tld>');
         expect(ma_list[0].domain).toBe('foo.bar.baz.tld');
     });
+    it('Parse MIME encoded address name', () => {
+        const ma_list = MailAddressInfo.parse('=?UTF-8?Q?Koteck=C3=BD?= <k@example.com>');
+        expect(ma_list[0].name).toBe('Koteck\u00fd');
+        expect(ma_list[0].address).toBe('k@example.com');
+        expect(ma_list[0].nameAndAddress).toBe('"Koteck\u00fd" <k@example.com>');
+    });
 });

--- a/src/app/common/mailaddressinfo.ts
+++ b/src/app/common/mailaddressinfo.ts
@@ -17,12 +17,15 @@
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
 
+import { decodeMimeEncodedWords } from './mime-encoded-word';
+
 export class MailAddressInfo {
     nameAndAddress: string;
     domain: string;
 
     constructor(public name: string, public address: string) {
-        this.nameAndAddress = name ? `"${name}" <${address}>` : address;
+        this.name = decodeMimeEncodedWords(name);
+        this.nameAndAddress = this.name ? `"${this.name}" <${address}>` : address;
         this.domain = address.split('@')[1];
     }
 

--- a/src/app/common/messageinfo.spec.ts
+++ b/src/app/common/messageinfo.spec.ts
@@ -30,6 +30,29 @@ describe('MessageInfo', () => {
         expect(MessageInfo.getSubjectWithoutAbbreviation(null)).toBe('');
     });
 
+    it('decodes MIME encoded subjects', () => {
+        const msg = new MessageInfo(1,
+            new Date(),
+            new Date(),
+            'Inbox',
+            false,
+            false,
+            false,
+            MailAddressInfo.parse('test@example.com'),
+            MailAddressInfo.parse('test2@example.com'),
+            [],
+            [],
+            '=?UTF-8?Q?[Par_S=C3=A9rie]?= renewal',
+            'The text',
+            50,
+            false
+            );
+
+        expect(msg.subject).toBe('[Par S\u00e9rie] renewal');
+        expect(MessageInfo.getSubjectWithoutAbbreviation('Re: =?UTF-8?Q?[Par_S=C3=A9rie]?= renewal'))
+            .toBe('[Par S\u00e9rie] renewal');
+    });
+
     it('testAddMessageToIndexWithDeleteFolders', () => {
         console.log('Testing that messages added to specified folders will be deleted');
         const msg = new MessageInfo(1,

--- a/src/app/common/messageinfo.ts
+++ b/src/app/common/messageinfo.ts
@@ -19,6 +19,7 @@
 
 import { XapianAPI } from '@runboxcom/runbox-searchindex/rmmxapianapi';
 import { MailAddressInfo } from './mailaddressinfo';
+import { decodeMimeEncodedWords } from './mime-encoded-word';
 
 export class MessageInfo {
     deletedFlag: boolean;
@@ -39,9 +40,11 @@ export class MessageInfo {
         public plaintext: string,
         public size: number,
         public attachment: boolean) {
+        this.subject = decodeMimeEncodedWords(subject);
     }
 
     static getSubjectWithoutAbbreviation(subject: string) {
+        subject = decodeMimeEncodedWords(subject);
         const  emailsubjectabbreviations = [
             'RE:',
             'Re:',

--- a/src/app/common/mime-encoded-word.spec.ts
+++ b/src/app/common/mime-encoded-word.spec.ts
@@ -1,0 +1,46 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { decodeMimeEncodedWords } from './mime-encoded-word';
+
+describe('decodeMimeEncodedWords', () => {
+    it('leaves plain text unchanged', () => {
+        expect(decodeMimeEncodedWords('Regular subject')).toBe('Regular subject');
+    });
+
+    it('decodes UTF-8 Q encoded words', () => {
+        expect(decodeMimeEncodedWords('=?UTF-8?Q?Koteck=C3=BD?=')).toBe('Koteck\u00fd');
+    });
+
+    it('decodes UTF-8 base64 encoded words', () => {
+        expect(decodeMimeEncodedWords('=?UTF-8?B?S290ZWNrw70=?=')).toBe('Koteck\u00fd');
+    });
+
+    it('joins adjacent encoded words without their transport whitespace', () => {
+        expect(decodeMimeEncodedWords('=?UTF-8?Q?Koteck?= =?UTF-8?Q?=C3=BD?=')).toBe('Koteck\u00fd');
+    });
+
+    it('decodes encoded words embedded in normal header text', () => {
+        expect(decodeMimeEncodedWords('[=?UTF-8?Q?Par_S=C3=A9rie?=] renewal')).toBe('[Par S\u00e9rie] renewal');
+    });
+
+    it('leaves unsupported encoded words unchanged', () => {
+        expect(decodeMimeEncodedWords('=?X-UNKNOWN?Q?Koteck=C3=BD?=')).toBe('=?X-UNKNOWN?Q?Koteck=C3=BD?=');
+    });
+});

--- a/src/app/common/mime-encoded-word.ts
+++ b/src/app/common/mime-encoded-word.ts
@@ -1,0 +1,117 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+const ENCODED_WORD_REGEXP = /=\?([^?]+)\?([bBqQ])\?([^?]*)\?=/g;
+
+export function decodeMimeEncodedWords(value: string): string {
+    if (!value || value.indexOf('=?') === -1) {
+        return value;
+    }
+
+    return value
+        .replace(/\?=[ \t\r\n]+=\?/g, '?==?')
+        .replace(ENCODED_WORD_REGEXP, (encodedWord, charset, encoding, encodedText) => {
+            const bytes = encoding.toUpperCase() === 'B'
+                ? decodeBase64Bytes(encodedText)
+                : decodeQBytes(encodedText);
+
+            if (!bytes) {
+                return encodedWord;
+            }
+
+            return decodeBytes(bytes, charset) ?? encodedWord;
+        });
+}
+
+function decodeBase64Bytes(value: string): Uint8Array {
+    if (typeof atob !== 'function') {
+        return null;
+    }
+
+    try {
+        const binary = atob(value.replace(/\s/g, ''));
+        const bytes = new Uint8Array(binary.length);
+        for (let index = 0; index < binary.length; index++) {
+            bytes[index] = binary.charCodeAt(index);
+        }
+        return bytes;
+    } catch (e) {
+        return null;
+    }
+}
+
+function decodeQBytes(value: string): Uint8Array {
+    const bytes: number[] = [];
+
+    for (let index = 0; index < value.length; index++) {
+        const char = value.charAt(index);
+        if (char === '_') {
+            bytes.push(0x20);
+        } else if (
+            char === '='
+            && index + 2 < value.length
+            && /^[0-9A-Fa-f]{2}$/.test(value.substr(index + 1, 2))
+        ) {
+            bytes.push(parseInt(value.substr(index + 1, 2), 16));
+            index += 2;
+        } else {
+            bytes.push(char.charCodeAt(0));
+        }
+    }
+
+    return new Uint8Array(bytes);
+}
+
+function decodeBytes(bytes: Uint8Array, charset: string): string {
+    const normalizedCharset = normalizeCharset(charset);
+
+    if (typeof TextDecoder !== 'undefined') {
+        try {
+            return new TextDecoder(normalizedCharset).decode(bytes);
+        } catch (e) {
+            // Fall through to the UTF-8 fallback below.
+        }
+    }
+
+    if (normalizedCharset === 'utf-8' || normalizedCharset === 'us-ascii') {
+        try {
+            return decodeURIComponent(Array.from(bytes)
+                .map((byte) => '%' + byte.toString(16).padStart(2, '0'))
+                .join(''));
+        } catch (e) {
+            return null;
+        }
+    }
+
+    return null;
+}
+
+function normalizeCharset(charset: string): string {
+    const normalized = charset.trim().toLowerCase();
+
+    switch (normalized) {
+        case 'utf8':
+            return 'utf-8';
+        case 'latin1':
+        case 'latin-1':
+            return 'iso-8859-1';
+        default:
+            return normalized;
+    }
+}

--- a/src/app/compose/compose.component.ts
+++ b/src/app/compose/compose.component.ts
@@ -41,6 +41,7 @@ import { MessageListService } from '../rmmapi/messagelist.service';
 import { MessageTableRowTool} from '../messagetable/messagetablerow';
 import { DefaultPrefGroups, PreferencesService } from '../common/preferences.service';
 import { objectEqualWithKeys } from '../common/util';
+import { decodeMimeEncodedWords } from '../common/mime-encoded-word';
 
 declare const MailParser;
 
@@ -489,7 +490,7 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
         const from: any = msgObj.headers.from;
         if (from) {
             model.from = from.value && from.value[0] ?
-                from.value[0].name !== 'undefined' ? from.text : from.value[0].address
+                from.value[0].name !== 'undefined' ? decodeMimeEncodedWords(from.text) : from.value[0].address
             : null;
         }
         if (msgObj.headers.to) {
@@ -504,7 +505,7 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
             this.hasBCC = true;
         }
 
-        model.subject = msgObj.headers.subject;
+        model.subject = decodeMimeEncodedWords(msgObj.headers.subject);
         if (msgObj.text) {
             if (msgObj.text.html) {
                 model.html = msgObj.text.html;

--- a/src/app/compose/draftdesk.service.spec.ts
+++ b/src/app/compose/draftdesk.service.spec.ts
@@ -41,6 +41,43 @@ const formatDate = (date) => {
 describe('DraftDesk', () => {
     const mailDate = new Date(2017, 6, 1);
 
+    it('Create: decodes MIME encoded draft subject and recipient name', () => {
+        const draft = DraftFormModel.create(
+            12,
+            Identity.fromObject({'email':'to@runbox.com'}),
+            '=?UTF-8?Q?Koteck=C3=BD?= <k@example.com>',
+            '=?UTF-8?Q?[Par_S=C3=A9rie]?= renewal'
+        );
+
+        expect(draft.subject).toBe('[Par S\u00e9rie] renewal');
+        expect(draft.to[0].nameAndAddress).toBe('"Koteck\u00fd" <k@example.com>');
+    });
+
+    it('Reply: decodes MIME encoded subject and sender name', () => {
+        const draft = DraftFormModel.reply({
+            headers: {
+                'message-id': 'themessageid12123abcdef',
+            },
+            from: [
+                {address: 'from@runbox.com', name: '=?UTF-8?Q?Koteck=C3=BD?='}
+            ],
+            to: [
+                {address: 'to@runbox.com', name: 'To'}
+            ],
+            date: mailDate,
+            subject: '=?UTF-8?Q?[Par_S=C3=A9rie]?= renewal',
+            text: 'blabla',
+            rawtext: 'blabla',
+            html: '<p>blabla</p>'
+        },
+        [ Identity.fromObject({'email':'to@runbox.com'})],
+        false, false);
+
+        expect(draft.subject).toBe('Re: [Par S\u00e9rie] renewal');
+        expect(draft.to[0].nameAndAddress).toBe('"Koteck\u00fd" <from@runbox.com>');
+        expect(draft.msg_body).toContain('"Koteck\u00fd" <from@runbox.com> wrote:');
+    });
+
     it('Forward: froms, plain text', (done) => {
         // fromObj, identities, all (t/f), html (t/f)
         const draft = DraftFormModel.forward({

--- a/src/app/compose/draftdesk.service.ts
+++ b/src/app/compose/draftdesk.service.ts
@@ -28,6 +28,7 @@ import { MessageTableRowTool} from '../messagetable/messagetablerow';
 import { Identity, ProfileService } from '../profiles/profile.service';
 import { from, of, BehaviorSubject, firstValueFrom } from 'rxjs';
 import { map, mergeMap, bufferCount, take, distinctUntilChanged } from 'rxjs/operators';
+import { decodeMimeEncodedWords } from '../common/mime-encoded-word';
 
 import moment from 'moment';
 import 'moment-timezone';
@@ -76,7 +77,7 @@ export class DraftFormModel {
         ret.from = fromAddress.email;
         ret.mid = draftId;
         ret.to = to ? MailAddressInfo.parse(to) : [];
-        ret.subject = subject;
+        ret.subject = decodeMimeEncodedWords(subject);
         if (preview) {
             // We create an element here because we want the plain text
             const previewElm = document.createElement('div');
@@ -134,9 +135,9 @@ export class DraftFormModel {
             + moment(mailObj.date, localTZ).format('yyyy-MM-DD HH:mm Z')
             + ' ' + moment.tz(localTZ).format('z')
             + ', '
-            + (mailObj.from[0].name
-                ? `"${mailObj.from[0].name}" &lt;${mailObj.from[0].address}&gt; wrote:`
-                : `${mailObj.from[0].address} wrote:`);
+            + (sender[0].name
+                ? `"${sender[0].name}" &lt;${sender[0].address}&gt; wrote:`
+                : `${sender[0].address} wrote:`);
 
         if (!useHTML && mailObj.rawtext) {
             let replyHeaderText = replyHeaderHTML.replaceAll('&lt;', '<');
@@ -170,14 +171,17 @@ export class DraftFormModel {
         const ret = new DraftFormModel();
         ret.setFromForResponse(mailObj, froms);
 
-        const fwdFromNameStr = mailObj.from[0].name
-            ? `"${mailObj.from[0].name}" &lt;${mailObj.from[0].address}&gt;`
-            : `${mailObj.from[0].address}`;
+        const sender = new MailAddressInfo(mailObj.from[0].name, mailObj.from[0].address);
+        const fwdFromNameStr = sender.name
+            ? `"${sender.name}" &lt;${sender.address}&gt;`
+            : `${sender.address}`;
         const localTZ = moment.tz.guess();
         const fwdDateStr = moment(mailObj.date, localTZ).local().format('yyyy-MM-DD HH:mm Z ') + moment.tz(localTZ).format('z');
-        const fwdSubjectStr = `Subject: ${mailObj.subject}`;
-        const fwdTo = mailObj.to ? mailObj.to.map((to) => `"${to.name}" &lt;${to.address}&gt;`) : [];
-        const fwdCC = mailObj.cc ? mailObj.cc.map((cc) => `"${cc.name}" &lt;${cc.address}&gt;`) : [];
+        const fwdSubjectStr = `Subject: ${decodeMimeEncodedWords(mailObj.subject)}`;
+        const fwdTo = mailObj.to ? mailObj.to.map((to) => new MailAddressInfo(to.name, to.address))
+            .map((to) => `"${to.name}" &lt;${to.address}&gt;`) : [];
+        const fwdCC = mailObj.cc ? mailObj.cc.map((cc) => new MailAddressInfo(cc.name, cc.address))
+            .map((cc) => `"${cc.name}" &lt;${cc.address}&gt;`) : [];
         const fwdHeaderHTML = `From: ${fwdFromNameStr} <br />
 Time: ${fwdDateStr} <br />
 ${fwdSubjectStr} <br />`
@@ -229,7 +233,7 @@ ${mailObj.sanitized_html}`;
     }
 
     private setSubjectForResponse(mailObj, prefix): void {
-        this.subject = prefix + MessageInfo.getSubjectWithoutAbbreviation(mailObj.subject);
+        this.subject = prefix + MessageInfo.getSubjectWithoutAbbreviation(decodeMimeEncodedWords(mailObj.subject));
     }
 }
 

--- a/src/app/mailviewer/singlemailviewer.component.ts
+++ b/src/app/mailviewer/singlemailviewer.component.ts
@@ -52,6 +52,7 @@ import { MessageTableRowTool} from '../messagetable/messagetablerow';
 import { PreferencesService } from '../common/preferences.service';
 // import { ShowImagesDialogComponent } from '../dialog/imagesconfirm.dialog';
 import { MailAddressInfo } from '../common/mailaddressinfo';
+import { decodeMimeEncodedWords } from '../common/mime-encoded-word';
 
 // const DOMPurify = require('dompurify');
 const showHtmlDecisionKey = 'rmm7showhtmldecision';
@@ -533,10 +534,11 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
       // Skip if we previously had an issue loading this messge
       throw res;
     }
-    res.subject = res.headers.subject;
+    res.subject = decodeMimeEncodedWords(res.headers.subject);
     res.from = res.headers.from.value.map(f => new MailAddressInfo(f.name,f.address));
-    res.to = res.headers.to ? res.headers.to.value : '';
-    res.cc = res.headers.cc ? res.headers.cc.value : '';
+    res.to = res.headers.to ? res.headers.to.value.map(to => new MailAddressInfo(to.name, to.address)) : '';
+    res.cc = res.headers.cc ? res.headers.cc.value.map(cc => new MailAddressInfo(cc.name, cc.address)) : '';
+    res.bcc = res.headers.bcc ? res.headers.bcc.value.map(bcc => new MailAddressInfo(bcc.name, bcc.address)) : '';
 
     // RFC 5322 says "Date" and "From" are the only 2 required fields
     // and yet we get emails without em.

--- a/src/app/xapian/searchservice.ts
+++ b/src/app/xapian/searchservice.ts
@@ -37,6 +37,7 @@ import { SyncProgressComponent } from './syncprogress.component';
 import { xapianLoadedSubject } from './xapianwebloader';
 import { PostMessageAction } from './messageactions';
 import { objectEqualWithKeys } from '../common/util';
+import { decodeMimeEncodedWords } from '../common/mime-encoded-word';
 
 // eslint-disable-next-line no-var
 declare var FS; declare var IDBFS; declare var Module;
@@ -851,8 +852,8 @@ export class SearchService {
 
           this.currentDocData = {
             id: docdataparts[0],
-            from: docdataparts[1],
-            subject: docdataparts[2],
+            from: decodeMimeEncodedWords(docdataparts[1]),
+            subject: decodeMimeEncodedWords(docdataparts[2]),
             recipients: [],
             textcontent: null
           };
@@ -880,7 +881,7 @@ export class SearchService {
                 } else if (s === XAPIAN_TERM_HASATTACHMENTS) {
                   this.currentDocData.attachment = true;
                 } else if (s.indexOf('XRECIPIENT') === 0) {
-                  const recipient = s.substring('XRECIPIENT:'.length);
+                  const recipient = decodeMimeEncodedWords(s.substring('XRECIPIENT:'.length));
                   this.currentDocData.recipients.push(recipient);
                 }
               });


### PR DESCRIPTION
## Summary

- Add a shared RFC 2047 encoded-word decoder for MIME header text.
- Decode encoded address display names and subjects when message-list, local-search, opened-message, draft, reply, and forward data enters the frontend.
- Add regression coverage for encoded UTF-8 Q/base64 words, adjacent encoded words, address parsing, message-list subjects, and compose replies/drafts.

Fixes #1373
Fixes #1389
Refs #479

## Validation

- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/common/mime-encoded-word.spec.ts --include=src/app/common/mailaddressinfo.spec.ts --include=src/app/common/messageinfo.spec.ts --include=src/app/compose/draftdesk.service.spec.ts` - 43 success
- `npx tsc -p tsconfig.json --noEmit`
- `git diff --check`
- `npm run lint` - exits 0 with existing repository warnings
- `npx ng test --watch=false --browsers=FirefoxHeadless` - 255 success, 2 skipped
- `node src/build/pre-build.js`
- `npx ng build runbox7 --configuration production --base-href /app/`
- `node src/build/post-build.js`
- `npm run policy` - exits 0; current commit passes, historical commit-message warnings remain
