### PR TITLE
fix(compose): stabilize recipient autocomplete

### DIFF
--- a/src/app/compose/mailrecipientinput.component.spec.ts
+++ b/src/app/compose/mailrecipientinput.component.spec.ts
@@ -1,0 +1,67 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2020 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { fakeAsync, tick } from '@angular/core/testing';
+import { BehaviorSubject } from 'rxjs';
+
+import { MailRecipientInputComponent } from './mailrecipientinput.component';
+import { Recipient } from './recipient';
+import { RecipientsService } from './recipients.service';
+
+function recipient(name: string, email: string): Recipient {
+    return new Recipient([`"${name}" <${email}>`], `"${name}" <${email}>`);
+}
+
+describe('MailRecipientInputComponent', () => {
+    it('filters autocomplete options from the latest recipient list only', fakeAsync(() => {
+        const initialRecipients = [
+            recipient('Alex Example', 'alex@example.com'),
+            recipient('Bailey Example', 'bailey@example.com'),
+        ];
+        const currentRecipients = [
+            recipient('Alex Example', 'alex@example.com'),
+            recipient('Alex Home', 'alex.home@example.com'),
+            recipient('Alex Work', 'alex.work@example.com'),
+            recipient('Bailey Example', 'bailey@example.com'),
+        ];
+        const recipients = new BehaviorSubject<Recipient[]>(initialRecipients);
+        const recipientsService = { recipients } as unknown as RecipientsService;
+        const component = new MailRecipientInputComponent(
+            null,
+            recipientsService,
+        );
+        const matchingEmissions: string[][] = [];
+
+        component.filteredRecipients.subscribe(filtered => {
+            if (filtered.length > 0) {
+                matchingEmissions.push(filtered.map(match => match.name));
+            }
+        });
+
+        recipients.next(currentRecipients);
+        component.searchTextFormControl.setValue('alex');
+        tick(51);
+
+        expect(matchingEmissions).toEqual([[
+            '"Alex Example" <alex@example.com>',
+            '"Alex Home" <alex.home@example.com>',
+            '"Alex Work" <alex.work@example.com>',
+        ]]);
+    }));
+});

--- a/src/app/compose/mailrecipientinput.component.ts
+++ b/src/app/compose/mailrecipientinput.component.ts
@@ -19,12 +19,12 @@
 
 import { Component, Input, EventEmitter, Output, OnChanges, ViewChild, ElementRef, AfterViewInit } from '@angular/core';
 import { UntypedFormControl } from '@angular/forms';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, combineLatest } from 'rxjs';
 import { MatLegacyAutocomplete as MatAutocomplete } from '@angular/material/legacy-autocomplete';
 import { MatLegacyChipInputEvent as MatChipInputEvent } from '@angular/material/legacy-chips';
 import { MatLegacySnackBar as MatSnackBar } from '@angular/material/legacy-snack-bar';
 import { ENTER } from '@angular/cdk/keycodes';
-import { debounceTime } from 'rxjs/operators';
+import { debounceTime, startWith } from 'rxjs/operators';
 import { RecipientsService } from './recipients.service';
 import { Recipient } from './recipient';
 import { MailAddressInfo } from '../common/mailaddressinfo';
@@ -61,25 +61,25 @@ export class MailRecipientInputComponent implements OnChanges, AfterViewInit {
         private snackBar: MatSnackBar,
         recipientservice: RecipientsService
     ) {
-        recipientservice.recipients.subscribe((recipients) => {
-
-        // Listen to search text input and popup suggestions from recipient list
-        this.searchTextFormControl.valueChanges
-            .pipe(debounceTime(50))
-            .subscribe((searchtext: string | Recipient) => {
-                if (searchtext) {
-                    const lowercaseSearchText = searchtext.toString().toLowerCase();
-                    this.filteredRecipients.next(
-                        recipients.filter(recipient =>
-                            recipient.name.toLowerCase().indexOf(lowercaseSearchText) > -1
-                        )
-                    );
-                } else {
-                    this.filteredRecipients.next([]);
-                }
-            }
-            );
+        combineLatest([
+            recipientservice.recipients,
+            this.searchTextFormControl.valueChanges.pipe(debounceTime(50), startWith('')),
+        ]).subscribe(([recipients, searchtext]: [Recipient[], string | Recipient]) => {
+            this.filterRecipients(recipients, searchtext);
         });
+    }
+
+    private filterRecipients(recipients: Recipient[], searchtext: string | Recipient) {
+        if (searchtext) {
+            const lowercaseSearchText = searchtext.toString().toLowerCase();
+            this.filteredRecipients.next(
+                recipients.filter(recipient =>
+                    recipient.name.toLowerCase().indexOf(lowercaseSearchText) > -1
+                )
+            );
+        } else {
+            this.filteredRecipients.next([]);
+        }
     }
 
     ngOnChanges() {


### PR DESCRIPTION
Fixes #1436

## Summary

- Replaced the nested autocomplete `valueChanges` subscriptions with one combined stream of the latest recipient list and current search text.
- Kept filtering tied to the newest recipients emitted by contacts/search-index updates, so stale suggestion lists cannot replace the full matching list while typing.
- Added focused regression coverage for a contact-name search with multiple matching addresses after recipient-list updates.

## Testing

- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/compose/mailrecipientinput.component.spec.ts`
- `npx ng test --watch=false --browsers=FirefoxHeadless --include="src/app/compose/**/*.spec.ts"`
- `npx tsc -p tsconfig.json --noEmit`
- `npx eslint src/app/compose/mailrecipientinput.component.ts src/app/compose/mailrecipientinput.component.spec.ts`
- `git diff --check`
- `git diff --cached --check`
- `npx ng test --watch=false --browsers=FirefoxHeadless`
- `npm run lint`
- `npm run policy`
- `node src/build/pre-build.js`
- `npx ng build --configuration production --base-href=/app/ runbox7`
- `node src/build/post-build.js`

## AI Disclosure

I used AI assistance from ChatGPT/Codex to inspect the relevant source, make this change, and run validation. I reviewed the resulting diff and test output before submitting.
