### PR TITLE
fix(contacts): place bulk actions in contact list

### DIFF
--- a/src/app/contacts-app/contacts-app.component.html
+++ b/src/app/contacts-app/contacts-app.component.html
@@ -69,21 +69,6 @@
             </mat-list-item>
         </mat-nav-list>
 
-        <div class="multiContactActions" *ngIf="selectedCount > 0">
-            <button mat-fab *ngIf="groups.length > 0"
-                matTooltip="Add these contacts to a group"
-                (click)="addSelectedToGroup()"
-            >
-                <mat-icon [matBadge]="selectedCount" matBadgePosition="below before" svgIcon="account-multiple-plus"></mat-icon>
-            </button>
-
-            <button mat-fab
-                matTooltip="Delete these contacts"
-                (click)="deleteSelected()"
-            >
-                <mat-icon [matBadge]="selectedCount" matBadgePosition="below before" svgIcon="delete"></mat-icon>
-            </button>
-        </div>
     </mat-sidenav>
     <mat-sidenav-content>
         <div id="contactsPageTop"></div>
@@ -103,6 +88,27 @@
         </mat-toolbar>
         <div [class]="appLayout">
             <div class="contactList">
+                <div class="multiContactActions" *ngIf="selectedCount > 0">
+                    <span class="multiContactActionsLabel">{{ selectedCount }} selected</span>
+                    <span class="multiContactActionsSpacer"></span>
+
+                    <button mat-mini-fab *ngIf="groups.length > 0"
+                        aria-label="Add selected contacts to a group"
+                        matTooltip="Add these contacts to a group"
+                        (click)="addSelectedToGroup()"
+                    >
+                        <mat-icon svgIcon="account-multiple-plus"></mat-icon>
+                    </button>
+
+                    <button mat-mini-fab
+                        aria-label="Delete selected contacts"
+                        matTooltip="Delete these contacts"
+                        (click)="deleteSelected()"
+                    >
+                        <mat-icon svgIcon="delete"></mat-icon>
+                    </button>
+                </div>
+
                 <mat-nav-list dense>
                     <app-contact-list #contactList
                         [contacts]="shownContacts"

--- a/src/app/contacts-app/contacts-app.component.scss
+++ b/src/app/contacts-app/contacts-app.component.scss
@@ -48,15 +48,25 @@ mat-list-item.contactListButton {
 
 .multiContactActions {
     display: flex;
-    flex-flow: column;
-    position: fixed;
-    bottom: 50px;
-    right: 50px;
-    z-index: 10;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 12px;
+    border-bottom: 1px solid #e0e0e0;
+    background: #fafafa;
 }
 
 .multiContactActions button {
-    margin-top: 10px;
+    flex: 0 0 auto;
+}
+
+.multiContactActionsLabel {
+    font-size: 14px;
+    font-weight: 500;
+    white-space: nowrap;
+}
+
+.multiContactActionsSpacer {
+    flex: 1 1 auto;
 }
 
 .contactListControls {

--- a/src/app/contacts-app/contacts-app.component.spec.ts
+++ b/src/app/contacts-app/contacts-app.component.spec.ts
@@ -1,0 +1,101 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { CommonModule } from '@angular/common';
+import { HttpClient } from '@angular/common/http';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatLegacyDialog as MatDialog } from '@angular/material/legacy-dialog';
+import { MatLegacySnackBar as MatSnackBar } from '@angular/material/legacy-snack-bar';
+import { ActivatedRoute, Router } from '@angular/router';
+import { BehaviorSubject, EMPTY, of, Subject } from 'rxjs';
+
+import { UsageReportsService } from '../common/usage-reports.service';
+import { MobileQueryService } from '../mobile-query.service';
+import { Contact } from './contact';
+import { ContactsAppComponent } from './contacts-app.component';
+import { ContactsService } from './contacts.service';
+
+describe('ContactsAppComponent', () => {
+    let fixture: ComponentFixture<ContactsAppComponent>;
+    let component: ContactsAppComponent;
+
+    const contactsServiceStub = {
+        activities: { observable: EMPTY },
+        contactCategories: new BehaviorSubject<string[]>([]),
+        contactsSubject: new BehaviorSubject<Contact[]>([]),
+        errorLog: EMPTY,
+        informationLog: EMPTY,
+        migratingContacts: 0,
+        showDragHelpers: false,
+    };
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            declarations: [ContactsAppComponent],
+            imports: [CommonModule],
+            providers: [
+                { provide: ContactsService, useValue: contactsServiceStub },
+                { provide: MatDialog, useValue: { open: () => ({ afterClosed: () => of(null) }) } },
+                { provide: HttpClient, useValue: { get: () => EMPTY } },
+                { provide: MobileQueryService, useValue: { changed: new Subject<boolean>(), matches: false } },
+                { provide: ActivatedRoute, useValue: { queryParams: of({}) } },
+                {
+                    provide: Router,
+                    useValue: {
+                        events: EMPTY,
+                        navigate: () => Promise.resolve(true),
+                        parseUrl: () => ({ root: { children: {} } }),
+                    }
+                },
+                { provide: MatSnackBar, useValue: { open: () => null } },
+                { provide: UsageReportsService, useValue: { report: () => null } },
+            ],
+            schemas: [NO_ERRORS_SCHEMA],
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(ContactsAppComponent);
+        component = fixture.componentInstance;
+    });
+
+    it('renders selected-contact actions in the contact list column', () => {
+        component.selectedCount = 2;
+        component.groups = [{ id: 'group-id', display_name: () => 'Team' } as Contact];
+
+        fixture.detectChanges();
+
+        const root = fixture.nativeElement as HTMLElement;
+        const actionBar = root.querySelector('.contactList > .multiContactActions');
+
+        expect(root.querySelector('#sideMenu .multiContactActions')).toBeNull();
+        expect(actionBar).not.toBeNull();
+        expect(actionBar.textContent).toContain('2 selected');
+        expect(actionBar.querySelectorAll('button').length).toBe(2);
+    });
+
+    it('hides selected-contact actions when no contacts are selected', () => {
+        component.selectedCount = 0;
+
+        fixture.detectChanges();
+
+        const root = fixture.nativeElement as HTMLElement;
+
+        expect(root.querySelector('.contactList > .multiContactActions')).toBeNull();
+    });
+});


### PR DESCRIPTION
Fixes #1405

## Summary

- move the selected-contact bulk actions out of the side menu and into the contact list column
- replace the fixed lower-right floating buttons with a compact inline action bar that does not cover contact rows
- keep the existing add-to-group and delete actions, now with explicit accessible labels
- cover the action bar placement with a focused component spec

## Validation

- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/contacts-app/contacts-app.component.spec.ts`
- `npx ng test --watch=false --browsers=FirefoxHeadless --include="src/app/contacts-app/**/*.spec.ts"`
- `npx tsc -p tsconfig.json --noEmit`
- `npx eslint src/app/contacts-app/contacts-app.component.ts src/app/contacts-app/contacts-app.component.html src/app/contacts-app/contacts-app.component.spec.ts`
- `npx ng test --watch=false --browsers=FirefoxHeadless`
- `npm run lint`
- `npm run policy`
- `node src/build/pre-build.js`
- `npx ng build --configuration production --base-href=/app/ runbox7`
- `node src/build/post-build.js`
- `git diff --check`
- `git diff --cached --check`

Notes: the full unit suite passed with `247 SUCCESS`, `2 skipped`. The full unit suite, lint, policy, and production build still print existing Angular/Karma/Sass/CommonJS/lint/historical commit-message warnings; all commands above exited successfully.

## AI Assistance Disclosure

This PR was prepared with assistance from OpenAI Codex.
