### PR TITLE
fix(mail): restore rows when clearing unread filter

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,0 +1,47 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { AppComponent } from './app.component';
+import { MessageList } from './common/messagelist';
+
+describe('AppComponent', () => {
+  it('restores cached message rows when unread-only filtering is cleared from an empty result', () => {
+    const component = Object.create(AppComponent.prototype) as AppComponent;
+    const rows = new MessageList([
+      { id: 1, seenFlag: true },
+      { id: 2, seenFlag: true }
+    ]);
+
+    component.searchText = '';
+    component.canvastable = {
+      rows,
+      hasChanges: false
+    } as unknown as AppComponent['canvastable'];
+
+    component.unreadMessagesOnlyCheckbox = true;
+    component.filterMessageDisplay();
+    expect(rows.rowCount()).toBe(0);
+
+    component.unreadMessagesOnlyCheckbox = false;
+    component.filterMessageDisplay();
+
+    expect(rows.rowCount()).toBe(2);
+    expect(component.canvastable.hasChanges).toBeTrue();
+  });
+});

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -901,7 +901,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
   }
 
   public filterMessageDisplay() {
-    if (this.canvastable.rows && this.canvastable.rows.rowCount() > 0) {
+    if (this.canvastable.rows) {
       const options = new Map();
       options.set('unreadOnly', this.unreadMessagesOnlyCheckbox);
       options.set('searchText', this.searchText);


### PR DESCRIPTION
## Summary

- allow the message-list filter to run even when the current visible row set is empty
- restore cached non-indexed message rows when `Unread only` is unchecked after filtering a folder down to zero unread messages
- add a focused regression spec for the empty-result filter reset

Fixes #1774.

## Testing

- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/app.component.spec.ts`
- red/green checked: the focused spec failed before the fix because clearing `Unread only` left the visible row count at `0`
- `npx tsc -p tsconfig.json --noEmit`
- `npx eslint src/app/app.component.ts src/app/app.component.spec.ts`
- `git diff --check`
- `npx ng test --watch=false --browsers=FirefoxHeadless`
- `npm run lint`
- `npm run policy`
- `node src/build/pre-build.js; npx ng build --configuration production --base-href=/app/ runbox7; node src/build/post-build.js`

Notes:

- Full Karma result was `246 SUCCESS`, `2 skipped`; the suite still prints existing Angular/Karma console noise from unrelated specs.
- Lint exits successfully with the repository's existing warnings.
- The production build exits successfully with existing dependency/theming/unused-entry warnings.
