### PR TITLE
fix(mail): sync message view option checkboxes

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -353,7 +353,7 @@
                             matLine
                             (change)="updateViewMode($event.source.checked ? 'conversations' : 'messages')"
                             (click)="$event.stopPropagation()"
-                            [disabled]="unreadMessagesOnlyCheckbox || !showingSearchResults"
+                            [disabled]="unreadMessagesOnlyCheckbox || !canUseConversationGrouping()"
                             class="tableViewOptionsMenuElement"
                             >
                 <mat-icon  svgIcon="format-align-right" class="tableViewOptionsMenuElement" [matTooltip]="conversationGroupingToolTip"></mat-icon>
@@ -365,7 +365,7 @@
                             matLine
                             (change)="updateSearch(true)"
                             (click)="$event.stopPropagation()"
-                            [disabled]="viewmode==='conversations'"
+                            [disabled]="conversationGroupingCheckbox"
                             class="tableViewOptionsMenuElement"
                             >
                 <mat-icon  svgIcon="email-open" class="tableViewOptionsMenuElement" [matTooltip]="unreadOnlyToolTip"></mat-icon>

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,0 +1,101 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { AppComponent } from './app.component';
+import { DefaultPrefGroups } from './common/preferences.service';
+
+interface PreferenceServiceStub {
+  prefGroup: string;
+  set: jasmine.Spy;
+}
+
+interface MessageListServiceStub {
+  unindexedFolders: string[];
+}
+
+interface AppComponentForTest {
+  dataReady: boolean;
+  lastSearchText: string;
+  searchText: string;
+  selectedFolder: string;
+  showingSearchResults: boolean;
+  showingWebSocketSearchResults: boolean;
+  usewebsocketsearch: boolean;
+  viewmode: string;
+  conversationGroupingCheckbox: boolean;
+  conversationGroupingToolTip: string;
+  unreadMessagesOnlyCheckbox: boolean;
+  unreadOnlyToolTip: string;
+  messagelist: unknown[];
+  messagelistservice: MessageListServiceStub;
+  preferenceService: PreferenceServiceStub;
+  resetColumns: jasmine.Spy;
+  setMessageDisplay: jasmine.Spy;
+  updateSearch(always?: boolean, noscroll?: boolean): void;
+}
+
+function buildComponentForTest(overrides: Partial<AppComponentForTest> = {}): AppComponentForTest {
+  const component = Object.create(AppComponent.prototype) as AppComponentForTest;
+
+  Object.assign(component, {
+    dataReady: true,
+    lastSearchText: '',
+    searchText: '',
+    selectedFolder: 'Inbox',
+    showingSearchResults: true,
+    showingWebSocketSearchResults: false,
+    usewebsocketsearch: true,
+    viewmode: 'conversations',
+    conversationGroupingCheckbox: true,
+    conversationGroupingToolTip: 'Threaded conversation view',
+    unreadMessagesOnlyCheckbox: false,
+    unreadOnlyToolTip: 'Unread messages only',
+    messagelist: [],
+    messagelistservice: {
+      unindexedFolders: []
+    },
+    preferenceService: {
+      prefGroup: DefaultPrefGroups.Desktop,
+      set: jasmine.createSpy('set')
+    },
+    resetColumns: jasmine.createSpy('resetColumns'),
+    setMessageDisplay: jasmine.createSpy('setMessageDisplay')
+  });
+
+  Object.assign(component, overrides);
+
+  return component;
+}
+
+describe('AppComponent message view options', () => {
+  it('clears stale threaded view state when the local index is unavailable', () => {
+    const component = buildComponentForTest();
+
+    component.updateSearch(true);
+
+    expect(component.viewmode).toBe('messages');
+    expect(component.conversationGroupingCheckbox).toBeFalse();
+    expect(component.preferenceService.set).toHaveBeenCalledWith(
+      DefaultPrefGroups.Desktop,
+      'rmm7mailViewerViewMode',
+      'messages'
+    );
+    expect(component.setMessageDisplay).toHaveBeenCalledWith('messagelist', component.messagelist);
+  });
+});

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -270,6 +270,8 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
         this.setMessageDisplay('websocketlist', results);
         this.showingWebSocketSearchResults = true;
       }
+      this.syncMessageViewOptionState();
+      this.updateTooltips();
       this.resetColumns();
     });
 
@@ -304,7 +306,8 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
       this.keepMessagePaneOpen = prefs.get(`${this.preferenceService.prefGroup}:${LOCAL_STORAGE_KEEP_PANE}`) === 'true';
       this.unreadMessagesOnlyCheckbox = prefs.get(`${DefaultPrefGroups.Global}:${LOCAL_STORAGE_SHOW_UNREAD_ONLY}`) === 'true';
       this.viewmode = prefs.get(`${this.preferenceService.prefGroup}:${LOCAL_STORAGE_VIEWMODE}`);
-      this.conversationGroupingCheckbox = !this.unreadMessagesOnlyCheckbox && this.viewmode === 'conversations';
+      this.syncMessageViewOptionState();
+      this.updateTooltips();
       this.messageSubjectDragTipShown = prefs.get(`${DefaultPrefGroups.Global}:messageSubjectDragTipShown`) === 'true';
 
       // jitsi video calling
@@ -342,6 +345,32 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     return this.singlemailviewer && this.singlemailviewer.adjustableHeight
       ? this.singlemailviewer.resizerHeight
       : 0;
+  }
+
+  public canUseConversationGrouping(): boolean {
+    return this.dataReady &&
+      this.showingSearchResults &&
+      !this.showingWebSocketSearchResults &&
+      !this.usewebsocketsearch;
+  }
+
+  private switchToMessagesViewMode(): void {
+    if (this.viewmode !== 'conversations') {
+      return;
+    }
+
+    this.viewmode = 'messages';
+    this.preferenceService.set(this.preferenceService.prefGroup, LOCAL_STORAGE_VIEWMODE, this.viewmode);
+  }
+
+  private syncMessageViewOptionState(): void {
+    if (this.unreadMessagesOnlyCheckbox) {
+      this.switchToMessagesViewMode();
+    }
+
+    this.conversationGroupingCheckbox = this.canUseConversationGrouping() &&
+      !this.unreadMessagesOnlyCheckbox &&
+      this.viewmode === 'conversations';
   }
 
   ngDoCheck(): void {
@@ -838,10 +867,10 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
       this.canvastable.topindex = 0;
       this.canvastable.rows = null;
       this.viewmode = 'messages';
-      this.conversationGroupingCheckbox = this.viewmode === 'conversations';
       this.preferenceService.set(this.preferenceService.prefGroup, LOCAL_STORAGE_VIEWMODE, this.viewmode);
       this.dataReady = false;
       this.showingSearchResults = false;
+      this.syncMessageViewOptionState();
       this.searchText = '';
 
       this.resetColumns();
@@ -1167,6 +1196,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
       if (viewmode !== 'singleconversation') {
         this.conversationSearchText = null;
       }
+      this.syncMessageViewOptionState();
       this.resetColumns();
       this.updateSearch(true);
     }
@@ -1257,10 +1287,10 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
   }
 
   updateTooltips() {
-    this.unreadOnlyToolTip = this.viewmode === 'conversations'
+    this.unreadOnlyToolTip = this.conversationGroupingCheckbox
       ? 'Leave threaded mode to view unread only'
       : 'Unread messages only';
-    this.conversationGroupingToolTip = !this.showingSearchResults
+    this.conversationGroupingToolTip = !this.canUseConversationGrouping()
       ? 'Synchronise the index to see threaded view'
       :  this.unreadMessagesOnlyCheckbox
         ? 'Leave unread only to see threaded view'
@@ -1274,6 +1304,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     // Ensure we save changed settings
     const setting = this.unreadMessagesOnlyCheckbox ? 'true' : 'false';
     this.preferenceService.set(DefaultPrefGroups.Global, LOCAL_STORAGE_SHOW_UNREAD_ONLY, setting);
+    this.syncMessageViewOptionState();
     this.updateTooltips();
 
     if (!this.dataReady || this.showingWebSocketSearchResults) {
@@ -1293,10 +1324,13 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
         /*
          * Message table from database, shown if local search index is not present
          */
+        this.switchToMessagesViewMode();
         if (this.showingSearchResults) {
           this.showingSearchResults = false;
           this.resetColumns();
         }
+        this.syncMessageViewOptionState();
+        this.updateTooltips();
 
         this.setMessageDisplay('messagelist', this.messagelist);
 
@@ -1338,6 +1372,8 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
         if (!this.showingSearchResults ||
           this.displayFolderColumn !== previousDisplayFolderColumn) {
           this.showingSearchResults = true;
+          this.syncMessageViewOptionState();
+          this.updateTooltips();
           this.resetColumns();
         }
 


### PR DESCRIPTION
## Summary

- keep the message-list view option checkbox state in sync with the view that can actually be displayed
- clear and persist stale threaded-view state when Runbox falls back to the non-indexed/API message list
- disable `Unread only` from the effective threaded checkbox state instead of raw saved `viewmode`
- add a regression spec for the stale threaded-view state described in #1724

Closes #1724.

## Testing

- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/app.component.spec.ts`
- red/green checked: the focused spec failed before the fix because `viewmode` stayed `conversations` and the threaded checkbox stayed checked
- `npx tsc -p tsconfig.json --noEmit`
- `npx eslint src/app/app.component.ts src/app/app.component.html src/app/app.component.spec.ts`
- `git diff --check`
- `npx ng test --watch=false --browsers=FirefoxHeadless`
- `npm run policy`
- `npm run lint`
- `npx ng build --configuration production --base-href=/app/ runbox7`

Notes:

- Full Karma result was `246 SUCCESS`, `2 skipped`; the suite still prints existing Angular/Karma console noise from unrelated specs.
- Lint exits successfully with the repository's existing warnings.
- The production build exits successfully with existing dependency/theming/unused-entry warnings.
