### PR TITLE
fix(contacts): update single-value company fields

### DIFF
--- a/src/app/contacts-app/contact.spec.ts
+++ b/src/app/contacts-app/contact.spec.ts
@@ -240,6 +240,25 @@ END:VCARD`);
         expect(sut.department).toBe('department');
     });
 
+    it('can update and clear a single-value company', () => {
+        let sut = Contact.fromVcard(null, `BEGIN:VCARD
+VERSION:3.0
+FN:testcontact
+ORG:runbox
+END:VCARD`);
+
+        sut.company = 'New Company';
+
+        expect(sut.company).toBe('New Company');
+        expect(sut.vcard()).toContain('ORG:New Company');
+
+        sut = Contact.fromVcard(null, sut.vcard());
+        sut.company = '';
+
+        expect(sut.company).toBe('');
+        expect(sut.vcard()).not.toContain('New Company');
+    });
+
     it('can parse grouped properties', () => {
         const sut = Contact.fromVcard(null, `BEGIN:VCARD
 VERSION:3.0

--- a/src/app/contacts-app/contact.ts
+++ b/src/app/contacts-app/contact.ts
@@ -191,8 +191,10 @@ export class Contact {
             const propValue = prop.getValues();
             if (!propValue) {
                 values = [];
+            } else if (Array.isArray(propValue[0])) {
+                values = propValue[0].slice();
             } else {
-                values = propValue[0];
+                values = propValue.slice();
             }
         } else {
             prop = new ICAL.Property(name, this.component);


### PR DESCRIPTION
## Summary
- normalize single-value vCard properties before updating indexed fields
- allow Contacts company names stored as single-value ORG fields to be changed or cleared
- add focused coverage for updating and clearing a single-value company

Fixes #1103.

## Tests
- confirmed the new focused spec fails before the fix with TypeError: 0 is read-only in setIndexedValue
- npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/contacts-app/contact.spec.ts
- npx tsc -p tsconfig.json --noEmit
- git diff --check
- npm run lint
- npx ng test --watch=false --browsers=FirefoxHeadless --include="src/app/contacts-app/**/*.spec.ts"
- npx ng test --watch=false --browsers=FirefoxHeadless
- node src/build/pre-build.js && npx ng build runbox7 --configuration production --base-href /app/ && node src/build/post-build.js
- npm run policy
