### PR TITLE
fix(mail): show sender email in new message notification

### DIFF
--- a/src/app/xapian/searchservice.spec.ts
+++ b/src/app/xapian/searchservice.spec.ts
@@ -17,7 +17,7 @@
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
 
-import { SearchService, XAPIAN_GLASS_WR } from './searchservice';
+import { getNewMessageNotificationBody, SearchService, XAPIAN_GLASS_WR } from './searchservice';
 import { Type } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { RunboxWebmailAPI, RunboxMe } from '../rmmapi/rbwebmail';
@@ -326,5 +326,23 @@ describe('SearchService', () => {
 
         FS.chdir('/');
         FS.unmount('/' + localdir);
+    });
+});
+
+describe('getNewMessageNotificationBody', () => {
+    it('uses the sender name when present', () => {
+        expect(getNewMessageNotificationBody({
+            from: [{ name: 'Sender Name', address: 'sender@example.com' }]
+        })).toBe('Sender Name');
+    });
+
+    it('falls back to the sender email address when the name is missing', () => {
+        expect(getNewMessageNotificationBody({
+            from: [{ name: null, address: 'sender@example.com' }]
+        })).toBe('sender@example.com');
+    });
+
+    it('falls back to an unknown sender label without sender details', () => {
+        expect(getNewMessageNotificationBody({ from: [] })).toBe('Unknown sender');
     });
 });

--- a/src/app/xapian/searchservice.ts
+++ b/src/app/xapian/searchservice.ts
@@ -65,6 +65,21 @@ export class SearchIndexDocumentData {
   attachment?: boolean;
 }
 
+export function getNewMessageNotificationBody(message: { from?: { name?: string | null; address?: string | null }[] }): string {
+  const sender = message && message.from && message.from[0];
+  if (!sender) {
+    return 'Unknown sender';
+  }
+
+  const name = typeof sender.name === 'string' ? sender.name.trim() : '';
+  if (name) {
+    return name;
+  }
+
+  const address = typeof sender.address === 'string' ? sender.address.trim() : '';
+  return address || 'Unknown sender';
+}
+
 @Injectable({
     providedIn: 'root'
 })
@@ -158,14 +173,17 @@ export class SearchService {
         } else if (data['action'] === PostMessageAction.newMessagesNotification) {
           if (this.notifyOnNewMessages && 'Notification' in window &&
             window['Notification']['permission'] === 'granted') {
-            const newMessagesTitle = data.prototype.hasOwnProperty('newMessages')
-              && data['newMessages'].length > 1 ?
-              `${data['newMessages'].length} new email messages` :
+            const newMessages = Array.isArray(data['newMessages']) ? data['newMessages'] : [];
+            if (newMessages.length === 0) {
+              return;
+            }
+            const newMessagesTitle = newMessages.length > 1 ?
+              `${newMessages.length} new email messages` :
               'New email message';
             try {
               // eslint-disable-next-line @typescript-eslint/no-unused-expressions
               new Notification(newMessagesTitle, {
-                body: data['newMessages'][0].from[0].name,
+                body: getNewMessageNotificationBody(newMessages[0]),
                 icon: 'assets/icons/icon-192x192.png',
                 tag: 'newmessages'
               });


### PR DESCRIPTION
Fixes #581.

## Summary

- use the sender display name when available in new-message desktop notifications
- fall back to the sender email address when the display name is empty or null
- guard the notification path against missing/empty `newMessages` payloads before creating a browser notification
- add focused helper coverage for name, email fallback, and missing sender details

## Testing

- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/xapian/searchservice.spec.ts --progress=false` (3 success, 2 skipped)
- `npx tsc -p tsconfig.json --noEmit`
- `npx eslint src/app/xapian/searchservice.ts src/app/xapian/searchservice.spec.ts` (0 errors, existing warnings only)
- `git diff --check`
- `npx ng test --watch=false --browsers=FirefoxHeadless --progress=false` (248 success, 2 skipped; existing console/template warnings)
- `npm run lint` (0 errors, 770 warnings)
- `npm run policy` (exited 0; existing historical commit-message warnings printed)
- production build using the PowerShell-equivalent steps from `npm run build` because the package script uses POSIX shell control flow; build succeeded with existing build warnings
- `git diff --cached --check`

AI assistance disclosure: I used AI assistance to inspect the issue path, implement this small fix, and run the validation commands.
