### PR TITLE
fix(mail): keep opened message highlight by id

### DIFF
--- a/src/app/canvastable/canvastable.ts
+++ b/src/app/canvastable/canvastable.ts
@@ -977,7 +977,7 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
       this.maxVisibleRows = this.canv.scrollHeight / this.rowheight;
       if(this.jumpToMessage) {
         // currently selected row in the centre:
-        if (this.rows.rowCount() > 0 && this.rows.openedRowIndex) {
+        if (this.rows.rowCount() > 0 && this.rows.openedRowIndex !== null && this.rows.openedRowIndex !== undefined) {
           this.topindex = this.rows.openedRowIndex - Math.round(this.maxVisibleRows / 2);
         }
         this.jumpToMessage = false;

--- a/src/app/common/messagedisplay.ts
+++ b/src/app/common/messagedisplay.ts
@@ -20,6 +20,7 @@ import { CanvasTableColumn } from '../canvastable/canvastablecolumn';
 
 export abstract class MessageDisplay {
   public openedRowIndex: number;
+  public openedMessageId: number;
   public selectedRowId: number;
   //  public openedRowId: number;
   public msgIdsSelected: { [key: number]: boolean } = {};
@@ -40,6 +41,7 @@ export abstract class MessageDisplay {
   setRows(rows: any) {
     this._rows = rows;
     this.rows = rows;
+    this.refreshOpenedRowIndex();
   }
 
   // rows:
@@ -86,6 +88,7 @@ export abstract class MessageDisplay {
   }
 
   public getCurrentRow(): any {
+    this.refreshOpenedRowIndex();
     return this.rows[this.openedRowIndex];
   }
 
@@ -103,6 +106,7 @@ export abstract class MessageDisplay {
       }
     });
     this.rows = filteredRows;
+    this.refreshOpenedRowIndex();
   }
 
   public rowSelected(rowIndex: number, columnIndex: number, multiSelect?: boolean) {
@@ -157,6 +161,7 @@ export abstract class MessageDisplay {
       // stays attached to the opened email
 //      this.openedRowId = this.selectedRowId;
       this.openedRowIndex = rowIndex;
+      this.openedMessageId = this.getRowMessageId(rowIndex);
 
       this.hasChanges = true;
     }
@@ -185,6 +190,9 @@ export abstract class MessageDisplay {
   }
 
   isOpenedRow(index: number): boolean {
+    if (this.openedMessageId) {
+      return this.rowExists(index) && this.getRowMessageId(index) === this.openedMessageId;
+    }
     return index === this.openedRowIndex;
   }
 
@@ -196,6 +204,14 @@ export abstract class MessageDisplay {
 
   clearOpenedRow() {
     this.openedRowIndex = null;
+    this.openedMessageId = null;
+  }
+
+  protected refreshOpenedRowIndex() {
+    if (this.openedMessageId) {
+      const openedRowIndex = this.findRowByMessageId(this.openedMessageId);
+      this.openedRowIndex = openedRowIndex > -1 ? openedRowIndex : null;
+    }
   }
 
   // filtering:

--- a/src/app/common/messagelist.spec.ts
+++ b/src/app/common/messagelist.spec.ts
@@ -1,0 +1,83 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { MessageList } from './messagelist';
+
+function message(id: number, seenFlag = false) {
+  return {
+    id,
+    seenFlag,
+    messageDate: new Date('2026-06-10T09:00:00Z'),
+    from: [],
+    to: [],
+    subject: `message ${id}`,
+    plaintext: '',
+    size: 0,
+    attachment: false,
+    answeredFlag: false,
+    flaggedFlag: false,
+  };
+}
+
+describe('MessageList', () => {
+  it('keeps the opened message highlighted when new rows are inserted above it', () => {
+    const messageList = new MessageList([
+      message(3),
+      message(2),
+      message(1),
+    ]);
+
+    messageList.rowSelected(1, 1, false);
+
+    messageList.setRows([
+      message(4),
+      message(3),
+      message(2),
+      message(1),
+    ]);
+
+    expect(messageList.openedRowIndex).toBe(2);
+    expect(messageList.isOpenedRow(0)).toBeFalse();
+    expect(messageList.isOpenedRow(1)).toBeFalse();
+    expect(messageList.isOpenedRow(2)).toBeTrue();
+  });
+
+  it('restores the opened highlight after filters hide and show the opened row', () => {
+    const messageList = new MessageList([
+      message(3, false),
+      message(2, true),
+      message(1, false),
+    ]);
+    const unreadOnly = new Map<string, boolean>();
+
+    messageList.rowSelected(1, 1, false);
+
+    unreadOnly.set('unreadOnly', true);
+    messageList.filterBy(unreadOnly);
+
+    expect(messageList.openedRowIndex).toBeNull();
+    expect(messageList.rows.map((row) => row.id)).toEqual([3, 1]);
+
+    unreadOnly.set('unreadOnly', false);
+    messageList.filterBy(unreadOnly);
+
+    expect(messageList.openedRowIndex).toBe(1);
+    expect(messageList.isOpenedRow(1)).toBeTrue();
+  });
+});

--- a/src/app/common/messagelist.ts
+++ b/src/app/common/messagelist.ts
@@ -68,6 +68,7 @@ export class MessageList extends MessageDisplay {
     if (options.has('unreadOnly') && options.get('unreadOnly')) {
       this.rows = this._rows.filter((msg) => !msg.seenFlag);
     }
+    this.refreshOpenedRowIndex();
   }
 
   public getCanvasTableColumns(app: any): CanvasTableColumn[] {

--- a/src/app/websocketsearch/websocketsearchmaillist.ts
+++ b/src/app/websocketsearch/websocketsearchmaillist.ts
@@ -49,6 +49,7 @@ export class WebSocketSearchMailList extends MessageDisplay {
     if (options.has('unreadOnly') && options.get('unreadOnly')) {
       this.rows = this._rows.filter((msg) => !msg.seen);
     }
+    this.refreshOpenedRowIndex();
   }
 
     public getCanvasTableColumns(app: any): CanvasTableColumn[] {


### PR DESCRIPTION
Fixes #1290.

## Summary
- Track the opened message by message id as well as by visible row index.
- Resync the opened row index when message-list rows are replaced or filtered, so new messages inserted above the previewed message do not steal the opened-row highlight.
- Apply the same resync path to API-backed message lists and websocket search lists.
- Allow `jumpToOpenMessage()` to work when the opened row is the first row.
- Add focused coverage for inserting a new row above the opened message and for hiding/showing the opened row with filters.

## Testing
- Confirmed the focused regression specs failed before the implementation.
- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/common/messagelist.spec.ts` (2 success)
- `npx ng test --watch=false --browsers=FirefoxHeadless --include="src/app/common/**/*.spec.ts" --include=src/app/canvastable/canvastable.spec.ts` (57 success; existing console noise)
- `npx tsc -p tsconfig.json --noEmit`
- `npx eslint src/app/common/messagedisplay.ts src/app/common/messagelist.ts src/app/common/messagelist.spec.ts src/app/websocketsearch/websocketsearchmaillist.ts src/app/canvastable/canvastable.ts` (exit 0; existing warnings)
- `git diff --check`
- `git diff --cached --check`
- `npx ng test --watch=false --browsers=FirefoxHeadless` (247 success, 2 skipped; existing console/template warnings)
- `npm run lint` (exit 0; existing warnings)
- `npm run policy` (exit 0; current commit OK, historical commit-message warnings still printed)
- `node src/build/pre-build.js; npx ng build --configuration production --base-href=/app/ runbox7; $res=$LASTEXITCODE; node src/build/post-build.js; exit $res` (exit 0; existing Angular/Sass/CommonJS warnings)
