### PR TITLE
fix(mail): show embedded images in HTML view

### DIFF
--- a/src/app/mailviewer/singlemailviewer.component.spec.ts
+++ b/src/app/mailviewer/singlemailviewer.component.spec.ts
@@ -231,6 +231,43 @@ describe('SingleMailViewerComponent', () => {
       expect(component.mailObj.attachments[1].downloadURL.indexOf('blob:')).toBe(0);
     }));
 
+  it('shows embedded cid images when external images are disabled', () => {
+    component['_messageId'] = 42;
+
+    const processed = component['processMessageContents'](Object.assign(new MessageContents(), {
+      mid: 42,
+      headers: {
+        from: {
+          value: [{
+            address: 'sender@example.com',
+            name: 'Sender'
+          }]
+        },
+        date: new Date(2026, 0, 1).toJSON(),
+        subject: 'Embedded image'
+      },
+      text: {
+        text: 'Plain body',
+        html: '<p>HTML body</p>',
+        textAsHtml: '<p>Plain body</p>'
+      },
+      sanitized_html:
+        '<p>Inline: <img src="cid:inline-logo"></p>' +
+        '<p>Remote: <img src="https://example.com/tracker.png"></p>',
+      sanitized_html_without_images: '<p>Inline: </p><p>Remote: </p>',
+      attachments: [{
+        filename: 'logo.png',
+        cid: 'inline-logo',
+        contentType: 'image/png',
+        size: 1024
+      }]
+    }));
+
+    const htmlWithoutExternalImages = processed.html_without_images.changingThisBreaksApplicationSecurity;
+    expect(htmlWithoutExternalImages).toContain('/rest/v1/email/42/attachment/0?download=true');
+    expect(htmlWithoutExternalImages).not.toContain('https://example.com/tracker.png');
+  });
+
   describe('mailto: link interceptor', () => {
     let messageContentsElement: HTMLElement;
     let mailtoLink: HTMLAnchorElement;

--- a/src/app/mailviewer/singlemailviewer.component.ts
+++ b/src/app/mailviewer/singlemailviewer.component.ts
@@ -566,7 +566,10 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
     res.sanitized_html = this.expandAttachmentData(res.attachments, res.sanitized_html);
     res.visible_attachment_count = res.attachments.filter((att) => !att.internal).length;
 
-    res.sanitized_html_without_images = this.expandAttachmentData(res.attachments, res.sanitized_html_without_images);
+    const sanitizedHtmlWithoutImages = this.expandAttachmentData(res.attachments, res.sanitized_html_without_images);
+    res.sanitized_html_without_images = res.sanitized_html
+      ? this.removeExternalImages(res.attachments, res.sanitized_html)
+      : sanitizedHtmlWithoutImages;
 
     // Remove style tag otherwise angular sanitazion will display style tag content as text
 
@@ -661,6 +664,33 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
       });
     }
     return html;
+  }
+
+  private removeExternalImages(attachments: Array<{ internal?: boolean; downloadURL?: string }>, html: string): string {
+    const internalImageSources = new Set(
+      attachments
+        .filter((att) => att.internal && att.downloadURL)
+        .map((att) => att.downloadURL)
+    );
+    const parsedDocument = new DOMParser().parseFromString(html, 'text/html');
+
+    parsedDocument.body.querySelectorAll('img').forEach((img) => {
+      const src = img.getAttribute('src');
+      if (!src || !internalImageSources.has(src)) {
+        img.remove();
+        return;
+      }
+      img.removeAttribute('srcset');
+    });
+    parsedDocument.body.querySelectorAll('source[srcset]').forEach((source) => source.remove());
+    parsedDocument.body.querySelectorAll('[style]').forEach((element) => {
+      if (/(^|[;\s])background(-image)?\s*:.*url\s*\(/i.test(element.getAttribute('style') || '')) {
+        element.removeAttribute('style');
+      }
+    });
+    parsedDocument.body.querySelectorAll('[background]').forEach((element) => element.removeAttribute('background'));
+
+    return parsedDocument.body.innerHTML;
   }
 
   saveShowHTMLDecision() {


### PR DESCRIPTION
Fixes #1753.

## Summary

- Derive the no-external-images HTML from the sanitized HTML after `cid:` attachment expansion, so embedded images render when the user enables HTML view.
- Strip remote image elements, `srcset`, and background-image URLs from that no-external-images variant so the existing external-images toggle is still required for remote resources.
- Add a focused `SingleMailViewerComponent` regression spec covering a `cid:` image beside a remote tracking image.

## Testing

- Pre-fix: `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/mailviewer/singlemailviewer.component.spec.ts` failed with the embedded attachment URL missing from `html_without_images`.
- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/mailviewer/singlemailviewer.component.spec.ts`
- `npx ng test --watch=false --browsers=FirefoxHeadless --include="src/app/mailviewer/**/*.spec.ts"`
- `npx tsc -p tsconfig.json --noEmit`
- `npx eslint src/app/mailviewer/singlemailviewer.component.ts src/app/mailviewer/singlemailviewer.component.spec.ts`
- `git diff --check --cached`
- `npm run lint`
- `npm run policy`
- `npx ng test --watch=false --browsers=FirefoxHeadless`
- `node src/build/pre-build.js; npx ng build runbox7 --configuration production --base-href /app/; node src/build/post-build.js`
- Post-commit: `npm run policy`
