### PR TITLE
fix(mail): restore folder after child route closes

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,0 +1,75 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { fakeAsync, tick } from '@angular/core/testing';
+import { BehaviorSubject } from 'rxjs';
+import { AppComponent } from './app.component';
+
+describe('AppComponent route activation', () => {
+  function createComponent(currentFolder = 'Inbox'): AppComponent {
+    const component = Object.create(AppComponent.prototype) as AppComponent;
+    const router = { navigate: jasmine.createSpy('navigate') };
+
+    component.hasChildRouterOutlet = true;
+    component.selectedFolder = null;
+    component.viewmode = 'conversations';
+    component.conversationSearchText = undefined;
+    Reflect.set(component, 'router', router);
+    component.messagelistservice = {
+      currentFolder,
+      messagesInViewSubject: new BehaviorSubject([]),
+      setCurrentFolder: jasmine.createSpy('setCurrentFolder'),
+      unindexedFolders: [],
+    } as unknown as AppComponent['messagelistservice'];
+    component.canvastable = {
+      scrollTop: jasmine.createSpy('scrollTop'),
+    } as unknown as AppComponent['canvastable'];
+    component.clearSelection = jasmine.createSpy('clearSelection');
+    component.resetColumns = jasmine.createSpy('resetColumns');
+    component.updateSearch = jasmine.createSpy('updateSearch');
+
+    return component;
+  }
+
+  it('clears the selected folder when a child route opens', () => {
+    const component = createComponent();
+    component.selectedFolder = 'Inbox';
+
+    component.childRouteActivated(true);
+
+    expect(component.hasChildRouterOutlet).toBeTrue();
+    expect(component.selectedFolder).toBeNull();
+  });
+
+  it('restores the current folder when returning from a child route', fakeAsync(() => {
+    const component = createComponent('Archive');
+
+    component.childRouteActivated(false);
+
+    expect(component.hasChildRouterOutlet).toBeFalse();
+    expect(component.selectedFolder).toBe('Archive');
+    expect(component.messagelistservice.setCurrentFolder).toHaveBeenCalledOnceWith('Archive');
+    expect(Reflect.get(component, 'router').navigate).not.toHaveBeenCalled();
+
+    tick();
+
+    expect(component.updateSearch).toHaveBeenCalledWith(true);
+    expect(component.canvastable.scrollTop).toHaveBeenCalled();
+  }));
+});

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1023,6 +1023,8 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     if (yes) {
       // Don't highlight a folder if we're not viewing one
       this.selectedFolder = null;
+    } else if (!this.selectedFolder) {
+      this.switchToFolder(this.messagelistservice.currentFolder || 'Inbox');
     }
   }
 


### PR DESCRIPTION
Fixes #1500

## Summary

- restore the current mail folder when a child route such as Account closes back to Mail
- reuse the existing folder switching path so the message list refresh/search update runs normally
- keep folder highlighting cleared while a child route is active
- cover child-route activation and return-to-mail behavior with a focused unit spec

## Validation

- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/app.component.spec.ts`
- `npx tsc -p tsconfig.json --noEmit`
- `npx eslint src/app/app.component.ts src/app/app.component.spec.ts`
- `npx ng test --watch=false --browsers=FirefoxHeadless`
- `npm run lint`
- `npm run policy`
- `node src/build/pre-build.js`
- `npx ng build --configuration production --base-href=/app/ runbox7`
- `node src/build/post-build.js`

Notes: the full unit suite, lint, policy, and production build still print existing Angular/Karma/Sass/CommonJS/lint/historical commit-message warnings; all commands above exited successfully.

## AI Assistance Disclosure

This PR was prepared with assistance from OpenAI Codex.
