### PR TITLE
fix(contacts): serialize birthday dates as dates

### DIFF
--- a/src/app/contacts-app/contact.spec.ts
+++ b/src/app/contacts-app/contact.spec.ts
@@ -290,6 +290,19 @@ END:VCARD`);
         expect(sut.vcard().toLowerCase()).toContain('bday;value=text:yesterday');
     });
 
+    it('serializes ISO birthday dates as date values', () => {
+        const sut = new Contact({});
+        sut.nickname = 'Birthday Boy';
+        sut.birthday = '2021-09-14';
+
+        const vcard = sut.vcard().toLowerCase();
+        expect(vcard).toContain('bday:20210914');
+        expect(vcard).not.toContain('bday;value=text:2021-09-14');
+
+        const parsed = Contact.fromVcard(null, sut.vcard());
+        expect(parsed.birthday).toBe('2021-09-14');
+    });
+
     it('can set photo to a data uri', () => {
         let sut = new Contact({});
         sut.nickname = 'Mr Photographed';

--- a/src/app/contacts-app/contact.ts
+++ b/src/app/contacts-app/contact.ts
@@ -150,6 +150,22 @@ export class Contact {
         return vcf.replace(group, '');
     }
 
+    private static isIsoDate(value: string): boolean {
+        const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+        if (!match) {
+            return false;
+        }
+
+        const year = Number(match[1]);
+        const month = Number(match[2]);
+        const day = Number(match[3]);
+        const date = new Date(Date.UTC(year, month - 1, day));
+
+        return date.getUTCFullYear() === year
+            && date.getUTCMonth() === month - 1
+            && date.getUTCDate() === day;
+    }
+
     // may throw ICAL.ParserError if input is not a valid vcf
     static fromVcf(vcf: string): Contact[] {
         let cards = ICAL.parse(this.preprocessVcf(vcf));
@@ -375,9 +391,9 @@ export class Contact {
             this.component.removeAllProperties('bday');
         }
         const prop = this.component.addPropertyWithValue('bday', value);
-        // TODO skip that bit if it's a correct format
-        // according to https://tools.ietf.org/html/rfc6350#section-4.3.4
-        prop.setParameter('value', 'text');
+        if (!Contact.isIsoDate(value)) {
+            prop.setParameter('value', 'text');
+        }
     }
 
     get note(): string {


### PR DESCRIPTION
## Summary
- serialize valid `YYYY-MM-DD` contact birthdays as date-valued vCard `BDAY` fields instead of marking them as text
- keep arbitrary/freeform birthday strings serialized with `VALUE=text`
- add focused coverage for ISO birthday serialization and round-tripping

Fixes #1106.

## Tests
- confirmed the new focused spec fails before the fix because the current output is `BDAY;VALUE=text:20210914`
- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/contacts-app/contact.spec.ts`
- `npx tsc -p tsconfig.json --noEmit`
- `git diff --check`
- `npm run lint`
- `npx ng test --watch=false --browsers=FirefoxHeadless --include="src/app/contacts-app/**/*.spec.ts"`
- `npx ng test --watch=false --browsers=FirefoxHeadless`
- `node src/build/pre-build.js && npx ng build runbox7 --configuration production --base-href /app/ && node src/build/post-build.js`
- `npm run policy`
