### PR TITLE
fix(mail): toggle opened message time zone

### DIFF
--- a/src/app/mailviewer/singlemailviewer.component.html
+++ b/src/app/mailviewer/singlemailviewer.component.html
@@ -238,7 +238,10 @@
           </div>
           <div class="messageHeaderRow">
             <div class="messageHeaderDate">Time:</div>
-            <div class="messageHeaderDate">{{mailObj.date | date:'yyyy-MM-dd HH:mm ZZZZ'}}</div>
+            <div class="messageHeaderDate">{{mailObj.date | date:messageDateFormat:messageDateTimezone}}</div>
+            <button mat-button type="button" class="messageHeaderTimeMode" (click)="toggleMessageDateMode()">
+              {{messageDateModeLabel}}
+            </button>
           </div>
           <div *ngIf="mailObj.to" class="messageHeaderRow">
             <div class="messageHeaderTo">

--- a/src/app/mailviewer/singlemailviewer.component.scss
+++ b/src/app/mailviewer/singlemailviewer.component.scss
@@ -18,6 +18,13 @@
     font-size: 12px;
 }
 
+.messageHeaderTimeMode {
+    font-size: 12px;
+    line-height: 20px;
+    min-width: 0;
+    padding: 0 4px;
+}
+
 .messageHeaderFrom {
     font-size: 15px;
 }

--- a/src/app/mailviewer/singlemailviewer.component.spec.ts
+++ b/src/app/mailviewer/singlemailviewer.component.spec.ts
@@ -231,6 +231,47 @@ describe('SingleMailViewerComponent', () => {
       expect(component.mailObj.attachments[1].downloadURL.indexOf('blob:')).toBe(0);
     }));
 
+  it('can switch opened message sent time between local and origin time', () => {
+    interface ProcessedMail {
+      date: Date;
+      dateOriginTimezone: string;
+    }
+
+    const mail = (component as unknown as {
+      processMessageContents(messageContents: MessageContents): ProcessedMail;
+    }).processMessageContents(Object.assign(new MessageContents(), {
+      headers: {
+        from: {
+          value: [{ address: 'sender@example.com', name: 'Sender' }]
+        },
+        date: '2024-01-02T09:30:00.000+02:30',
+        subject: 'Time zone test'
+      },
+      text: {
+        text: 'body',
+        html: null,
+        textAsHtml: 'body'
+      },
+      attachments: [],
+      sanitized_html: '',
+      sanitized_html_without_images: ''
+    }));
+
+    component.mailObj = mail;
+
+    expect(mail.date.getTime()).toBe(new Date('2024-01-02T09:30:00.000+02:30').getTime());
+    expect(mail.dateOriginTimezone).toBe('+0230');
+    expect(component.messageDateModeLabel).toBe('Local time');
+    expect(component.messageDateFormat).toBe('yyyy-MM-dd HH:mm');
+    expect(component.messageDateTimezone).toBeUndefined();
+
+    component.toggleMessageDateMode();
+
+    expect(component.messageDateModeLabel).toBe('Origin time');
+    expect(component.messageDateFormat).toBe('yyyy-MM-dd HH:mm ZZZZZ');
+    expect(component.messageDateTimezone).toBe('+0230');
+  });
+
   describe('mailto: link interceptor', () => {
     let messageContentsElement: HTMLElement;
     let mailtoLink: HTMLAnchorElement;

--- a/src/app/mailviewer/singlemailviewer.component.ts
+++ b/src/app/mailviewer/singlemailviewer.component.ts
@@ -115,6 +115,7 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
   public savedForThisSender = false;
   public savedAlways = false;
   public showAllHeaders = false;
+  public displayOriginDate = false;
 
   contacts: Contact[] = [];
 
@@ -543,25 +544,29 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
     if (!res.headers.date) {
       res.headers.date = '1970-01-01T00:00:00.000Z';
     }
-    res.date = (
-      (arr: string[]): Date =>
-        new Date(
-          parseInt(arr[1], 10),
-          parseInt(arr[2], 10) - 1,
-          parseInt(arr[3], 10),
-          parseInt(arr[4], 10),
-          parseInt(arr[5], 10),
-          parseInt(arr[6], 10),
-          parseInt(arr[7], 10)
-        )
-    )
-      (
-        new RegExp('([0-9][0-9][0-9][0-9])-([0-9][0-9])-([0-9][0-9])T' +
-          '([0-9][0-9]):([0-9][0-9]):([0-9][0-9])\.([0-9][0-9][0-9])')
-          .exec(res.headers.date)
-      );
+    res.dateOriginTimezone = this.getDateHeaderTimezone(res.headers.date);
+    res.date = res.dateOriginTimezone ? new Date(res.headers.date) : new Date(NaN);
+    if (isNaN(res.date.getTime())) {
+      res.date = (
+        (arr: string[]): Date =>
+          new Date(
+            parseInt(arr[1], 10),
+            parseInt(arr[2], 10) - 1,
+            parseInt(arr[3], 10),
+            parseInt(arr[4], 10),
+            parseInt(arr[5], 10),
+            parseInt(arr[6], 10),
+            parseInt(arr[7], 10)
+          )
+      )
+        (
+          new RegExp('([0-9][0-9][0-9][0-9])-([0-9][0-9])-([0-9][0-9])T' +
+            '([0-9][0-9]):([0-9][0-9]):([0-9][0-9])\.([0-9][0-9][0-9])')
+            .exec(res.headers.date)
+        );
 
-    res.date.setMinutes(res.date.getMinutes() - res.date.getTimezoneOffset());
+      res.date.setMinutes(res.date.getMinutes() - res.date.getTimezoneOffset());
+    }
 
     res.sanitized_html = this.expandAttachmentData(res.attachments, res.sanitized_html);
     res.visible_attachment_count = res.attachments.filter((att) => !att.internal).length;
@@ -623,6 +628,17 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
    //  res.text = text;
     res.text = this.domSanitizer.bypassSecurityTrustHtml(DOMPurify.sanitize(res.text.textAsHtml)); // res.text.textAsHtml;
     return res;
+  }
+
+  private getDateHeaderTimezone(dateHeader: string): string | undefined {
+    const timezone = /(Z|[+-][0-9]{2}:?[0-9]{2})$/.exec(dateHeader);
+    if (!timezone) {
+      return undefined;
+    }
+    if (timezone[1] === 'Z') {
+      return '+0000';
+    }
+    return timezone[1].replace(':', '');
   }
 
   expandAttachmentData(attachments: any[], html: string): string {
@@ -854,6 +870,22 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
       }, 0);
     }
 
+  }
+
+  public get messageDateFormat(): string {
+    return this.displayOriginDate ? 'yyyy-MM-dd HH:mm ZZZZZ' : 'yyyy-MM-dd HH:mm';
+  }
+
+  public get messageDateTimezone(): string | undefined {
+    return this.displayOriginDate ? this.mailObj?.dateOriginTimezone : undefined;
+  }
+
+  public get messageDateModeLabel(): string {
+    return this.displayOriginDate ? 'Origin time' : 'Local time';
+  }
+
+  public toggleMessageDateMode() {
+    this.displayOriginDate = !this.displayOriginDate;
   }
 
   heightChanged(percentage: number) {


### PR DESCRIPTION
Fixes #1455.

## Summary
- Add a compact Time header toggle for opened messages that switches between local display time and the message origin time.
- Hide the UTC offset in local-time mode, and show the parsed Date header offset in origin-time mode.
- Preserve the existing fallback parsing path for Date headers that do not include an offset.
- Add focused coverage for parsing an offset Date header and switching the displayed time mode.

## Testing
- Confirmed the focused regression spec failed before the implementation.
- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/mailviewer/singlemailviewer.component.spec.ts` (9 success; existing template console warnings and attachment thumbnail 404 noise)
- `npx ng test --watch=false --browsers=FirefoxHeadless --include="src/app/mailviewer/**/*.spec.ts"` (9 success; same existing console noise)
- `npx tsc -p tsconfig.json --noEmit`
- `npx eslint src/app/mailviewer/singlemailviewer.component.ts src/app/mailviewer/singlemailviewer.component.html src/app/mailviewer/singlemailviewer.component.spec.ts` (exit 0; existing warnings)
- `git diff --check`
- `git diff --cached --check`
- `npx ng test --watch=false --browsers=FirefoxHeadless` (246 success, 2 skipped; existing console/template warnings)
- `npm run lint` (exit 0; existing warnings)
- `npm run policy` (exit 0; current commit OK, historical commit-message warnings still printed)
- `node src/build/pre-build.js; npx ng build --configuration production --base-href=/app/ runbox7; $res=$LASTEXITCODE; node src/build/post-build.js; exit $res` (exit 0; existing Angular/Sass/CommonJS warnings)
