### PR TITLE
fix(mail): make HTML display controls selectable

### DIFF
--- a/src/app/mailviewer/singlemailviewer.component.html
+++ b/src/app/mailviewer/singlemailviewer.component.html
@@ -299,16 +299,15 @@
         <mat-radio-group
           aria-label="Toggle Plain/HTML view"
           [value]="showHTML ? 'HTML' : 'Plain'"
+          (change)="setHtmlView($event.value)"
           >
           <mat-radio-button
-            (click)="toggleHtml($event)"
             value="Plain"
             matTooltip="Toggle Plain Text version of message"
             >
             <mat-icon svgIcon="format-letter-case"></mat-icon>
           </mat-radio-button>
           <mat-radio-button
-            (click)="toggleHtml($event)"
             value="HTML"
             matTooltip="Toggle HTML version of message"
             >
@@ -316,17 +315,20 @@
           </mat-radio-button>
         </mat-radio-group>
 	<mat-checkbox *ngIf="showHTML"
-          (click)="showExternalImages($event)"
+          (change)="setExternalImages($event.checked)"
           [checked]="showImages"
           matTooltip="Show external images"
 	  >
           <mat-icon svgIcon="image"></mat-icon>
+          Images
 	</mat-checkbox>
         <mat-checkbox *ngIf="!showHTML"
           color="gray"
+          [disabled]="true"
           matTooltip="Show external images (only in HTML view)"
           >
           <mat-icon svgIcon="image" class="themePaletteDarkGray"></mat-icon>
+          Images
         </mat-checkbox>
 	<span class="space"></span>
         <span> For: </span>

--- a/src/app/mailviewer/singlemailviewer.component.spec.ts
+++ b/src/app/mailviewer/singlemailviewer.component.spec.ts
@@ -231,6 +231,49 @@ describe('SingleMailViewerComponent', () => {
       expect(component.mailObj.attachments[1].downloadURL.indexOf('blob:')).toBe(0);
     }));
 
+  it('sets plain and HTML view modes without toggling the selected mode', () => {
+    const htmlControls = component as unknown as {
+      setHtmlView(mode: 'Plain' | 'HTML'): void;
+    };
+
+    component.showHTMLDecision = 'dontask';
+    component.showHTML = false;
+
+    htmlControls.setHtmlView('HTML');
+    expect(component.showHTML).toBeTrue();
+
+    htmlControls.setHtmlView('HTML');
+    expect(component.showHTML).toBeTrue();
+
+    htmlControls.setHtmlView('Plain');
+    expect(component.showHTML).toBeFalse();
+
+    htmlControls.setHtmlView('Plain');
+    expect(component.showHTML).toBeFalse();
+  });
+
+  it('sets external image visibility from the checkbox state', () => {
+    const htmlControls = component as unknown as {
+      setExternalImages(showImages: boolean): void;
+    };
+
+    component.mailContentHTMLWithImages = '<img src="remote.jpg">';
+    component.mailContentHTMLWithoutImages = '<p>No remote images</p>';
+    component.showImages = false;
+
+    htmlControls.setExternalImages(true);
+    expect(component.showImages).toBeTrue();
+    expect(component.mailContentHTML).toBe(component.mailContentHTMLWithImages);
+
+    htmlControls.setExternalImages(true);
+    expect(component.showImages).toBeTrue();
+    expect(component.mailContentHTML).toBe(component.mailContentHTMLWithImages);
+
+    htmlControls.setExternalImages(false);
+    expect(component.showImages).toBeFalse();
+    expect(component.mailContentHTML).toBe(component.mailContentHTMLWithoutImages);
+  });
+
   describe('mailto: link interceptor', () => {
     let messageContentsElement: HTMLElement;
     let mailtoLink: HTMLAnchorElement;

--- a/src/app/mailviewer/singlemailviewer.component.ts
+++ b/src/app/mailviewer/singlemailviewer.component.ts
@@ -357,27 +357,48 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
   public toggleHtml(event) {
     event.preventDefault();
 
+    this.setHtmlView(this.showHTML ? 'Plain' : 'HTML');
+  }
+
+  public setHtmlView(viewMode: 'Plain' | 'HTML') {
+    if (viewMode === 'Plain') {
+      if (!this.showHTML) {
+        return;
+      }
+      this.savedAlways = false;
+      this.savedForThisSender = false;
+      this.showHTML = false;
+      return;
+    }
+
+    if (this.showHTML) {
+      return;
+    }
+
     this.savedAlways = false;
     this.savedForThisSender = false;
-    if (!this.showHTML) {
-      console.log(this.showHTMLDecision);
-      const decisionObservable = this.showHTMLDecision ?
-        of(this.showHTMLDecision) : this.dialog.open(ShowHTMLDialogComponent).afterClosed();
+    const decisionObservable = this.showHTMLDecision ?
+      of(this.showHTMLDecision) : this.dialog.open(ShowHTMLDialogComponent).afterClosed();
 
-      decisionObservable.subscribe(result => {
-        this.preferenceService.set(this.preferenceService.prefGroup, showHtmlDecisionKey, result);
-        this.showHTMLDecision = result;
-        this.showHTML = true;
-      });
-    } else {
-      this.showHTML = false;
-    }
+    decisionObservable.subscribe(result => {
+      this.preferenceService.set(this.preferenceService.prefGroup, showHtmlDecisionKey, result);
+      this.showHTMLDecision = result;
+      this.showHTML = true;
+    });
   }
 
   public showExternalImages(event) {
     event.preventDefault();
 
-    this.showImages = !this.showImages;
+    this.setExternalImages(!this.showImages);
+  }
+
+  public setExternalImages(showImages: boolean) {
+    if (this.showImages === showImages) {
+      return;
+    }
+
+    this.showImages = showImages;
     this.savedAlways = false;
     this.savedForThisSender = false;
     // turn on:


### PR DESCRIPTION
Fixes #1395.

## Summary
- Make the opened-message Plain/HTML radio buttons set the requested view instead of toggling away from the currently selected option.
- Drive external image visibility from the checkbox checked state instead of click toggling.
- Add an `Images` checkbox label so the image control has a larger clickable target, and keep it disabled while plain-text view is active.
- Add focused coverage for repeated Plain/HTML selections and repeated external-image checkbox states.

## Testing
- Confirmed the focused regression specs failed before the implementation.
- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/mailviewer/singlemailviewer.component.spec.ts` (10 success; existing template console warnings and attachment thumbnail 404 noise)
- `npx ng test --watch=false --browsers=FirefoxHeadless --include="src/app/mailviewer/**/*.spec.ts"` (10 success; same existing console noise)
- `npx tsc -p tsconfig.json --noEmit`
- `npx eslint src/app/mailviewer/singlemailviewer.component.ts src/app/mailviewer/singlemailviewer.component.html src/app/mailviewer/singlemailviewer.component.spec.ts` (exit 0; existing warnings)
- `git diff --check`
- `git diff --cached --check`
- `npx ng test --watch=false --browsers=FirefoxHeadless` (247 success, 2 skipped; existing console/template warnings)
- `npm run lint` (exit 0; existing warnings)
- `npm run policy` (exit 0; current commit OK, historical commit-message warnings still printed)
- `node src/build/pre-build.js; npx ng build --configuration production --base-href=/app/ runbox7; $res=$LASTEXITCODE; node src/build/post-build.js; exit $res` (exit 0; existing Angular/Sass/CommonJS warnings)
