### PR TITLE
fix(aliases): remove identities after alias deletion

### DIFF
--- a/src/app/aliases/aliases.lister.spec.ts
+++ b/src/app/aliases/aliases.lister.spec.ts
@@ -17,9 +17,9 @@
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
 
-import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, flush, tick } from '@angular/core/testing';
 import { AliasesListerComponent } from './aliases.lister';
-import { MatLegacyDialogModule } from '@angular/material/legacy-dialog';
+import { MatLegacyDialog as MatDialog, MatLegacyDialogModule } from '@angular/material/legacy-dialog';
 import { MatLegacySnackBarModule } from '@angular/material/legacy-snack-bar';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
@@ -30,10 +30,12 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { AliasesEditorModalComponent } from './aliases.editor.modal';
 import { MatLegacyCommonModule, MatLegacyOptionModule } from '@angular/material/legacy-core';
 import { HttpClient } from '@angular/common/http';
+import { ProfileService } from '../profiles/profile.service';
 
 describe('AliasesListerComponent', () => {
     let component: AliasesListerComponent;
     let fixture: ComponentFixture<AliasesListerComponent>;
+    let profileService: jasmine.SpyObj<ProfileService>;
 
     const DEFAULT_EMAIL = 'a.kalou@shadowcat.co.uk';
     const ALLOWED_DOMAINS = ['runbox.com', 'shadowcat.co.uk'];
@@ -44,6 +46,8 @@ describe('AliasesListerComponent', () => {
     ];
 
     beforeEach(() => {
+        profileService = jasmine.createSpyObj<ProfileService>('ProfileService', ['deleteAssociatedAliasIdentities']);
+        profileService.deleteAssociatedAliasIdentities.and.returnValue(of([]));
         TestBed.configureTestingModule({
             imports: [
                 CommonModule,
@@ -84,8 +88,12 @@ describe('AliasesListerComponent', () => {
                             status: 'success',
                             result: {alias: alias}
                         }),
+                        delete: () => of({
+                            status: 'success',
+                        }),
                     }
                 } },
+                { provide: ProfileService, useValue: profileService },
             ],
             declarations: [
                 AliasesListerComponent,
@@ -161,4 +169,26 @@ describe('AliasesListerComponent', () => {
             expect(domain.textContent).toContain(allowed_domain);
         });
     });
+
+    it('cleans up the associated identity after deleting an alias', fakeAsync(() => {
+        const alias = {
+            id: 123,
+            localpart: 'testface',
+            domain: 'runbox.com',
+            forward_to: 'mctestface@runbox.com',
+        };
+        component.aliases = [alias];
+
+        component.delete(alias);
+        fixture.detectChanges();
+
+        const dialog = TestBed.inject(MatDialog);
+        dialog.openDialogs[dialog.openDialogs.length - 1].componentInstance.delete();
+        tick();
+
+        expect(component.aliases).toEqual([]);
+        expect(profileService.deleteAssociatedAliasIdentities).toHaveBeenCalledTimes(1);
+        expect(profileService.deleteAssociatedAliasIdentities).toHaveBeenCalledWith(alias);
+        flush();
+    }));
 });

--- a/src/app/aliases/aliases.lister.ts
+++ b/src/app/aliases/aliases.lister.ts
@@ -21,6 +21,7 @@ import { MatLegacyDialog as MatDialog } from '@angular/material/legacy-dialog';
 import { AliasesEditorModalComponent } from './aliases.editor.modal';
 import { RMM } from '../rmm';
 import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
+import { ProfileService } from '../profiles/profile.service';
 
 @Component({
   selector: 'app-aliases-lister',
@@ -36,6 +37,7 @@ export class AliasesListerComponent {
     private dialog: MatDialog,
     rmmapi: RunboxWebmailAPI,
     rmm: RMM,
+    private profileService: ProfileService,
   ) {
     rmm.alias.load().subscribe(reply => { 
         if (reply['status'] === 'success') { 
@@ -86,6 +88,7 @@ export class AliasesListerComponent {
         if (result !== undefined) {
             const itemIndex = this.aliases.findIndex(v => v.id === result.id);
             this.aliases.splice(itemIndex, 1);
+            this.profileService.deleteAssociatedAliasIdentities(result).subscribe();
         }
     });
   }

--- a/src/app/profiles/profile.service.spec.ts
+++ b/src/app/profiles/profile.service.spec.ts
@@ -40,6 +40,8 @@ describe('Identity', () => {
 
 describe('ProfileService', () => {
     let service: ProfileService;
+    let deletedProfileIds: number[];
+    let profileList: Array<Partial<Identity>>;
 
     const DEFAULT_EMAIL = 'a2@example.com';
     const PROFILES =        [{
@@ -137,6 +139,8 @@ describe('ProfileService', () => {
     const ALLOWED_DOMAINS = ['runbox.com', 'example.com'];
 
     beforeEach(waitForAsync(() => {
+        deletedProfileIds = [];
+        profileList = JSON.parse(JSON.stringify(PROFILES)) as Array<Partial<Identity>>;
         TestBed.configureTestingModule({
             imports: [
                 HttpClientTestingModule,
@@ -144,11 +148,16 @@ describe('ProfileService', () => {
             providers: [
                 { provide: RunboxWebmailAPI, useValue: {
                     me: of({first_name: 'Test', last_name: 'User'}),
-                    getProfiles: () => of(PROFILES),
-                    createProfile: (newprofile) => {
+                    getProfiles: () => of(profileList.map(p => Identity.fromObject(p))),
+                    createProfile: (newprofile: Partial<Identity>) => {
                         newprofile['reference_type'] = 'aliases';
-                        PROFILES.unshift(newprofile);
-                        return of(PROFILES.length);
+                        profileList.unshift(newprofile);
+                        return of(profileList.length);
+                    },
+                    deleteProfile: (id: number) => {
+                        deletedProfileIds.push(id);
+                        profileList = profileList.filter(profile => profile.id !== id);
+                        return of(true);
                     },
                     getRunboxDomains: () => of([{ 'id': 1, name: 'runbox.com'}]),
                 } },
@@ -167,13 +176,13 @@ describe('ProfileService', () => {
     });
     it('loads all profiles', (done) => {
         service.profiles.subscribe(profiles => {
-            expect(profiles.length).toBe(PROFILES.length);
+            expect(profiles.length).toBe(profileList.length);
             done();
         });
     });
     it('loads alias profile subsets', (done) => {
         service.aliases.subscribe(profiles => {
-            expect(profiles.length).toBe(PROFILES.filter(p => p.reference_type === 'aliases').length);
+            expect(profiles.length).toBe(profileList.filter(p => p.reference_type === 'aliases').length);
             done();
         });
     });
@@ -199,5 +208,41 @@ describe('ProfileService', () => {
                 done();
             });
                              
+    });
+
+    it('deletes alias identities associated with a deleted alias', (done) => {
+        service.deleteAssociatedAliasIdentities({
+            id: 278,
+            localpart: 'aa1',
+            domain: 'example.com',
+        }).subscribe((res) => {
+            expect(res.length).toBe(1);
+            expect(deletedProfileIds).toEqual([16456]);
+            done();
+        });
+    });
+
+    it('falls back to alias email when matching associated identities', (done) => {
+        service.deleteAssociatedAliasIdentities({
+            id: 999,
+            localpart: 'testmail',
+            domain: 'testmail.com',
+        }).subscribe((res) => {
+            expect(res.length).toBe(1);
+            expect(deletedProfileIds).toEqual([16457]);
+            done();
+        });
+    });
+
+    it('does not delete the main identity when alias email matches it', (done) => {
+        service.deleteAssociatedAliasIdentities({
+            id: 999,
+            localpart: 'a2',
+            domain: 'example.com',
+        }).subscribe((res) => {
+            expect(res).toEqual([]);
+            expect(deletedProfileIds).toEqual([]);
+            done();
+        });
     });
 });

--- a/src/app/profiles/profile.service.ts
+++ b/src/app/profiles/profile.service.ts
@@ -17,13 +17,20 @@
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
 import { Injectable } from '@angular/core';
-import { map } from 'rxjs/operators';
-import { BehaviorSubject, Observable } from 'rxjs';
+import { catchError, map, switchMap } from 'rxjs/operators';
+import { BehaviorSubject, forkJoin, Observable, of } from 'rxjs';
 import { RunboxMe, RunboxWebmailAPI } from '../rmmapi/rbwebmail';
 
 export interface FromPriority {
     from_priority: number;
     id: number;
+}
+
+export interface AliasProfileReference {
+    id?: number | string;
+    localpart?: string;
+    domain?: string;
+    email?: string;
 }
 
 export class Identity {
@@ -43,7 +50,7 @@ export class Identity {
     smtp_port: string;
     smtp_username: string;
     is_verified: boolean;
-    reference: { status: number };
+    reference: { status?: number; id?: number | string; [key: string]: unknown };
     preferred_runbox_domain: string;
     // FIXME: Legacy rubbish for send-folder-options
     folder: string;
@@ -116,6 +123,25 @@ export class ProfileService {
         );
     }
 
+    deleteAssociatedAliasIdentities(alias: AliasProfileReference): Observable<boolean[]> {
+        return this.rmmapi.getProfiles().pipe(
+          map(profiles => profiles.filter(profile => this.isProfileForAlias(profile, alias))),
+          switchMap(profiles => {
+              if (!profiles.length) {
+                  return of([]);
+              }
+              return forkJoin(profiles.map(profile => this.rmmapi.deleteProfile(profile.id)));
+          }),
+          map(results => {
+              if (results.length) {
+                  this.refresh();
+              }
+              return results;
+          }),
+          catchError(() => of([]))
+        );
+    }
+
     update(id, values): Observable<boolean> {
         return this.rmmapi.updateProfile(id, values).pipe(
           map((res: boolean) => {
@@ -137,6 +163,39 @@ export class ProfileService {
                 this.refresh();
             }
         );
+    }
+
+    private isProfileForAlias(profile: Identity, alias: AliasProfileReference): boolean {
+        if (profile.type !== 'aliases' || profile.reference_type !== 'aliases') {
+            return false;
+        }
+
+        const aliasId = this.normalizedId(alias.id);
+        const profileReferenceId = this.normalizedId(profile.reference && profile.reference.id);
+        if (aliasId !== undefined && aliasId === profileReferenceId) {
+            return true;
+        }
+
+        const aliasEmail = this.aliasEmail(alias);
+        return !!aliasEmail && profile.email && profile.email.toLowerCase() === aliasEmail;
+    }
+
+    private normalizedId(id: number | string | undefined): number | string | undefined {
+        if (id === undefined || id === null) {
+            return undefined;
+        }
+        const numberId = Number(id);
+        return Number.isNaN(numberId) ? id : numberId;
+    }
+
+    private aliasEmail(alias: AliasProfileReference): string {
+        if (alias.email) {
+            return alias.email.toLowerCase();
+        }
+        if (alias.localpart && alias.domain) {
+            return `${alias.localpart}@${alias.domain}`.toLowerCase();
+        }
+        return '';
     }
 
 }


### PR DESCRIPTION
## Summary

- clean up alias-backed identities after a successful alias deletion
- match the associated identity by alias reference id first, then by alias email as a fallback
- keep main/non-alias identities protected from the cleanup path

Closes #1387.

## Validation

- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/aliases/aliases.lister.spec.ts --include=src/app/profiles/profile.service.spec.ts --progress=false`
- `npx tsc -p tsconfig.json --noEmit`
- `npx eslint src/app/aliases/aliases.lister.ts src/app/aliases/aliases.lister.spec.ts src/app/profiles/profile.service.ts src/app/profiles/profile.service.spec.ts`
- `git diff --check`
- `git diff --cached --check`
- `npx ng test --watch=false --browsers=FirefoxHeadless --progress=false`
- `npm run lint`
- `npm run policy`
- `node src/build/pre-build.js; npx ng build --configuration production --base-href=/app/ runbox7; node src/build/post-build.js`
- `npm run policy`

## AI Disclosure

I used OpenAI Codex to inspect the relevant alias/profile code paths, implement the patch, and run the validation commands above. I reviewed the changes before submitting.
