### PR TITLE
fix(compose): reply from runbox global domains

### DIFF
--- a/src/app/aliases/aliases.lister.ts
+++ b/src/app/aliases/aliases.lister.ts
@@ -20,7 +20,7 @@ import { Component } from '@angular/core';
 import { MatLegacyDialog as MatDialog } from '@angular/material/legacy-dialog';
 import { AliasesEditorModalComponent } from './aliases.editor.modal';
 import { RMM } from '../rmm';
-import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
+import { RunboxDomain, RunboxWebmailAPI } from '../rmmapi/rbwebmail';
 
 @Component({
   selector: 'app-aliases-lister',
@@ -29,7 +29,7 @@ import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
 })
 export class AliasesListerComponent {
   aliases: any[] = [];
-  domains: string[] = [];
+  domains: RunboxDomain[] = [];
   defaultEmail: string;
 
   constructor(

--- a/src/app/compose/draftdesk.service.spec.ts
+++ b/src/app/compose/draftdesk.service.spec.ts
@@ -430,9 +430,15 @@ describe('DraftDeskService', () => {
         // Mock ProfileService
         mockProfileService = {
             validProfiles: new BehaviorSubject([
-                Identity.fromObject({ email: 'test@runbox.com', name: 'Test User' })
+                Identity.fromObject({ email: 'test@runbox.com', name: 'Test User', type: 'main' })
             ]),
-            composeProfile: Identity.fromObject({ email: 'test@runbox.com', name: 'Test User' })
+            composeProfile: Identity.fromObject({ email: 'test@runbox.com', name: 'Test User', type: 'main' }),
+            globalDomains: new BehaviorSubject([
+                { id: 1, name: 'runbox.com' },
+                { id: 2, name: 'rbx.email' }
+            ]),
+            me: { uid: 42, username: 'testuser' },
+            meSubject: new BehaviorSubject({ uid: 42, username: 'testuser' })
         };
 
         // Mock HttpClient
@@ -474,6 +480,87 @@ describe('DraftDeskService', () => {
                 expect(froms[0].email).toBe('test@runbox.com');
                 done();
             });
+        });
+
+        it('should include Runbox global domain addresses for the username identity', () => {
+            const froms = draftDeskService.fromsSubject.value;
+
+            expect(froms.map(from => from.email)).toContain('testuser@runbox.com');
+            expect(froms.map(from => from.email)).toContain('testuser@rbx.email');
+        });
+
+        it('should update Runbox global domain addresses when the username loads', () => {
+            const meSubject = new BehaviorSubject(null);
+            mockProfileService.meSubject = meSubject;
+            draftDeskService = new DraftDeskService(
+                mockRmmapi,
+                mockMessageListService,
+                mockProfileService,
+                mockHttp
+            );
+
+            expect(draftDeskService.fromsSubject.value.map(from => from.email)).toContain('test@rbx.email');
+
+            meSubject.next({ uid: 42, username: 'testuser' });
+
+            const emails = draftDeskService.fromsSubject.value.map(from => from.email);
+            expect(emails).toContain('testuser@rbx.email');
+            expect(emails).not.toContain('test@rbx.email');
+        });
+
+        it('should include Runbox global domain addresses for Runbox aliases', () => {
+            mockProfileService.validProfiles.next([
+                Identity.fromObject({ email: 'test@runbox.com', type: 'main' }),
+                Identity.fromObject({ email: 'sales@runbox.com', type: 'aliases' })
+            ]);
+
+            const emails = draftDeskService.fromsSubject.value.map(from => from.email);
+
+            expect(emails).toContain('sales@rbx.email');
+            expect(emails.filter(email => email === 'sales@runbox.com').length).toBe(1);
+        });
+
+        it('should not generate Runbox global domain addresses for virtual domain aliases', () => {
+            mockProfileService.validProfiles.next([
+                Identity.fromObject({ email: 'test@runbox.com', type: 'main' }),
+                Identity.fromObject({
+                    email: 'sales@example.com',
+                    type: 'aliases',
+                    reference: {
+                        virtual_domainid: 16,
+                        virtual_domain: { name: 'example.com' }
+                    }
+                })
+            ]);
+
+            const emails = draftDeskService.fromsSubject.value.map(from => from.email);
+
+            expect(emails).toContain('sales@example.com');
+            expect(emails).not.toContain('sales@runbox.com');
+            expect(emails).not.toContain('sales@rbx.email');
+        });
+
+        it('should reply from the Runbox global domain address that received the message', () => {
+            const draft = DraftFormModel.reply({
+                headers: {
+                    'message-id': 'themessageid12123abcdef',
+                },
+                from: [
+                    {address: 'from@runbox.com', name: 'From'}
+                ],
+                to: [
+                    {address: 'testuser@rbx.email', name: 'Test User'}
+                ],
+                date: new Date(2017, 6, 1),
+                subject: 'Test subject',
+                text: 'blabla',
+                rawtext: 'blabla',
+                html: '<p>blabla</p>'
+            },
+            draftDeskService.fromsSubject.value,
+            false, false);
+
+            expect(draft.from).toBe('testuser@rbx.email');
         });
 
         it('should emit new draftModels when drafts are added', async () => {

--- a/src/app/compose/draftdesk.service.ts
+++ b/src/app/compose/draftdesk.service.ts
@@ -19,14 +19,14 @@
 
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
+import { RunboxDomain, RunboxMe, RunboxWebmailAPI } from '../rmmapi/rbwebmail';
 import { FolderListEntry } from '../common/folderlistentry';
 import { MessageInfo } from '../common/messageinfo';
 import { MailAddressInfo } from '../common/mailaddressinfo';
 import { MessageListService } from '../rmmapi/messagelist.service';
 import { MessageTableRowTool} from '../messagetable/messagetablerow';
 import { Identity, ProfileService } from '../profiles/profile.service';
-import { from, of, BehaviorSubject, firstValueFrom } from 'rxjs';
+import { from, of, BehaviorSubject, firstValueFrom, combineLatest } from 'rxjs';
 import { map, mergeMap, bufferCount, take, distinctUntilChanged } from 'rxjs/operators';
 
 import moment from 'moment';
@@ -246,8 +246,12 @@ export class DraftDeskService {
                 private profileService: ProfileService,
                 private http: HttpClient
                ) {
-        this.profileService.validProfiles.subscribe((profiles) => {
-            this.fromsSubject.next(profiles);
+        combineLatest([
+            this.profileService.validProfiles,
+            this.profileService.globalDomains,
+            this.profileService.meSubject
+        ]).subscribe(([profiles, globalDomains, me]) => {
+            this.fromsSubject.next(this.withRunboxGlobalDomainIdentities(profiles, globalDomains, me));
         });
 
         // Recreate drafts when froms(identities) change
@@ -275,6 +279,84 @@ export class DraftDeskService {
     // default identity for creating an email
     public mainIdentity(): Identity {
         return this.profileService.composeProfile;
+    }
+
+    private withRunboxGlobalDomainIdentities(
+        profiles: Identity[],
+        globalDomains: RunboxDomain[],
+        me: RunboxMe | null
+    ): Identity[] {
+        const globalDomainNames = this.globalDomainNames(globalDomains);
+        if (globalDomainNames.length === 0) {
+            return profiles;
+        }
+
+        const seenEmails = new Set<string>();
+        const froms = profiles.filter(profile => {
+            const email = (profile.email || '').toLowerCase();
+            if (!email || seenEmails.has(email)) {
+                return false;
+            }
+            seenEmails.add(email);
+            return true;
+        });
+
+        profiles
+            .filter(profile => this.shouldGenerateRunboxGlobalDomainIdentities(profile, globalDomainNames, me))
+            .forEach(profile => {
+                const localpart = this.runboxGlobalDomainLocalpart(profile, me);
+                if (!localpart) {
+                    return;
+                }
+
+                globalDomainNames.forEach(domainName => {
+                    const email = `${localpart}@${domainName}`;
+                    if (seenEmails.has(email)) {
+                        return;
+                    }
+
+                    froms.push(Identity.fromObject(Object.assign({}, profile, { email })));
+                    seenEmails.add(email);
+                });
+            });
+
+        return froms;
+    }
+
+    private globalDomainNames(globalDomains: RunboxDomain[]): string[] {
+        return Array.from(new Set((globalDomains || [])
+            .map(domain => this.globalDomainName(domain))
+            .filter(domain => domain)
+            .map(domain => domain.toLowerCase())));
+    }
+
+    private globalDomainName(domain: RunboxDomain): string {
+        return domain.name;
+    }
+
+    private shouldGenerateRunboxGlobalDomainIdentities(
+        profile: Identity,
+        globalDomainNames: string[],
+        me: RunboxMe | null
+    ): boolean {
+        if (profile.type === 'main') {
+            return !!this.runboxGlobalDomainLocalpart(profile, me);
+        }
+
+        return profile.type === 'aliases'
+            && globalDomainNames.includes(this.emailDomain(profile.email));
+    }
+
+    private runboxGlobalDomainLocalpart(profile: Identity, me: RunboxMe | null): string {
+        const source = profile.type === 'main' && me?.username
+            ? me.username
+            : profile.email;
+
+        return (source || '').split('@')[0].toLowerCase();
+    }
+
+    private emailDomain(email: string): string {
+        return (email || '').split('@')[1]?.toLowerCase();
     }
 
     private refreshDrafts() {

--- a/src/app/profiles/profile.service.ts
+++ b/src/app/profiles/profile.service.ts
@@ -19,7 +19,7 @@
 import { Injectable } from '@angular/core';
 import { map } from 'rxjs/operators';
 import { BehaviorSubject, Observable } from 'rxjs';
-import { RunboxMe, RunboxWebmailAPI } from '../rmmapi/rbwebmail';
+import { RunboxDomain, RunboxMe, RunboxWebmailAPI } from '../rmmapi/rbwebmail';
 
 export interface FromPriority {
     from_priority: number;
@@ -69,13 +69,21 @@ export class ProfileService {
     public validProfiles: BehaviorSubject<Identity[]> = new BehaviorSubject([]);
     public composeProfile: Identity;
     public me: RunboxMe;
-    public global_domains = [];
+    public meSubject: BehaviorSubject<RunboxMe | null> = new BehaviorSubject(null);
+    public global_domains: RunboxDomain[] = [];
+    public globalDomains: BehaviorSubject<RunboxDomain[]> = new BehaviorSubject([]);
     constructor(
         public rmmapi: RunboxWebmailAPI
     ) {
         this.refresh();
-        this.rmmapi.getRunboxDomains().subscribe(domains => this.global_domains = domains);
-        this.rmmapi.me.subscribe(me => this.me = me);
+        this.rmmapi.getRunboxDomains().subscribe(domains => {
+            this.global_domains = domains;
+            this.globalDomains.next(domains);
+        });
+        this.rmmapi.me.subscribe(me => {
+            this.me = me;
+            this.meSubject.next(me);
+        });
     }
 
     refresh() {

--- a/src/app/rmmapi/rbwebmail.ts
+++ b/src/app/rmmapi/rbwebmail.ts
@@ -126,6 +126,10 @@ export class RunboxMe {
     }
 }
 
+export interface RunboxDomain {
+    name: string;
+}
+
 export class MessageTextpart {
     type: string;
     textAsHtml: string;
@@ -624,7 +628,7 @@ export class RunboxWebmailAPI {
         return this.http.get('/rest/v1/aliases/limits');
     }
 
-    public getRunboxDomains(): Observable<string[]> {
+    public getRunboxDomains(): Observable<RunboxDomain[]> {
         return this.http.get('/rest/v1/runbox_domains')
             .pipe(
                 map((res: any) => res.results),


### PR DESCRIPTION
Fixes #1603

## Summary

- Add a typed Runbox domain API shape and observable domain/account metadata on `ProfileService`.
- Expand the compose `fromsSubject` with generated Runbox global-domain identities for the username identity and Runbox aliases, while keeping configured identities first and deduplicated.
- Exclude aliases on non-Runbox/virtual domains from generated global-domain identities.
- Cover username generation, late username metadata arrival, alias generation, virtual-domain exclusion, and reply-from matching in `DraftDeskService` tests.

## Validation

- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/compose/draftdesk.service.spec.ts` (`27 SUCCESS`)
- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/aliases/aliases.lister.spec.ts` (`6 SUCCESS`; existing Angular Material test-template console warnings)
- `npx tsc -p tsconfig.json --noEmit`
- `npx eslint src/app/aliases/aliases.lister.ts src/app/compose/draftdesk.service.ts src/app/compose/draftdesk.service.spec.ts src/app/profiles/profile.service.ts src/app/rmmapi/rbwebmail.ts` (`0 errors`; existing warnings)
- `git diff --check`
- `npx ng test --watch=false --browsers=FirefoxHeadless` (`250 SUCCESS`, `2 skipped`; command exits `0` with existing Karma console noise)
- `npm run lint` (`0 errors`; existing warning baseline)
- `npm run policy` (current commit OK; historical commit-message warnings remain)
- `node src/build/pre-build.js; npx ng build --configuration production --base-href=/app/ runbox7; $res=$LASTEXITCODE; node src/build/post-build.js; exit $res`
