### PR TITLE
fix(mail): preserve list position after deletion

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -816,7 +816,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
       messageIds: messageIds,
       updateLocal: (msgIds: number[]) => {
         // remove from message display
-        this.canvastable.rows.removeMessages(messageIds);
+        this.canvastable.removeMessages(msgIds);
         this.searchService.deleteMessages(msgIds);
         if (this.selectedFolder === this.messagelistservice.trashFolderName) {
           this.messagelistservice.deleteTrashMessages(msgIds);

--- a/src/app/canvastable/canvastable.spec.ts
+++ b/src/app/canvastable/canvastable.spec.ts
@@ -22,6 +22,15 @@ import { CanvasTableModule, CanvasTableContainerComponent } from './canvastable'
 import { MessageList } from '../common/messagelist';
 
 describe('canvastable', () => {
+    const selectListener = {
+        rowSelected: (): void => {
+            return undefined;
+        },
+        saveColumnWidthsPreference: (): void => {
+            return undefined;
+        }
+    };
+
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [
@@ -32,13 +41,7 @@ describe('canvastable', () => {
 
     it('should activate draggable column overlay on mouseover', async () => {
         const fixture = TestBed.createComponent(CanvasTableContainerComponent);
-        fixture.componentInstance.canvastableselectlistener = {
-            rowSelected: (rowIndex: number, colIndex: number, rowContent: any, multiSelect?: boolean): void => {
-
-            },
-            saveColumnWidthsPreference: (widths: any): void => {
-            }
-        };
+        fixture.componentInstance.canvastableselectlistener = selectListener;
         fixture.componentInstance.canvastable.columns = [
             {
                 name: 'Column1',
@@ -72,5 +75,33 @@ describe('canvastable', () => {
         fixture.detectChanges();
         expect(fixture.componentInstance.canvastable.floatingTooltip).toBeTruthy();
         expect(fixture.componentInstance.canvastable.columnOverlay).toBeTruthy();
+    });
+
+    it('should move the deleted message follower to the top after row removal', () => {
+        const fixture = TestBed.createComponent(CanvasTableContainerComponent);
+        fixture.componentInstance.canvastableselectlistener = selectListener;
+        fixture.componentInstance.canvastable.columns = [
+            {
+                name: 'Subject',
+                cacheKey: 'subject',
+                sortColumn: null,
+                getValue: (row) => row.subject,
+                width: 200
+            }
+        ];
+        fixture.componentInstance.canvastable.rows = new MessageList(
+            Array.from({ length: 40 }, (_, index) => ({
+                id: index + 1,
+                subject: `Message ${index + 1}`
+            }))
+        );
+        fixture.componentInstance.canvastable.topindex = 4;
+        fixture.detectChanges();
+
+        fixture.componentInstance.canvastable.removeMessages([6, 11, 21]);
+
+        expect(fixture.componentInstance.canvastable.rows.rowCount()).toBe(37);
+        expect(fixture.componentInstance.canvastable.topindex).toBe(18);
+        expect(fixture.componentInstance.canvastable.rows.getRowMessageId(18)).toBe(22);
     });
 });

--- a/src/app/canvastable/canvastable.ts
+++ b/src/app/canvastable/canvastable.ts
@@ -853,6 +853,40 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
     this.hasChanges = true;
   }
 
+  public removeMessages(messageIds: number[]) {
+    if (!this.rows) {
+      return;
+    }
+
+    const topIndexAfterRemoval = this.getTopIndexAfterMessageRemoval(messageIds);
+
+    this.rows.removeMessages(messageIds);
+
+    if (topIndexAfterRemoval !== null) {
+      this.topindex = topIndexAfterRemoval;
+      this.enforceScrollLimit();
+    }
+    this.hasChanges = true;
+  }
+
+  private getTopIndexAfterMessageRemoval(messageIds: number[]): number | null {
+    if (!this.rows || messageIds.length === 0) {
+      return null;
+    }
+
+    const removedRowIndexes = Array.from(new Set(messageIds))
+      .map(messageId => this.rows.findRowByMessageId(messageId))
+      .filter(rowIndex => rowIndex >= 0)
+      .sort((a, b) => a - b);
+
+    if (removedRowIndexes.length === 0) {
+      return null;
+    }
+
+    const lastRemovedRowIndex = removedRowIndexes[removedRowIndexes.length - 1];
+    return Math.max(0, lastRemovedRowIndex + 1 - removedRowIndexes.length);
+  }
+
   public get showContentTextPreview(): boolean {
     return this._showContentTextPreview;
   }


### PR DESCRIPTION
Fixes #1201.

## Summary
- Keep the mail list focused near the deleted selection by routing selected-message deletion through `CanvasTableComponent.removeMessages()`.
- Compute the row that followed the last deleted message before mutating the backing `MessageList`, then move that row to the top of the visible table after removal.
- Clamp the resulting scroll position with the existing canvas-table scroll-limit logic.
- Add focused canvastable coverage for deleting non-contiguous selected messages from a longer list.

## Testing
- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/canvastable/canvastable.spec.ts` (2 success)
- `npx tsc -p tsconfig.json --noEmit`
- `npx eslint src/app/app.component.ts src/app/canvastable/canvastable.ts src/app/canvastable/canvastable.spec.ts` (exit 0; existing warnings)
- `git diff --check` (normal Windows line-ending warnings only)
- `git diff --cached --check`
- `npx ng test --watch=false --browsers=FirefoxHeadless` (exit 0; 246 success, 2 skipped; existing Karma/console noise)
- `npm run lint` (exit 0; existing warnings)
- `node src/build/pre-build.js`, `npx ng build --configuration production --base-href=/app/ runbox7`, `node src/build/post-build.js` (exit 0; existing Angular/Sass/CommonJS warnings)
- `npm run policy` (exit 0; current commit OK, historical commit-message warnings still printed)

## AI Assistance
This PR was implemented with assistance from OpenAI Codex. I reviewed the issue, source changes, tests, and validation output before submitting.
