### PR TITLE
fix(mail): parse comma in sender display name

### DIFF
--- a/src/app/common/mailaddressinfo.spec.ts
+++ b/src/app/common/mailaddressinfo.spec.ts
@@ -46,6 +46,13 @@ describe('MailAddressInfo', () => {
         expect(ma[0].address).toBe('test1@runbox.com');
         expect(ma[0].nameAndAddress).toBe('"Test" <test1@runbox.com>');
     });
+    it('Parse full single address with unquoted comma in name', () => {
+        const ma = MailAddressInfo.parse('Surname, Firstname <test1@runbox.com>');
+        expect(ma.length).toBe(1);
+        expect(ma[0].name).toBe('Surname, Firstname');
+        expect(ma[0].address).toBe('test1@runbox.com');
+        expect(ma[0].nameAndAddress).toBe('"Surname, Firstname" <test1@runbox.com>');
+    });
     it('Parse address list', () => {
         const ma_list = MailAddressInfo.parse('test1@runbox.com,test2@runbox.com');
         expect(ma_list[0].name).toBe(null);
@@ -69,6 +76,14 @@ describe('MailAddressInfo', () => {
         expect(ma_list[1].name).toBe('Test2');
         expect(ma_list[1].address).toBe('test2@runbox.com');
         expect(ma_list[1].nameAndAddress).toBe('"Test2" <test2@runbox.com>');
+    });
+    it('Parse address list with unquoted comma in name', () => {
+        const ma_list = MailAddressInfo.parse('Surname, Firstname <test1@runbox.com>, Test2 <test2@runbox.com>');
+        expect(ma_list.length).toBe(2);
+        expect(ma_list[0].name).toBe('Surname, Firstname');
+        expect(ma_list[0].address).toBe('test1@runbox.com');
+        expect(ma_list[1].name).toBe('Test2');
+        expect(ma_list[1].address).toBe('test2@runbox.com');
     });
     it('Parse multi-level domain', () => {
         const ma_list = MailAddressInfo.parse('"Fred B" <fred@foo.bar.baz.tld>');

--- a/src/app/common/mailaddressinfo.ts
+++ b/src/app/common/mailaddressinfo.ts
@@ -26,6 +26,24 @@ export class MailAddressInfo {
         this.domain = address.split('@')[1];
     }
 
+    private static commaSeparatesAddress(mailaddr: string, lastStart: number, commaIndex: number): boolean {
+        const currentAddressPart = mailaddr.substring(lastStart, commaIndex);
+        if (
+            currentAddressPart.indexOf('@') >= 0 ||
+            currentAddressPart.indexOf('<') >= 0 ||
+            currentAddressPart.indexOf('>') >= 0
+        ) {
+            return true;
+        }
+
+        const nextCommaIndex = mailaddr.indexOf(',', commaIndex + 1);
+        const nextAddressPart = mailaddr.substring(
+            commaIndex + 1,
+            nextCommaIndex === -1 ? mailaddr.length : nextCommaIndex
+        );
+        return nextAddressPart.indexOf('<') === -1;
+    }
+
     public static parse(mailaddr: string): MailAddressInfo[] {
         const ret: MailAddressInfo[] = [];
         let namePart = false;
@@ -46,7 +64,7 @@ export class MailAddressInfo {
                     }
                     break;
                 case ',':
-                    if (!namePart) {
+                    if (!namePart && MailAddressInfo.commaSeparatesAddress(mailaddr, lastStart, n)) {
                         if (!addr) {
                             addr = mailaddr.substring(lastStart, n).trim();
                         }


### PR DESCRIPTION
Fixes #524.
Fixes #236.

## Summary

- keep an unquoted comma as part of the display name when it appears before the `<address>` part
- preserve comma splitting for ordinary address lists such as `one@example.com,two@example.com`
- add parser coverage for a single `Surname, Firstname <address>` value and for that value inside an address list

## Testing

- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/common/mailaddressinfo.spec.ts --progress=false` (10 success)
- `npx tsc -p tsconfig.json --noEmit`
- `npx eslint src/app/common/mailaddressinfo.ts src/app/common/mailaddressinfo.spec.ts`
- `git diff --check`
- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/common/mailaddressinfo.spec.ts --include=src/app/compose/draftdesk.service.spec.ts --progress=false` (32 success)
- `npx ng test --watch=false --browsers=FirefoxHeadless --progress=false` (247 success, 2 skipped; existing console/template warnings)
- `npm run lint` (0 errors, 770 warnings)
- production build using the PowerShell-equivalent steps from `npm run build` because the package script uses POSIX shell control flow; build succeeded with existing build warnings
- `npm run policy` (exited 0; existing historical commit-message warnings printed)
- `git diff --cached --check`

AI assistance disclosure: I used AI assistance to inspect the issue history, implement this parser fix, and run the validation commands.
