### PR TITLE
fix(mail): retain selection when opening messages

### DIFF
--- a/src/app/common/messagedisplay.spec.ts
+++ b/src/app/common/messagedisplay.spec.ts
@@ -1,0 +1,62 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { MessageList } from './messagelist';
+
+describe('MessageDisplay', () => {
+  function messageList(): MessageList {
+    return new MessageList([
+      { id: 101, seenFlag: false },
+      { id: 102, seenFlag: false },
+      { id: 103, seenFlag: false },
+    ]);
+  }
+
+  it('retains checked message selections when opening another message', () => {
+    const display = messageList();
+
+    display.rowSelected(0, 0);
+    display.rowSelected(1, 0);
+    display.rowSelected(2, 3);
+
+    expect(display.selectedMessageIds()).toEqual([101, 102]);
+    expect(display.isOpenedRow(2)).toBe(true);
+    expect(display.hasChanges).toBe(true);
+  });
+
+  it('does not toggle a selected message off when opening it', () => {
+    const display = messageList();
+
+    display.rowSelected(0, 0);
+    display.rowSelected(0, 3);
+
+    expect(display.selectedMessageIds()).toEqual([101]);
+    expect(display.isOpenedRow(0)).toBe(true);
+  });
+
+  it('keeps checkbox toggles unchanged', () => {
+    const display = messageList();
+
+    display.rowSelected(0, 0);
+    display.rowSelected(0, 0);
+
+    expect(display.selectedMessageIds()).toEqual([]);
+    expect(display.anySelected()).toBe(false);
+  });
+});

--- a/src/app/common/messagedisplay.ts
+++ b/src/app/common/messagedisplay.ts
@@ -126,6 +126,14 @@ export abstract class MessageDisplay {
     // multiSelect is true if we're applying rowSelect in a loop
     this.selectedRowId = selectedRowId;
 
+    // Clicks right of the checkbox open a message. Keep existing checkbox
+    // selections intact so the selected messages can still be operated on.
+    if (columnIndex > 0) {
+      this.openedRowIndex = rowIndex;
+      this.hasChanges = true;
+      return;
+    }
+
     // flip sense of selected row (deleted below if now false)
     if (columnIndex >= -1) {
       this.flipSelectedRow(this.selectedRowId);
@@ -134,12 +142,6 @@ export abstract class MessageDisplay {
       // MS is a special snowflake:
       this.selectRow(this.selectedRowId);
       return;
-    }
-
-    // click anywhere on a row right of the checkbox, reset the selected rows
-    // as we want to open the email instead
-    if (columnIndex > 0) {
-      this.msgIdsSelected = {};
     }
 
     // columnIndex == -1 if drag & drop
@@ -151,15 +153,6 @@ export abstract class MessageDisplay {
       this.delSelectedRow(selectedRowId);
     }
 
-    // If we clicked right of the checkbox, we wanted to open the email:
-    if (columnIndex > 0) {
-      // selectedRow will change when we click on other checkboxes, this one
-      // stays attached to the opened email
-//      this.openedRowId = this.selectedRowId;
-      this.openedRowIndex = rowIndex;
-
-      this.hasChanges = true;
-    }
   }
 
   // row entries


### PR DESCRIPTION
Fixes #1388.

## Summary
- Keep existing checkbox selections intact when opening a message from the message list.
- Still update the opened row state when clicking right of the checkbox so the preview/opened-message behavior remains unchanged.
- Add focused coverage for opening another message with selected messages, opening an already selected message, and regular checkbox toggling.

## Testing
- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/common/messagedisplay.spec.ts`
- `npx tsc -p tsconfig.json --noEmit`
- `npx eslint src/app/common/messagedisplay.ts src/app/common/messagedisplay.spec.ts` (exit 0; existing `messagedisplay.ts` `any` warnings)
- `git diff --check`
- `git diff --cached --check`
- `npx ng test --watch=false --browsers=FirefoxHeadless` (248 success, 2 skipped; existing console/template warnings)
- `npm run lint` (exit 0; existing warnings)
- `npm run policy` (exit 0; current commit OK, historical commit-message warnings still printed)
- `node src/build/pre-build.js; npx ng build --configuration production --base-href=/app/ runbox7; $res=$LASTEXITCODE; node src/build/post-build.js; exit $res` (exit 0; existing Angular/Sass/CommonJS warnings)
