### PR TITLE
fix(identities): skip validation for alias profiles

### DIFF
--- a/src/app/profiles/profile.service.spec.ts
+++ b/src/app/profiles/profile.service.spec.ts
@@ -19,7 +19,7 @@
 
 import { Identity, ProfileService } from './profile.service';
 import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed, waitForAsync } from '@angular/core/testing';
 import { of } from 'rxjs';
 
@@ -40,6 +40,9 @@ describe('Identity', () => {
 
 describe('ProfileService', () => {
     let service: ProfileService;
+    let createdProfile: Partial<Identity>;
+    let updatedProfile: Partial<Identity>;
+    let profileList;
 
     const DEFAULT_EMAIL = 'a2@example.com';
     const PROFILES =        [{
@@ -134,9 +137,18 @@ describe('ProfileService', () => {
         'id': 16450
     }];
 
-    const ALLOWED_DOMAINS = ['runbox.com', 'example.com'];
+    const ALIASES = [
+        { id: 1, localpart: 'aliasmatch', domain: 'example.com', forward_to: DEFAULT_EMAIL },
+        { id: 2, localpart: 'casealias', domain: 'runbox.com', email: 'CaseAlias@Runbox.com' },
+    ];
 
     beforeEach(waitForAsync(() => {
+        createdProfile = null;
+        updatedProfile = null;
+        profileList = PROFILES.map(profile => ({
+            ...profile,
+            reference: { ...profile.reference },
+        }));
         TestBed.configureTestingModule({
             imports: [
                 HttpClientTestingModule,
@@ -144,12 +156,18 @@ describe('ProfileService', () => {
             providers: [
                 { provide: RunboxWebmailAPI, useValue: {
                     me: of({first_name: 'Test', last_name: 'User'}),
-                    getProfiles: () => of(PROFILES),
+                    getProfiles: () => of(profileList),
                     createProfile: (newprofile) => {
+                        createdProfile = newprofile;
                         newprofile['reference_type'] = 'aliases';
-                        PROFILES.unshift(newprofile);
-                        return of(PROFILES.length);
+                        profileList.unshift(newprofile);
+                        return of(profileList.length);
                     },
+                    updateProfile: (_id, profile) => {
+                        updatedProfile = profile;
+                        return of(true);
+                    },
+                    getAliases: () => of(ALIASES),
                     getRunboxDomains: () => of([{ 'id': 1, name: 'runbox.com'}]),
                 } },
                 ProfileService
@@ -199,5 +217,35 @@ describe('ProfileService', () => {
                 done();
             });
                              
+    });
+
+    it('creates alias identities without email validation when the address matches an existing alias', (done) => {
+        service.create({
+            name: 'Alias Identity',
+            email: 'aliasmatch@example.com',
+            from_name: 'Alias User',
+            signature: 'Alias sig'
+        })
+            .subscribe((res) => {
+                expect(res).toBeTruthy();
+                expect(createdProfile.type).toBe('aliases');
+                done();
+            });
+
+    });
+
+    it('updates identities without email validation when the address matches an existing alias', (done) => {
+        service.update(123, {
+            name: 'Alias Identity',
+            email: 'casealias@runbox.com',
+            from_name: 'Alias User',
+            signature: 'Alias sig'
+        })
+            .subscribe((res) => {
+                expect(res).toBeTruthy();
+                expect(updatedProfile.type).toBe('aliases');
+                done();
+            });
+
     });
 });

--- a/src/app/profiles/profile.service.ts
+++ b/src/app/profiles/profile.service.ts
@@ -17,13 +17,19 @@
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
 import { Injectable } from '@angular/core';
-import { map } from 'rxjs/operators';
-import { BehaviorSubject, Observable } from 'rxjs';
-import { RunboxMe, RunboxWebmailAPI } from '../rmmapi/rbwebmail';
+import { catchError, map, switchMap, take } from 'rxjs/operators';
+import { BehaviorSubject, Observable, of } from 'rxjs';
+import { Alias, RunboxMe, RunboxWebmailAPI } from '../rmmapi/rbwebmail';
 
 export interface FromPriority {
     from_priority: number;
     id: number;
+}
+
+export interface ProfileValues {
+    email?: string;
+    type?: string;
+    [key: string]: unknown;
 }
 
 export class Identity {
@@ -99,13 +105,49 @@ export class ProfileService {
         );
     }  
     
-    create(values): Observable<boolean> {
-      return this.rmmapi.createProfile(values).pipe(
-          map((res: boolean) => {
-              this.refresh();
-              return res;
-          })
-      );
+    private normalizeEmail(email: string): string {
+        return (email || '').trim().toLowerCase();
+    }
+
+    private aliasEmail(alias: Alias): string {
+        if (alias.email) {
+            return this.normalizeEmail(alias.email);
+        }
+        if (alias.localpart && alias.domain) {
+            return this.normalizeEmail(`${alias.localpart}@${alias.domain}`);
+        }
+        return '';
+    }
+
+    private getAliasEmails(): Observable<Set<string>> {
+        return this.rmmapi.getAliases().pipe(
+            map((aliases: Alias[]) => new Set(
+                aliases.map(alias => this.aliasEmail(alias)).filter(email => email)
+            )),
+            catchError(() => of(new Set<string>()))
+        );
+    }
+
+    private withAliasProfileType(values: ProfileValues): Observable<ProfileValues> {
+        return this.getAliasEmails().pipe(
+            take(1),
+            map((aliasEmails: Set<string>) => {
+                if (aliasEmails.has(this.normalizeEmail(values.email))) {
+                    return { ...values, type: 'aliases' };
+                }
+                return values;
+            })
+        );
+    }
+
+    create(values: ProfileValues): Observable<boolean> {
+        return this.withAliasProfileType(values).pipe(
+            switchMap(profileValues => this.rmmapi.createProfile(profileValues)),
+            map((res: boolean) => {
+                this.refresh();
+                return res;
+            })
+        );
     }
     delete(id): Observable<boolean> {
         return this.rmmapi.deleteProfile(id).pipe(
@@ -116,12 +158,13 @@ export class ProfileService {
         );
     }
 
-    update(id, values): Observable<boolean> {
-        return this.rmmapi.updateProfile(id, values).pipe(
-          map((res: boolean) => {
-              this.refresh();
-              return res;
-          })
+    update(id, values: ProfileValues): Observable<boolean> {
+        return this.withAliasProfileType(values).pipe(
+            switchMap(profileValues => this.rmmapi.updateProfile(id, profileValues)),
+            map((res: boolean) => {
+                this.refresh();
+                return res;
+            })
         );
     }
     reValidate(id) {

--- a/src/app/rmmapi/rbwebmail.spec.ts
+++ b/src/app/rmmapi/rbwebmail.spec.ts
@@ -118,6 +118,25 @@ describe('RBWebMail', () => {
         expect(messageContents.subject).toBe('test3');
     });
 
+    it('should load aliases from the alias list endpoint', async () => {
+        const rmmapi = TestBed.inject(RunboxWebmailAPI);
+        const aliasesPromise = firstValueFrom(rmmapi.getAliases());
+        const httpTestingController = TestBed.inject(HttpTestingController);
+        const req = httpTestingController.expectOne('/rest/v1/aliases');
+        req.flush({
+            status: 'success',
+            result: {
+                aliases: [
+                    { id: 1, localpart: 'aliasmatch', domain: 'example.com', forward_to: 'a2@example.com' }
+                ]
+            }
+        });
+
+        const aliases = await aliasesPromise;
+        expect(aliases.length).toBe(1);
+        expect(aliases[0].email).toBe('aliasmatch@example.com');
+    });
+
     it('should flatten folder tree structure', async () => {
         const listEmailFoldersResponse = {
             'status': 'success',

--- a/src/app/rmmapi/rbwebmail.ts
+++ b/src/app/rmmapi/rbwebmail.ts
@@ -53,13 +53,35 @@ export class MessageFields {
     to: string;
 }
 
+export interface AliasData {
+    id: number;
+    localpart: string;
+    name?: string;
+    email?: string;
+    domain?: string;
+    forward_to?: string;
+}
+
+interface AliasListResponse {
+    result?: {
+        aliases?: AliasData[];
+    };
+}
+
 export class Alias {
     constructor(
         public id: number,
         public localpart: string,
         public name: string,
-        public email: string
+        public email: string,
+        public domain?: string,
+        public forward_to?: string
     ) { }
+
+    public static fromObject(obj: AliasData): Alias {
+        const email = obj.email || (obj.localpart && obj.domain ? `${obj.localpart}@${obj.domain}` : '');
+        return new Alias(obj.id, obj.localpart, obj.name || '', email, obj.domain, obj.forward_to);
+    }
 }
 
 export class ContactSyncResult {
@@ -622,6 +644,15 @@ export class RunboxWebmailAPI {
 
     public getAliasLimits(): Observable<any> {
         return this.http.get('/rest/v1/aliases/limits');
+    }
+
+    public getAliases(): Observable<Alias[]> {
+        return this.http.get('/rest/v1/aliases').pipe(
+            map((res: AliasListResponse) => {
+                const aliases = res.result && res.result.aliases ? res.result.aliases : [];
+                return aliases.map(alias => Alias.fromObject(alias));
+            })
+        );
     }
 
     public getRunboxDomains(): Observable<string[]> {


### PR DESCRIPTION
Fixes #1586.

## Summary
- add a typed `/rest/v1/aliases` wrapper so identity saves can compare the submitted address with existing aliases
- send `type: 'aliases'` on profile create/update when the saved email matches an alias address, avoiding the external-email validation path
- cover alias-backed create/update payloads plus alias-list mapping in unit tests

## Tests
- `npx tsc -p tsconfig.json --noEmit`
- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/profiles/profile.service.spec.ts --include=src/app/rmmapi/rbwebmail.spec.ts`
- `npx eslint src/app/profiles/profile.service.ts src/app/profiles/profile.service.spec.ts src/app/rmmapi/rbwebmail.ts src/app/rmmapi/rbwebmail.spec.ts`
- `git diff --check`
- `git diff --cached --check`
- `npx ng test --watch=false --browsers=FirefoxHeadless`
- `npm run lint`
- `node src/build/pre-build.js; npx ng build --configuration production --base-href=/app/ runbox7; node src/build/post-build.js`
- `npm run policy`

AI disclosure: I used OpenAI Codex to inspect the codebase, implement this patch, and run the validation commands above.
