### PR TITLE
fix(compose): commit typed recipients before send

### DIFF
--- a/src/app/compose/compose.component.spec.ts
+++ b/src/app/compose/compose.component.spec.ts
@@ -1,0 +1,112 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { Location } from '@angular/common';
+import { HttpClient } from '@angular/common/http';
+import { NgZone, QueryList } from '@angular/core';
+import { UntypedFormBuilder } from '@angular/forms';
+import { MatLegacySnackBar as MatSnackBar } from '@angular/material/legacy-snack-bar';
+import { Router } from '@angular/router';
+import { BehaviorSubject, of } from 'rxjs';
+import { MailAddressInfo } from '../common/mailaddressinfo';
+import { PreferencesService } from '../common/preferences.service';
+import { DialogService } from '../dialog/dialog.service';
+import { MessageListService } from '../rmmapi/messagelist.service';
+import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
+import { Identity } from '../profiles/profile.service';
+import { ComposeComponent } from './compose.component';
+import { DraftDeskService, DraftFormModel } from './draftdesk.service';
+import { MailRecipientInputComponent } from './mailrecipientinput.component';
+import { RecipientsService } from './recipients.service';
+
+describe('ComposeComponent', () => {
+    it('commits pending typed recipients before validating a send', () => {
+        const formBuilder = new UntypedFormBuilder();
+        const fromIdentity = new Identity();
+        fromIdentity.email = 'sender@runbox.com';
+        fromIdentity.from_name = 'Sender';
+        fromIdentity.resolveNameAndAddress();
+
+        const router = { navigate: jasmine.createSpy('navigate') } as unknown as Router;
+        const snackBar = { open: jasmine.createSpy('open') } as unknown as MatSnackBar;
+        const rmmapi = {
+            saveDraft: jasmine.createSpy('saveDraft').and.returnValue(of(['1', 'Sent', '42'])),
+            deleteCachedMessageContents: jasmine.createSpy('deleteCachedMessageContents'),
+            me: of({ username: 'sender' }),
+        } as unknown as RunboxWebmailAPI;
+        const draftDeskService = {
+            fromsSubject: new BehaviorSubject([fromIdentity]),
+            isEditing: -1,
+            composingNewDraft: null,
+            shouldReturnToPreviousPage: false,
+        } as unknown as DraftDeskService;
+        const messageListService = {
+            refreshFolderList: jasmine.createSpy('refreshFolderList'),
+        } as unknown as MessageListService;
+        const dialogService = {
+            openProgressDialog: jasmine.createSpy('openProgressDialog'),
+            closeProgressDialog: jasmine.createSpy('closeProgressDialog'),
+        } as unknown as DialogService;
+        const recipientService = { recentlyUsed: of([]) } as unknown as RecipientsService;
+        const preferenceService = {
+            preferences: new BehaviorSubject(new Map<string, string>()),
+            prefGroup: 'compose',
+        } as unknown as PreferencesService;
+
+        const component = new ComposeComponent(
+            router,
+            snackBar,
+            rmmapi,
+            draftDeskService,
+            messageListService,
+            {} as HttpClient,
+            formBuilder,
+            {} as Location,
+            dialogService,
+            recipientService,
+            preferenceService,
+            {} as NgZone,
+        );
+        component.formGroup = formBuilder.group({
+            from: fromIdentity.nameAndAddress,
+            subject: 'Subject',
+            msg_body: 'Body',
+            useHTML: false,
+        });
+        component.model = new DraftFormModel();
+        component.model.from = fromIdentity.nameAndAddress;
+
+        const commitPendingRecipient = jasmine.createSpy('commitPendingRecipient').and.callFake((force: boolean) => {
+            expect(force).toBe(true);
+            component.model.to = MailAddressInfo.parse('typed@example.com');
+        });
+        component.recipientInputs = {
+            forEach(callback: (input: MailRecipientInputComponent) => void) {
+                callback({ commitPendingRecipient } as unknown as MailRecipientInputComponent);
+            },
+        } as QueryList<MailRecipientInputComponent>;
+
+        component.submit(true);
+
+        expect(commitPendingRecipient).toHaveBeenCalled();
+        expect(rmmapi.saveDraft).toHaveBeenCalled();
+        const sentDraft = (rmmapi.saveDraft as jasmine.Spy).calls.mostRecent().args[0] as DraftFormModel;
+        expect(sentDraft.to[0].address).toBe('typed@example.com');
+    });
+});

--- a/src/app/compose/compose.component.ts
+++ b/src/app/compose/compose.component.ts
@@ -18,7 +18,8 @@
 // ---------- END RUNBOX LICENSE ----------
 
 import {
-    Input, Output, EventEmitter, Component, ElementRef, ViewChild, AfterViewInit, OnDestroy, OnInit, NgZone
+    Input, Output, EventEmitter, Component, ElementRef, ViewChild, ViewChildren, AfterViewInit, OnDestroy, OnInit,
+    NgZone, QueryList
 } from '@angular/core';
 import { Location } from '@angular/common';
 import { Router } from '@angular/router';
@@ -41,6 +42,7 @@ import { MessageListService } from '../rmmapi/messagelist.service';
 import { MessageTableRowTool} from '../messagetable/messagetablerow';
 import { DefaultPrefGroups, PreferencesService } from '../common/preferences.service';
 import { objectEqualWithKeys } from '../common/util';
+import { MailRecipientInputComponent } from './mailrecipientinput.component';
 
 declare const MailParser;
 
@@ -60,6 +62,7 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
     @ViewChild('editor') editorRef: ElementRef;
     @ViewChild('attachmentFileUploadInput') attachmentFileUploadInput: any;
     @ViewChild('messageTextArea', { read: ElementRef }) messageTextArea: ElementRef;
+    @ViewChildren(MailRecipientInputComponent) recipientInputs: QueryList<MailRecipientInputComponent>;
 
     editor: any = null;
     editorId: string;
@@ -696,6 +699,8 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
         this.savingInProgress = true;
 
         if (send) {
+            this.recipientInputs?.forEach(input => input.commitPendingRecipient(true));
+
             let validemails = false;
             validemails = isValidEmailArray(this.model.to);
             if (!validemails) {

--- a/src/app/compose/mailrecipientinput.component.spec.ts
+++ b/src/app/compose/mailrecipientinput.component.spec.ts
@@ -1,0 +1,105 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { MatLegacyAutocomplete as MatAutocomplete, MatLegacyAutocompleteModule } from '@angular/material/legacy-autocomplete';
+import { MatLegacyChipInputEvent as MatChipInputEvent, MatLegacyChipsModule } from '@angular/material/legacy-chips';
+import { MatLegacyFormFieldModule } from '@angular/material/legacy-form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatLegacyInputModule } from '@angular/material/legacy-input';
+import { MatLegacySnackBarModule } from '@angular/material/legacy-snack-bar';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { of } from 'rxjs';
+import { MailRecipientInputComponent } from './mailrecipientinput.component';
+import { RecipientsService } from './recipients.service';
+
+describe('MailRecipientInputComponent', () => {
+    let component: MailRecipientInputComponent;
+    let fixture: ComponentFixture<MailRecipientInputComponent>;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [
+                MatLegacyAutocompleteModule,
+                MatLegacyChipsModule,
+                MatLegacyFormFieldModule,
+                MatIconModule,
+                MatLegacyInputModule,
+                MatLegacySnackBarModule,
+                NoopAnimationsModule,
+                ReactiveFormsModule,
+            ],
+            declarations: [
+                MailRecipientInputComponent,
+            ],
+            providers: [
+                { provide: RecipientsService, useValue: { recipients: of([]) } },
+            ],
+        });
+
+        fixture = TestBed.createComponent(MailRecipientInputComponent);
+        component = fixture.componentInstance;
+        component.recipients = [];
+        component.ngOnChanges();
+        fixture.detectChanges();
+    });
+
+    function textInput(): HTMLInputElement {
+        return fixture.nativeElement.querySelector('input');
+    }
+
+    it('turns a typed address into a recipient chip after blur', fakeAsync(() => {
+        const input = textInput();
+
+        component.auto = { isOpen: true } as MatAutocomplete;
+        input.value = 'person@example.com';
+        input.dispatchEvent(new Event('blur'));
+        tick();
+
+        expect(component.recipientsList.length).toBe(1);
+        expect(component.recipientsList[0].address).toBe('person@example.com');
+        expect(input.value).toBe('');
+        expect(component.invalidemail).toBe(false);
+    }));
+
+    it('can force a pending typed address into a recipient before send validation', () => {
+        const input = textInput();
+
+        component.addedFromAutoComplete = true;
+        input.value = 'typed@example.com';
+        component.commitPendingRecipient(true);
+
+        expect(component.recipientsList.length).toBe(1);
+        expect(component.recipientsList[0].address).toBe('typed@example.com');
+        expect(input.value).toBe('');
+        expect(component.addedFromAutoComplete).toBe(false);
+    });
+
+    it('does not add an Enter token while autocomplete is open', () => {
+        const input = textInput();
+
+        component.auto = { isOpen: true } as MatAutocomplete;
+        input.value = 'typed@example.com';
+        component.addRecipientFromEnter({ input } as MatChipInputEvent);
+
+        expect(component.recipientsList.length).toBe(0);
+        expect(input.value).toBe('typed@example.com');
+    });
+});

--- a/src/app/compose/mailrecipientinput.component.ts
+++ b/src/app/compose/mailrecipientinput.component.ts
@@ -130,26 +130,32 @@ export class MailRecipientInputComponent implements OnChanges, AfterViewInit {
     }
 
     addRecipientFromBlur() {
+        setTimeout(() => this.commitPendingRecipient(true));
+    }
+
+    commitPendingRecipient(force = false) {
         const input = this.searchTextInput.nativeElement;
         const value = (input.value || '').trim();
 
-        if (this.auto.isOpen || this.addedFromAutoComplete) {
+        if (!value) {
+            this.addedFromAutoComplete = false;
+            this.invalidemail = false;
+            return;
+        }
+        if (!force && (this.auto.isOpen || this.addedFromAutoComplete)) {
             this.addedFromAutoComplete = false;
             return;
         }
-        if (value) {
-            this.addRecipient(input);
-            this.addedFromAutoComplete = false;
-            return;
-        }
-        this.invalidemail = false;
+        this.addRecipient(input);
+        this.addedFromAutoComplete = false;
     }
 
     addRecipientFromEnter(event: MatChipInputEvent) {
         const input = event.input;
         const value = (input.value || '').trim();
 
-        if (this.addedFromAutoComplete) {
+        if (this.auto.isOpen || this.addedFromAutoComplete) {
+            this.addedFromAutoComplete = false;
             return;
         }
         if (value) {


### PR DESCRIPTION
Fixes #1670.

## Summary
- Commit pending typed recipient text before Send validates the To/CC/BCC arrays.
- Reuse the same commit helper for blur so leaving the field turns a typed address into a chip after the autocomplete event cycle has settled.
- Keep the Enter/autocomplete guard so selecting an autocomplete option does not also create a duplicate typed-address chip.
- Add focused coverage for blur commit, forced send commit, autocomplete-open Enter behavior, and the compose submit path.

## Testing
- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/compose/mailrecipientinput.component.spec.ts`
- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/compose/mailrecipientinput.component.spec.ts --include=src/app/compose/compose.component.spec.ts`
- `npx tsc -p tsconfig.json --noEmit`
- `npx eslint src/app/compose/compose.component.ts src/app/compose/compose.component.spec.ts src/app/compose/mailrecipientinput.component.ts src/app/compose/mailrecipientinput.component.spec.ts` (exit 0; existing `compose.component.ts` `any` warnings)
- `git diff --check`
- `git diff --cached --check`
- `npx ng test --watch=false --browsers=FirefoxHeadless` (249 success, 2 skipped; existing console noise)
- `npm run lint` (exit 0; existing warnings)
- `npm run policy` (exit 0; current commit OK, historical commit-message warnings still printed)
- `node src/build/pre-build.js; npx ng build --configuration production --base-href=/app/ runbox7; $res=$LASTEXITCODE; node src/build/post-build.js; exit $res` (exit 0; existing Angular/Sass/CommonJS warnings)
