### PR TITLE
fix(contacts): search all contact fields

### DIFF
--- a/src/app/contacts-app/contact-list.component.spec.ts
+++ b/src/app/contacts-app/contact-list.component.spec.ts
@@ -1,0 +1,103 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { Address, AddressDetails, Contact } from './contact';
+import { ContactListComponent } from './contact-list.component';
+
+describe('ContactListComponent', () => {
+    let component: ContactListComponent;
+
+    beforeEach(() => {
+        component = new ContactListComponent();
+        component.contacts = [
+            new Contact({
+                id: 'alice-id',
+                first_name: 'Alice',
+                last_name: 'Able',
+                emails: [
+                    { types: ['home'], value: 'alice@example.com' },
+                    { types: ['work'], value: 'a.able@runbox.test' },
+                ],
+                phones: [
+                    { types: ['cell'], value: '+47 555 0100' },
+                ],
+                categories: ['Friends'],
+                note: 'Met at the storage migration planning session',
+            }),
+            new Contact({
+                id: 'bob-id',
+                first_name: 'Bob',
+                last_name: 'Baker',
+                emails: [
+                    { types: ['work'], value: 'bob@example.com' },
+                ],
+                company: 'Example Logistics',
+                department: 'Billing',
+                categories: ['Team'],
+            }),
+        ];
+        component.contacts[0].addresses = [
+            new Address(
+                ['work'],
+                new AddressDetails(['', '', 'Search Street 7', 'Oslo', 'Viken', '0123', 'Norway'])
+            ),
+        ];
+    });
+
+    function shownContactIds(): string[] {
+        return component.shownContacts.map(c => c.id);
+    }
+
+    it('searches email, phone, address, and note fields', () => {
+        component.searchTerm = 'a.able@runbox.test';
+        component.filterContacts();
+        expect(shownContactIds()).toEqual(['alice-id']);
+
+        component.searchTerm = '555 0100';
+        component.filterContacts();
+        expect(shownContactIds()).toEqual(['alice-id']);
+
+        component.searchTerm = 'search street';
+        component.filterContacts();
+        expect(shownContactIds()).toEqual(['alice-id']);
+
+        component.searchTerm = 'storage migration';
+        component.filterContacts();
+        expect(shownContactIds()).toEqual(['alice-id']);
+    });
+
+    it('searches company and department fields', () => {
+        component.searchTerm = 'example logistics';
+        component.filterContacts();
+        expect(shownContactIds()).toEqual(['bob-id']);
+
+        component.searchTerm = 'billing';
+        component.filterContacts();
+        expect(shownContactIds()).toEqual(['bob-id']);
+    });
+
+    it('keeps category filtering when searching non-name fields', () => {
+        component.categoryFilter = 'USER:Team';
+        component.searchTerm = 'a.able@runbox.test';
+
+        component.filterContacts();
+
+        expect(shownContactIds()).toEqual([]);
+    });
+});

--- a/src/app/contacts-app/contact-list.component.ts
+++ b/src/app/contacts-app/contact-list.component.ts
@@ -59,6 +59,8 @@ export class ContactListComponent implements OnChanges {
     }
 
     filterContacts() {
+        const searchTerm = this.searchTerm.trim().toLowerCase();
+
         this.shownContacts = this.contacts.filter(c => {
             if (this.categoryFilter === 'RUNBOX:ALL') {
                 return true;
@@ -71,10 +73,36 @@ export class ContactListComponent implements OnChanges {
 
             return c.categories.find(g => g === target);
         }).filter(c => {
-            return (c.display_name() || '').toLowerCase().indexOf(this.searchTerm.toLowerCase()) !== -1;
+            return !searchTerm || this.contactMatchesSearch(c, searchTerm);
         });
 
         this.sortContacts();
+    }
+
+    private contactMatchesSearch(contact: Contact, searchTerm: string): boolean {
+        return this.valueMatchesSearch(contact.display_name(), searchTerm)
+            || this.valueMatchesSearch(contact.toDict(), searchTerm);
+    }
+
+    private valueMatchesSearch(value: unknown, searchTerm: string): boolean {
+        if (value === null || value === undefined) {
+            return false;
+        }
+
+        if (typeof value === 'string' || typeof value === 'number') {
+            return value.toString().toLowerCase().indexOf(searchTerm) !== -1;
+        }
+
+        if (Array.isArray(value)) {
+            return value.some(entry => this.valueMatchesSearch(entry, searchTerm));
+        }
+
+        if (typeof value === 'object') {
+            return Object.values(value as Record<string, unknown>)
+                .some(entry => this.valueMatchesSearch(entry, searchTerm));
+        }
+
+        return false;
     }
 
     onContactChecked(): void {


### PR DESCRIPTION
Fixes #1406

## Summary

- search contacts through the structured contact dictionary instead of display name only
- include email, phone, address, note, company, department, category, and other saved contact fields in the existing search box
- keep the existing category filtering and contact sorting behavior
- cover non-name field matching and category filtering with a focused unit spec

## Validation

- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/contacts-app/contact-list.component.spec.ts`
- `npx ng test --watch=false --browsers=FirefoxHeadless --include="src/app/contacts-app/**/*.spec.ts"`
- `npx tsc -p tsconfig.json --noEmit`
- `npx eslint src/app/contacts-app/contact-list.component.ts src/app/contacts-app/contact-list.component.spec.ts`
- `npx ng test --watch=false --browsers=FirefoxHeadless`
- `npm run lint`
- `npm run policy`
- `node src/build/pre-build.js`
- `npx ng build --configuration production --base-href=/app/ runbox7`
- `node src/build/post-build.js`
- `git diff --check`
- `git diff --cached --check`

Notes: the full unit suite passed on rerun with `248 SUCCESS`, `2 skipped`. The full unit suite, lint, policy, and production build still print existing Angular/Karma/Sass/CommonJS/lint/historical commit-message warnings; all commands above exited successfully.

## AI Assistance Disclosure

This PR was prepared with assistance from OpenAI Codex.
