### PR TITLE
feat(mail): remember local index prompt choice

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -204,6 +204,14 @@
           </p>
           <mat-list>
             <mat-list-item>
+              <mat-checkbox
+                [(ngModel)]="rememberLocalIndexPromptDecision"
+                [disabled]="searchService.indexDownloadingInProgress"
+                data-cy="remember-local-index-choice">
+                Remember my choice on this device
+              </mat-checkbox>
+            </mat-list-item>
+            <mat-list-item>
               <button mat-raised-button (click)="downloadIndexFromServer()" matTooltip="Synchronize index with your device" color="primary" [disabled]="searchService.indexDownloadingInProgress">OK!</button>
               <button mat-raised-button (click)="cancelOrRefuseLocalIndex()" matTooltip="{{ searchService.indexDownloadingInProgress ? 'Cancel Download' : 'Do not synchronize index'}}" data-cy="cancel-button" color="warn">Cancel</button>
             </mat-list-item>

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,0 +1,73 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { AppComponent } from './app.component';
+
+describe('AppComponent', () => {
+  function createComponent() {
+    const component = Object.create(AppComponent.prototype) as AppComponent;
+    const storageSet = jasmine.createSpy('storage.set');
+
+    component.enableNotification = jasmine.createSpy('enableNotification');
+    component.searchService = {
+      indexDownloadingInProgress: false,
+      stopIndexDownloadingInProgress: false
+    } as AppComponent['searchService'];
+    component.offerInitialLocalIndex = true;
+    component.localSearchIndexPrompted = false;
+    component.rememberLocalIndexPromptDecision = false;
+    Object.assign(component, {
+      storage: {
+        set: storageSet
+      }
+    });
+
+    return { component, storageSet };
+  }
+
+  it('does not remember a refused local index prompt unless requested', () => {
+    const { component, storageSet } = createComponent();
+
+    component.cancelOrRefuseLocalIndex();
+
+    expect(storageSet).not.toHaveBeenCalled();
+    expect(component.localSearchIndexPrompted).toBeFalse();
+    expect(component.offerInitialLocalIndex).toBeFalse();
+  });
+
+  it('remembers a refused local index prompt when requested', () => {
+    const { component, storageSet } = createComponent();
+    component.rememberLocalIndexPromptDecision = true;
+
+    component.cancelOrRefuseLocalIndex();
+
+    expect(storageSet).toHaveBeenCalledOnceWith('localSearchPromptDisplayed', 'true');
+    expect(component.localSearchIndexPrompted).toBeTrue();
+    expect(component.offerInitialLocalIndex).toBeFalse();
+  });
+
+  it('marks an active local index download for cancellation', () => {
+    const { component } = createComponent();
+    component.searchService.indexDownloadingInProgress = true;
+
+    component.cancelOrRefuseLocalIndex();
+
+    expect(component.searchService.stopIndexDownloadingInProgress).toBeTrue();
+  });
+});

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -101,6 +101,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
   unreadMessagesOnlyCheckbox = false;
   unreadOnlyToolTip = 'Unread messages only';
   localSearchIndexPrompted = false;
+  rememberLocalIndexPromptDecision = false;
   offerInitialLocalIndex = false;
 
   indexDocCount = 0;
@@ -328,8 +329,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
 
       this.preferences = prefs;
     });
-    // localSearchIndexPrompted isnt a "preference" (users cant change it back)
-    // and we want it to prompt for eeach new device:
+    // Device-scoped storage controls whether the initial index prompt should be shown again.
     this.storage.get(LOCAL_STORAGE_INDEX_PROMPT).then((val) => {
       this.localSearchIndexPrompted = val === 'true';
     });
@@ -1028,8 +1028,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
 
   public downloadIndexFromServer() {
     this.enableNotification();
-    this.storage.set(LOCAL_STORAGE_INDEX_PROMPT, 'true');
-    this.localSearchIndexPrompted = true;
+    this.setLocalSearchIndexPrompted();
     this.searchService.downloadIndexFromServer().subscribe((res) => {
       if (res && !this.searchService.stopIndexDownloadingInProgress) {
         this.searchService.downloadPartitions().subscribe(() => {
@@ -1057,9 +1056,15 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     if (this.searchService.indexDownloadingInProgress) {
       this.searchService.stopIndexDownloadingInProgress = true;
     }
-    // User has had the initial prompt, stop asking
-    this.storage.set(LOCAL_STORAGE_INDEX_PROMPT, 'true');
+    if (this.rememberLocalIndexPromptDecision) {
+      this.setLocalSearchIndexPrompted();
+    }
     this.offerInitialLocalIndex = false;
+  }
+
+  private setLocalSearchIndexPrompted(): void {
+    this.storage.set(LOCAL_STORAGE_INDEX_PROMPT, 'true');
+    this.localSearchIndexPrompted = true;
   }
 
   singleMailViewerClosed(action: string): void {


### PR DESCRIPTION
Fixes #1721.

## Summary

- Add a `Remember my choice on this device` checkbox to the initial local-index synchronization prompt.
- Keep accepting synchronization as a remembered decision.
- Only persist a refusal when the checkbox is selected, so users who do not ask to remember the choice can be prompted again in a later session.
- Keep cancellation of an active index download working by setting `stopIndexDownloadingInProgress`.

This keeps the prompt device-scoped while making the "do not synchronize" decision optional to remember.

## Validation

- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/app.component.spec.ts`
- `npx tsc -p tsconfig.json --noEmit`
- `npx eslint src/app/app.component.ts src/app/app.component.html src/app/app.component.spec.ts`
- `git diff --check`
- `git diff --cached --check`
- `npx ng test --watch=false --browsers=FirefoxHeadless`
- `npm run lint`
- `npm run policy`
- `node src/build/pre-build.js; npx ng build --configuration production --base-href=/app/ runbox7; $res=$LASTEXITCODE; node src/build/post-build.js; exit $res`

## AI Assistance

This PR was prepared with AI-assisted source review, implementation, and test generation, with local validation run before submission.
