### PR TITLE
fix(identities): create new profiles as external email

### DIFF
--- a/e2e/cypress/integration/profile.ts
+++ b/e2e/cypress/integration/profile.ts
@@ -24,17 +24,21 @@ describe('Profiles settings page', () => {
 
         // open dialog, fill in fields, submit
         cy.get('app-profiles-edit').should('be.visible');
-        cy.get('input[name="email"]').type('newprof@runbox.com');
+        cy.get('input[name="email"]').type('newprof+tag@runbox.com');
         cy.get('input[name="from"]').type('My Name');
         cy.get('input[name="name"]').type('My Profile');
         cy.get('textarea[name="signature"]').type('My Sig');
 
-        cy.intercept('POST', '/rest/v1/profile', {
-            statusCode: 200,
-            body: {
-                status: 'success',
-                result: {id: 1}
-            }
+        cy.intercept('POST', '/rest/v1/profile', (req) => {
+            expect(req.body.email).to.equal('newprof+tag@runbox.com');
+            expect(req.body.type).to.equal('external_email');
+            req.reply({
+                statusCode: 200,
+                body: {
+                    status: 'success',
+                    result: {id: 1}
+                }
+            });
         }).as('postProfile');
         cy.get('button#save').click();
         cy.wait('@postProfile');

--- a/src/app/profiles/profile.service.spec.ts
+++ b/src/app/profiles/profile.service.spec.ts
@@ -40,6 +40,7 @@ describe('Identity', () => {
 
 describe('ProfileService', () => {
     let service: ProfileService;
+    let createdProfile: Partial<Identity>;
 
     const DEFAULT_EMAIL = 'a2@example.com';
     const PROFILES =        [{
@@ -137,6 +138,7 @@ describe('ProfileService', () => {
     const ALLOWED_DOMAINS = ['runbox.com', 'example.com'];
 
     beforeEach(waitForAsync(() => {
+        createdProfile = null;
         TestBed.configureTestingModule({
             imports: [
                 HttpClientTestingModule,
@@ -146,6 +148,7 @@ describe('ProfileService', () => {
                     me: of({first_name: 'Test', last_name: 'User'}),
                     getProfiles: () => of(PROFILES),
                     createProfile: (newprofile) => {
+                        createdProfile = newprofile;
                         newprofile['reference_type'] = 'aliases';
                         PROFILES.unshift(newprofile);
                         return of(PROFILES.length);
@@ -190,12 +193,15 @@ describe('ProfileService', () => {
 
     it('adds a new profile on create', (done) => {
         service.create({ name: 'New Profile Name',
-                         email: 'newp@runbox.com',
+                         email: 'newp+tag@runbox.com',
                          from_name: 'New Profile',
                          signature: 'My sig'})
             .subscribe((res) => {
                 expect(res).toBeTruthy();
-                expect(PROFILES.length).toBe(PROFILES.length);
+                expect(createdProfile).toEqual(jasmine.objectContaining({
+                    email: 'newp+tag@runbox.com',
+                    type: 'external_email'
+                }));
                 done();
             });
                              

--- a/src/app/profiles/profile.service.ts
+++ b/src/app/profiles/profile.service.ts
@@ -100,7 +100,11 @@ export class ProfileService {
     }  
     
     create(values): Observable<boolean> {
-      return this.rmmapi.createProfile(values).pipe(
+      const profileValues = {
+          ...values,
+          type: values.type || 'external_email',
+      };
+      return this.rmmapi.createProfile(profileValues).pipe(
           map((res: boolean) => {
               this.refresh();
               return res;


### PR DESCRIPTION
## Summary

- Default newly created identities/profiles to `external_email` before sending them to the profile API.
- Preserve plus/sub-addressed email values unchanged in the create-profile payload.
- Add unit and Cypress coverage for creating a plus-address identity.

Fixes #1826.

## Regression Coverage

The updated profile service spec and Cypress create-profile flow both use plus-addressed emails and assert that the request includes `type: external_email`. These checks fail against the previous implementation because new profile creation omitted the identity type.

## Testing

- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/profiles/profile.service.spec.ts`
- `npx tsc -p tsconfig.json --noEmit`
- `npx eslint src/app/profiles/profile.service.ts src/app/profiles/profile.service.spec.ts e2e/cypress/integration/profile.ts`
- `npx ng test --watch=false --browsers=FirefoxHeadless`
- `npm run lint`
- `npx cypress run --headless --spec e2e/cypress/integration/profile.ts`
- `node src/build/pre-build.js && npx ng build --configuration production --base-href=/app/ runbox7 && node src/build/post-build.js`
- `npm run policy`

## AI Disclosure

This PR was prepared with assistance from OpenAI Codex (GPT-5.5) in the local worktree, including code/test changes and validation commands.
