### PR TITLE
fix(calendar): disable add event until calendars load

### DIFF
--- a/src/app/calendar-app/calendar-app.component.html
+++ b/src/app/calendar-app/calendar-app.component.html
@@ -6,7 +6,7 @@
             </span>
             <div style="display: flex; flex-direction: column;">
                 <div class="add-new-event">
-                    <button mat-icon-button color="primary" (click)="addEvent(day.date); $event.stopPropagation()"> <mat-icon style="transform: scale(1.5);" svgIcon="plus-circle"> </mat-icon> </button>
+                    <button mat-icon-button color="primary" [disabled]="!canAddEvents" (click)="addEvent(day.date); $event.stopPropagation()"> <mat-icon style="transform: scale(1.5);" svgIcon="plus-circle"> </mat-icon> </button>
                 </div>
                 <button mat-button class="calendarMonthDayEvent"
                     *ngFor="let event of (day.events.length > 4 ? day.events.slice(0, 3) : day.events)"
@@ -115,10 +115,10 @@
                 <ng-container *ngTemplateOutlet="viewModeButtons"></ng-container>
             </div>
 
-            <mat-list-item id="addEventButton" mat-button (click)="addEvent()" class="calendarMenuButton">
+            <button mat-list-item id="addEventButton" type="button" (click)="addEvent()" [disabled]="!canAddEvents" [attr.disabled]="canAddEvents ? null : ''" class="calendarMenuButton">
                 <mat-icon mat-list-icon svgIcon="plus"></mat-icon>
                 <p mat-line>Add Event</p>
-            </mat-list-item>
+            </button>
 
             <mat-list-item (click)="importEventClicked()" class="calendarMenuButton">
                 <input #icsUploadInput accept="text/calendar,.ics" type="file" [hidden]="true" multiple (change)="onIcsUploaded($event)" />

--- a/src/app/calendar-app/calendar-app.component.spec.ts
+++ b/src/app/calendar-app/calendar-app.component.spec.ts
@@ -33,6 +33,7 @@ import { PreferencesService } from '../common/preferences.service';
 import { RouterTestingModule } from '@angular/router/testing';
 import { take } from 'rxjs/operators';
 import { of, Observable, ReplaySubject } from 'rxjs';
+import { MatLegacyDialog as MatDialog } from '@angular/material/legacy-dialog';
 import { MatLegacySnackBar as MatSnackBar } from '@angular/material/legacy-snack-bar';
 import { RunboxCalendar } from './runbox-calendar';
 import { RunboxCalendarEvent } from './runbox-calendar-event';
@@ -97,8 +98,12 @@ describe('CalendarAppComponent', () => {
          'calendar': 'test-calendar',
         }];
 
+    const testCalendars = () => [
+        new RunboxCalendar({ id: 'test-calendar', displayname: 'Test Calendar', color: 'pink', syncToken: 'testsync' })
+    ];
+
     const mockData = {
-        calendars: [ new RunboxCalendar({ id: 'test-calendar', displayname: 'Test Calendar', color: 'pink', syncToken: 'testsync' }) ],
+        calendars: testCalendars(),
         events:    [], // set in test cases
         timezone:
 `BEGIN:VCALENDAR
@@ -209,6 +214,8 @@ END:VCALENDAR
 
     beforeEach(() => {
         localStorage.clear();
+        mockData['calendars'] = testCalendars();
+        mockData['events'] = [];
         fixture = TestBed.createComponent(CalendarAppComponent);
         component = fixture.componentInstance;
     });
@@ -226,6 +233,21 @@ END:VCALENDAR
 
         const icon = calendar.querySelector('.calendarColorLabel', 'test calendar has a correct icon colour');
         expect(icon.style.color).toBe('pink');
+    });
+
+    it('should not offer to add events before calendars are loaded', () => {
+        const dialog = TestBed.inject(MatDialog);
+        const openDialog = spyOn(dialog, 'open');
+
+        component.calendars = [];
+        fixture.detectChanges();
+
+        expect(component.canAddEvents).toBeFalse();
+        const addEventButton: HTMLButtonElement = fixture.debugElement.nativeElement.querySelector('#addEventButton');
+        expect(addEventButton.disabled).toBeTrue();
+
+        component.addEvent();
+        expect(openDialog).not.toHaveBeenCalled();
     });
 
     it('should display events', () => {

--- a/src/app/calendar-app/calendar-app.component.ts
+++ b/src/app/calendar-app/calendar-app.component.ts
@@ -166,7 +166,15 @@ export class CalendarAppComponent implements OnDestroy {
         clearInterval(this.viewRefreshInterval);
     }
 
+    get canAddEvents(): boolean {
+        return this.calendars.length > 0;
+    }
+
     addEvent(on?: Date): void {
+        if (!this.canAddEvents) {
+            return;
+        }
+
         // setup new event
         const new_event = RunboxCalendarEvent.newEmpty(this.calendarservice.me.timezone);
         new_event.timezone = this.calendarservice.me.timezone;

--- a/src/app/calendar-app/event-editor-dialog.component.ts
+++ b/src/app/calendar-app/event-editor-dialog.component.ts
@@ -100,8 +100,10 @@ export class EventEditorDialogComponent {
         public dialogRef: MatDialogRef<EventEditorDialogComponent>,
         @Inject(MAT_DIALOG_DATA) public data: any
     ) {
-        this.calendars = data['calendars'];
-        this.calendarFC.setValue(this.calendars[0].id);
+        this.calendars = data['calendars'] || [];
+        if (this.calendars.length > 0) {
+            this.calendarFC.setValue(this.calendars[0].id);
+        }
 
         this.event = data['event'];
         if (!data['is_new']) {


### PR DESCRIPTION
## Summary
- disable the Calendar Add Event controls until at least one calendar is available
- guard addEvent() so the event editor cannot be opened with an empty calendar list
- keep the event editor from dereferencing calendars[0] if an empty list is ever passed in

Fixes #1330.

## Tests
- npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/calendar-app/calendar-app.component.spec.ts
- npx tsc -p tsconfig.json --noEmit
- npm run lint
- git diff --check
- npx ng test --watch=false --browsers=FirefoxHeadless
- node src/build/pre-build.js && npx ng build runbox7 --configuration production --base-href /app/ && node src/build/post-build.js
- npm run policy