### PR TITLE
fix(app): allow public changelog access

### DIFF
--- a/src/app/app.module.spec.ts
+++ b/src/app/app.module.spec.ts
@@ -1,0 +1,39 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { routes } from './app.module';
+import { RMMAuthGuardService } from './rmmapi/rmmauthguard.service';
+
+describe('AppModule routes', () => {
+  it('keeps the changelog available before authentication', () => {
+    const changelogRouteIndex = routes.findIndex((route) => route.path === 'changelog');
+    const guardedShellIndex = routes.findIndex((route) =>
+      route.canActivateChild && route.canActivateChild.includes(RMMAuthGuardService)
+    );
+
+    expect(changelogRouteIndex).toBeGreaterThan(-1);
+    expect(guardedShellIndex).toBeGreaterThan(-1);
+    expect(changelogRouteIndex).toBeLessThan(guardedShellIndex);
+
+    const guardedShell = routes[guardedShellIndex];
+    const guardedChangelogRoute = guardedShell.children.find((route) => route.path === 'changelog');
+
+    expect(guardedChangelogRoute).toBeUndefined();
+  });
+});

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -93,7 +93,8 @@ import { DomainRegisterRedirectComponent } from './domainregister/domreg-redirec
 window.addEventListener('dragover', (event) => event.preventDefault());
 window.addEventListener('drop', (event) => event.preventDefault());
 
-const routes: Routes = [
+export const routes: Routes = [
+  { path: 'changelog',          loadChildren: () => import('./changelog/changelog.module').then(m => m.ChangelogModule) },
   {
     path: '',
     canActivateChild: [RMMAuthGuardService],
@@ -126,7 +127,6 @@ const routes: Routes = [
       { path: 'dev',                loadChildren: () => import('./dev/dev.module').then(m => m.DevModule) },
       { path: 'dkim',               loadChildren: () => import('./dkim/dkim.module').then(m => m.DkimModule) },
       { path: 'calendar',           loadChildren: () => import('./calendar-app/calendar-app.module').then(m => m.CalendarAppModule) },
-      { path: 'changelog',          loadChildren: () => import('./changelog/changelog.module').then(m => m.ChangelogModule) },
       { path: 'contacts',           loadChildren: () => import('./contacts-app/contacts-app.module').then(m => m.ContactsAppModule) },
       { path: 'onscreen',           loadChildren: () => import('./onscreen/onscreen.module').then(m => m.OnscreenModule) },
       { path: 'identities',         redirectTo: '/account/identities' },


### PR DESCRIPTION
Fixes #1039.

## Summary
- Move the `/changelog` route before the authenticated app shell so the changelog lazy module can load without hitting `RMMAuthGuardService`.
- Keep the rest of the app routes behind the existing `canActivateChild` guard.
- Add a focused route configuration spec that checks the changelog route stays public and outside the guarded shell.

## Testing
- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/app.module.spec.ts` (1 success)
- `npx tsc -p tsconfig.json --noEmit`
- `npx eslint src/app/app.module.ts src/app/app.module.spec.ts`
- `git diff --check`
- `git diff --cached --check`
- `npx ng test --watch=false --browsers=FirefoxHeadless` (246 success, 2 skipped; existing console/template warnings)
- `npm run lint` (exit 0; existing warnings)
- `npm run policy` (exit 0; current commit OK, historical commit-message warnings still printed)
- `node src/build/pre-build.js; npx ng build --configuration production --base-href=/app/ runbox7; $res=$LASTEXITCODE; node src/build/post-build.js; exit $res` (exit 0; existing Angular/Sass/CommonJS warnings)
