### PR TITLE
fix(account): make TOTP label editable

### DIFF
--- a/src/app/account-security/two-factor-authentication.component.html
+++ b/src/app/account-security/two-factor-authentication.component.html
@@ -114,8 +114,10 @@
                     <p>
                         <span><strong>Label:</strong></span>
                         <mat-form-field>
-                            <input matInput name="totp_label" [value]="rmm.account_security.tfa.totp_label"
-                                disabled="" readonly >
+                            <input matInput name="totp_label" placeholder="Label"
+                                [(ngModel)]="rmm.account_security.tfa.totp_label"
+                                (ngModelChange)="totp_label_change()"
+                                [disabled]="!rmm.account_security.tfa.new_totp_code">
                         </mat-form-field>
                     </p>
                 </div>

--- a/src/app/account-security/two-factor-authentication.component.ts
+++ b/src/app/account-security/two-factor-authentication.component.ts
@@ -69,6 +69,10 @@ export class TwoFactorAuthenticationComponent implements OnInit {
         this.rmm.account_security.tfa.totp_regenerate({});
     }
 
+    totp_label_change() {
+        this.rmm.account_security.tfa.update_totp_qr_code();
+    }
+
     otp_generate() {
         this.is_busy_otp_update = true;
         if (!this.rmm.account_security.user_password) {

--- a/src/app/rmm/account-security-2fa.spec.ts
+++ b/src/app/rmm/account-security-2fa.spec.ts
@@ -1,0 +1,55 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { AccountSecurity2fa } from './account-security-2fa';
+
+describe('AccountSecurity2fa', () => {
+    let tfa: AccountSecurity2fa;
+
+    beforeEach(() => {
+        tfa = new AccountSecurity2fa({
+            me: {
+                data: {
+                    username: 'default-user',
+                },
+            },
+        } as any);
+    });
+
+    it('should build TOTP QR data from the editable label', () => {
+        tfa.new_totp_code = 'JBSWY3DPEHPK3PXP';
+        tfa.totp_label = 'Custom Label';
+
+        tfa.update_totp_qr_code();
+
+        expect(tfa.qr_code_value.protocol).toBe('otpauth:');
+        expect(tfa.qr_code_value.href).toContain('Runbox:Custom%20Label');
+        expect(tfa.qr_code_value.searchParams.get('issuer')).toBe('Runbox');
+        expect(tfa.qr_code_value.searchParams.get('secret')).toBe('JBSWY3DPEHPK3PXP');
+    });
+
+    it('should fall back to the username when the editable label is empty', () => {
+        tfa.new_totp_code = 'JBSWY3DPEHPK3PXP';
+        tfa.totp_label = '';
+
+        tfa.update_totp_qr_code();
+
+        expect(tfa.qr_code_value.href).toContain('Runbox:default-user');
+    });
+});

--- a/src/app/rmm/account-security-2fa.ts
+++ b/src/app/rmm/account-security-2fa.ts
@@ -142,9 +142,18 @@ export class AccountSecurity2fa {
         this.is_busy = true;
         this.new_totp_code = this.generate_totp_code();
         this.totp_label = this.app.me.data.username;
+        this.update_totp_qr_code();
+    }
+
+    update_totp_qr_code() {
+        if (!this.new_totp_code) {
+            this.qr_code_value = undefined;
+            return;
+        }
+
         const otpa = new OTPAuth.TOTP({
             issuer: 'Runbox',
-            label: this.totp_label,
+            label: this.totp_label || this.app.me.data.username,
             secret: this.new_totp_code
         });
         this.qr_code_value = new URL(otpa.toString());


### PR DESCRIPTION
## Summary
- make the generated TOTP label field editable after a new key is generated
- rebuild the TOTP QR payload whenever the label changes so authenticator apps receive the edited label
- add focused coverage for QR payload generation from a custom label

Fixes #1237.

## Tests
- npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/rmm/account-security-2fa.spec.ts
- npx tsc -p tsconfig.json --noEmit
- git diff --check
- npm run lint
- npx ng test --watch=false --browsers=FirefoxHeadless
- node src/build/pre-build.js && npx ng build runbox7 --configuration production --base-href /app/ && node src/build/post-build.js
- npm run policy
