### PR TITLE
fix(mail): show unread threaded conversations

### DIFF
--- a/src/app/xapian/searchmessagedisplay.spec.ts
+++ b/src/app/xapian/searchmessagedisplay.spec.ts
@@ -1,0 +1,120 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { CanvasTableColumn } from '../canvastable/canvastablecolumn';
+import { SearchIndexDocumentData, SearchService } from './searchservice';
+import { SearchMessageDisplay } from './searchmessagedisplay';
+
+interface SearchApiFake {
+  clearValueRange(): void;
+  getStringValue(docId: number, valueNo: number): string;
+  setStringValueRange(valueNo: number, prefix: string): void;
+  sortedXapianQuery(
+    query: string,
+    sortColumn: number,
+    sortDescending: number,
+    offset: number,
+    limit: number,
+    collapseValue: number
+  ): number[][];
+}
+
+interface SearchServiceFake {
+  api: SearchApiFake;
+  getDocData(docId: number): SearchIndexDocumentData;
+  getMessageIdFromDocId(docId: number): number;
+}
+
+const createSearchService = (): SearchService => {
+  const valueRanges: string[] = [];
+  const docData: Record<number, SearchIndexDocumentData> = {
+    10: {
+      id: 'M10',
+      from: 'read@example.com',
+      subject: 'Thread subject',
+      recipients: [],
+      textcontent: '',
+      seen: true
+    },
+    11: {
+      id: 'M11',
+      from: 'unread@example.com',
+      subject: 'Thread subject',
+      recipients: [],
+      textcontent: '',
+      seen: false
+    }
+  };
+
+  const api: SearchApiFake = {
+    clearValueRange: (): void => {
+      valueRanges.length = 0;
+    },
+    getStringValue: (docId: number, _valueNo: number): string => docId === 10 || docId === 11 ? 'THREAD1' : '',
+    setStringValueRange: (valueNo: number, prefix: string): void => {
+      valueRanges.push(`${valueNo}:${prefix}`);
+    },
+    sortedXapianQuery: (
+      query: string,
+      _sortColumn: number,
+      _sortDescending: number,
+      _offset: number,
+      _limit: number,
+      _collapseValue: number
+    ): number[][] => {
+      if (query === 'conversation:THREAD1..THREAD1') {
+        return [[10, 1]];
+      }
+
+      if (query === 'conversation:THREAD1..THREAD1 AND NOT flag:seen') {
+        return [[11, 0]];
+      }
+
+      return [];
+    }
+  };
+
+  const searchService: SearchServiceFake = {
+    api,
+    getDocData: (docId: number): SearchIndexDocumentData => docData[docId],
+    getMessageIdFromDocId: (docId: number): number => docId + 1000
+  };
+
+  return searchService as unknown as SearchService;
+};
+
+describe('SearchMessageDisplay', () => {
+  it('marks a threaded row as unread when an older message in the conversation is unread', async () => {
+    const display = new SearchMessageDisplay(createSearchService(), [[10]]);
+    const columns = display.getCanvasTableColumns({
+      displayFolderColumn: false,
+      selectedFolder: 'Inbox',
+      viewmode: 'conversations'
+    });
+    const countColumn = columns.find((column: CanvasTableColumn) => column.cacheKey === 'count');
+
+    expect(display.getRowSeen(0)).toBeFalse();
+    expect(countColumn.getValue(0)).toBe('RETRY');
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(countColumn.getValue(0)).toBe('2');
+    expect(display.getRowSeen(0)).toBeTrue();
+  });
+});

--- a/src/app/xapian/searchmessagedisplay.ts
+++ b/src/app/xapian/searchmessagedisplay.ts
@@ -23,6 +23,9 @@ import { MessageTableRowTool} from '../messagetable/messagetablerow';
 import { CanvasTableColumn } from '../canvastable/canvastablecolumn';
 
 export class SearchMessageDisplay extends MessageDisplay {
+  private static readonly CONVERSATION_COUNT_INDEX = 2;
+  private static readonly CONVERSATION_UNREAD_INDEX = 3;
+
   private searchService: SearchService;
 
   // MessageDisplay implementations have different numbers of arguments..
@@ -32,6 +35,11 @@ export class SearchMessageDisplay extends MessageDisplay {
   }
 
   getRowSeen(index: number): boolean {
+    const conversationUnread = this.rows[index][SearchMessageDisplay.CONVERSATION_UNREAD_INDEX];
+    if (typeof conversationUnread === 'boolean') {
+      return conversationUnread;
+    }
+
     return this.searchService.getDocData(this.rows[index][0]).seen ? false : true;
   }
 
@@ -121,8 +129,13 @@ export class SearchMessageDisplay extends MessageDisplay {
           conversationSearchText,
           1, 0, 0, 1000, 1
         );
+        const unreadResults = this.searchService.api.sortedXapianQuery(
+          `${conversationSearchText} AND NOT flag:seen`,
+          1, 0, 0, 1, -1
+        );
         this.searchService.api.clearValueRange();
-        rowObj[2] = `${results[0][1] + 1}`;
+        rowObj[SearchMessageDisplay.CONVERSATION_COUNT_INDEX] = `${results[0][1] + 1}`;
+        rowObj[SearchMessageDisplay.CONVERSATION_UNREAD_INDEX] = unreadResults.length > 0;
 
         currentCountObject = null;
       };
@@ -135,14 +148,16 @@ export class SearchMessageDisplay extends MessageDisplay {
           sortColumn: null,
           rowWrapModeChipCounter: true,
           getValue: (rowIndex): string => {
-            if (!this.getRow(rowIndex)[2]) {
+            const row = this.getRow(rowIndex);
+            if (!row[SearchMessageDisplay.CONVERSATION_COUNT_INDEX]
+              || typeof row[SearchMessageDisplay.CONVERSATION_UNREAD_INDEX] !== 'boolean') {
               if (currentCountObject === null) {
-                currentCountObject = this.getRow(rowIndex);
+                currentCountObject = row;
                 setTimeout(() => processCurrentCountObject(), 0);
               }
               return 'RETRY';
             } else {
-              return this.getRow(rowIndex)[2];
+              return row[SearchMessageDisplay.CONVERSATION_COUNT_INDEX];
             }
           },
           textAlign: 1,


### PR DESCRIPTION
Fixes https://github.com/runbox/runbox7/issues/1189.

## Summary

- Computes whether a threaded conversation row contains any unread messages when the existing lazy conversation count lookup runs.
- Uses that computed conversation unread state for row bolding once available, while preserving the current per-message unread behavior before the threaded metadata is loaded.
- Adds a focused regression spec for the case where the newest visible thread row is read but an older message in the same conversation is unread.

## Testing

- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/xapian/searchmessagedisplay.spec.ts`
- `npx tsc -p tsconfig.json --noEmit`
- `npx eslint src/app/xapian/searchmessagedisplay.ts src/app/xapian/searchmessagedisplay.spec.ts`
- `npx ng test --watch=false --browsers=FirefoxHeadless --include="src/app/xapian/**/*.spec.ts"`
- `git diff --check --cached`
- `npm run lint`
- `npm run policy`
- `npx ng test --watch=false --browsers=FirefoxHeadless`
- `node src/build/pre-build.js; npx ng build runbox7 --configuration production --base-href /app/; node src/build/post-build.js`
- `npm run policy`
