### PR TITLE
fix(account): avoid resending unchanged alt email

### DIFF
--- a/src/app/account-details/personal-details.component.spec.ts
+++ b/src/app/account-details/personal-details.component.spec.ts
@@ -1,0 +1,148 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule, UntypedFormBuilder } from '@angular/forms';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { MatLegacyDialog as MatDialog } from '@angular/material/legacy-dialog';
+import { RMM } from '../rmm';
+import { PersonalDetailsComponent } from './personal-details.component';
+
+describe('PersonalDetailsComponent', () => {
+    let fixture: ComponentFixture<PersonalDetailsComponent>;
+    let component: PersonalDetailsComponent;
+    let httpMock: HttpTestingController;
+
+    const details = {
+        first_name: 'Test',
+        last_name: 'User',
+        email_alternative: 'test@example.com',
+        email_alternative_status: 0,
+        phone_number: '',
+        company: '',
+        org_number: '',
+        vat_number: '',
+        street_address: '',
+        city: '',
+        postal_code: '',
+        country: 'NO',
+        timezone: 'Europe/Oslo',
+    };
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            declarations: [PersonalDetailsComponent],
+            imports: [
+                HttpClientTestingModule,
+                ReactiveFormsModule,
+            ],
+            providers: [
+                UntypedFormBuilder,
+                {
+                    provide: MatDialog,
+                    useValue: {
+                        open: jasmine.createSpy('open'),
+                    },
+                },
+                {
+                    provide: RMM,
+                    useValue: {
+                        account_security: {
+                            user_password: 'secret-password',
+                        },
+                        show_error: jasmine.createSpy('show_error'),
+                    },
+                },
+            ],
+            schemas: [NO_ERRORS_SCHEMA],
+        });
+
+        fixture = TestBed.createComponent(PersonalDetailsComponent);
+        component = fixture.componentInstance;
+        httpMock = TestBed.inject(HttpTestingController);
+
+        httpMock.match('/rest/v1/account/details').forEach((req) => req.flush({
+            status: 'success',
+            result: details,
+        }));
+        httpMock.expectOne('/rest/v1/timezones').flush({
+            status: 'success',
+            result: {
+                timezones: ['Europe/Oslo'],
+            },
+        });
+    });
+
+    afterEach(() => {
+        httpMock.verify();
+    });
+
+    it('does not post an unchanged alternative email address', () => {
+        component.detailsForm.get('first_name').setValue('Updated');
+        component.detailsForm.get('first_name').markAsDirty();
+
+        component.detailsForm.get('email_alternative').setValue(details.email_alternative);
+        component.detailsForm.get('email_alternative').markAsDirty();
+        component.selectedCountry = details.country;
+        component.selectedTimezone = details.timezone;
+
+        component.update();
+
+        const req = httpMock.expectOne('/rest/v1/account/details');
+        expect(req.request.method).toBe('POST');
+        expect(req.request.body).toEqual({
+            first_name: 'Updated',
+            password: 'secret-password',
+        });
+
+        req.flush({
+            status: 'success',
+            result: {
+                ...details,
+                first_name: 'Updated',
+            },
+        });
+    });
+
+    it('posts the alternative email address when it changes', () => {
+        component.detailsForm.get('email_alternative').setValue('new@example.com');
+        component.detailsForm.get('email_alternative').markAsDirty();
+        component.selectedCountry = details.country;
+        component.selectedTimezone = details.timezone;
+
+        component.update();
+
+        const req = httpMock.expectOne('/rest/v1/account/details');
+        expect(req.request.method).toBe('POST');
+        expect(req.request.body).toEqual({
+            email_alternative: 'new@example.com',
+            password: 'secret-password',
+        });
+
+        req.flush({
+            status: 'success',
+            result: {
+                ...details,
+                email_alternative: 'new@example.com',
+                email_alternative_status: 1,
+            },
+        });
+    });
+});

--- a/src/app/account-details/personal-details.component.ts
+++ b/src/app/account-details/personal-details.component.ts
@@ -17,7 +17,7 @@
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
 
-import { HttpClient, HttpResponse } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Component, OnInit } from '@angular/core';
 import { UntypedFormBuilder, UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
 import { MatLegacyDialog as MatDialog } from '@angular/material/legacy-dialog';
@@ -50,8 +50,9 @@ export class PersonalDetailsComponent implements OnInit {
     details: Subject<AccountDetailsInterface> = new Subject();
     is_alternative_email_validated = false;
 
-    selectedCountry: any;
-    selectedTimezone: any;
+    selectedCountry: string;
+    selectedTimezone: string;
+    private loadedDetails: Partial<AccountDetailsInterface> = {};
 
     constructor(
         private fb: UntypedFormBuilder,
@@ -63,12 +64,14 @@ export class PersonalDetailsComponent implements OnInit {
             if (!details) return;
 
             this.detailsForm.patchValue(details);
+            this.loadedDetails = {...details};
+            this.selectedCountry = details.country;
+            this.selectedTimezone = details.timezone;
             this.is_alternative_email_validated = details.email_alternative_status === 0;
         });
 
         this.loadDetails();
         this.loadCountryList();
-        this.loadSelectFields();
         this.loadTimezones();
     }
 
@@ -110,27 +113,17 @@ export class PersonalDetailsComponent implements OnInit {
 
     loadTimezones() {
         firstValueFrom(this.http
-            .get('/rest/v1/timezones')
-            .pipe(map((res: HttpResponse<any>) => res['result'])))
+            .get<{ result: { timezones: string[] } }>('/rest/v1/timezones')
+            .pipe(map((res) => res.result)))
             .then((data) => this.timezones = data.timezones);
     }
 
     private loadDetails() {
         this.http
-            .get('/rest/v1/account/details')
-            .pipe(map((res: HttpResponse<any>) => res['result']))
+            .get<{ result: AccountDetailsInterface }>('/rest/v1/account/details')
+            .pipe(map((res) => res.result))
             .subscribe((details) => {
                 this.details.next(details);
-            });
-    }
-
-    private loadSelectFields() {
-        firstValueFrom(this.http
-            .get('/rest/v1/account/details')
-            .pipe(map((res: HttpResponse<any>) => res['result'])))
-            .then((data) => {
-                this.selectedCountry = data.country;
-                this.selectedTimezone = data.timezone;
             });
     }
 
@@ -144,21 +137,21 @@ export class PersonalDetailsComponent implements OnInit {
         for (const name of Object.keys(this.detailsForm.controls)) {
             const ctl = this.detailsForm.get(name);
 
-            // Select fields can't be marked as 'dirty', so it
-            // needs a specified case for Countries and Timezones
-            if (ctl.dirty) {
+            if (ctl.dirty && ctl.value !== this.loadedDetails[name]) {
                 updates[name] = ctl.value;
-            } else if (name === 'timezone') {
-                updates[name] = this.selectedTimezone;
-            } else if (name === 'country') {
-                updates[name] = this.selectedCountry;
             }
+        }
+        if (this.selectedTimezone !== this.loadedDetails.timezone) {
+            updates['timezone'] = this.selectedTimezone;
+        }
+        if (this.selectedCountry !== this.loadedDetails.country) {
+            updates['country'] = this.selectedCountry;
         }
         updates['password'] = this.rmm.account_security.user_password;
 
         this.http
-            .post('/rest/v1/account/details', updates)
-            .pipe(map((res: HttpResponse<any>) => res['result']))
+            .post<{ result?: AccountDetailsInterface }>('/rest/v1/account/details', updates)
+            .pipe(map((res) => res.result))
             .subscribe((details) => {
                 if(details && details.email_alternative) {
                     this.details.next(details);
@@ -171,7 +164,7 @@ export class PersonalDetailsComponent implements OnInit {
 
     public validate_alt_email() {
       this.http.post('/rest/v1/account/alt_email_validation', {})
-            .subscribe((res) => {
+            .subscribe(() => {
                 this.rmm.show_error('Validation email resent', 'Dismiss');
             });
     }


### PR DESCRIPTION
Fixes #1737.

## Summary

- Keep a snapshot of the Account Details values loaded from the API.
- Build the update payload from values that actually changed, rather than `dirty` state alone.
- Avoid posting an unchanged `email_alternative` value, even if the browser or form control marks it dirty.
- Initialize Country and Time zone from the existing details response, removing the duplicate `/rest/v1/account/details` request, and only post those select values when they change.

This keeps an unchanged alternative email address out of ordinary Personal Details updates while still posting it when the user really changes that address.

## Validation

- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/account-details/personal-details.component.spec.ts`
- `npx tsc -p tsconfig.json --noEmit`
- `npx eslint src/app/account-details/personal-details.component.ts src/app/account-details/personal-details.component.spec.ts`
- `git diff --check`
- `git diff --cached --check`
- `npx ng test --watch=false --browsers=FirefoxHeadless`
- `npm run lint`
- `npm run policy`
- `node src/build/pre-build.js; npx ng build --configuration production --base-href=/app/ runbox7; $res=$LASTEXITCODE; node src/build/post-build.js; exit $res`
