### PR TITLE
fix(mail): use result folder in message URL

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,0 +1,75 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { AppComponent } from './app.component';
+
+describe('AppComponent URL fragments', () => {
+  function createComponent(rowFolder = 'Archive') {
+    const component = Object.create(AppComponent.prototype) as AppComponent;
+    const router = {
+      url: '/',
+      navigate: jasmine.createSpy('navigate')
+    };
+    const rows = {
+      hasChanges: true,
+      rowSelected: jasmine.createSpy('rowSelected'),
+      anySelected: jasmine.createSpy('anySelected').and.returnValue(false),
+      getRowMessageId: jasmine.createSpy('getRowMessageId').and.returnValue(42),
+      getRowFolder: jasmine.createSpy('getRowFolder').and.returnValue(rowFolder)
+    };
+
+    Reflect.set(component, 'router', router);
+    component.selectedFolder = 'Inbox';
+    component.fragment = 'Inbox';
+    component.viewmode = 'messages';
+    component.messageSubjectDragTipShown = true;
+    component.mobileQuery = { matches: false } as AppComponent['mobileQuery'];
+    component.messagelistservice = {
+      templateFolderName: 'Templates'
+    } as AppComponent['messagelistservice'];
+    component.canvastable = {
+      rows,
+      hasChanges: false
+    } as unknown as AppComponent['canvastable'];
+    component.singlemailviewer = {
+      messageId: null
+    } as AppComponent['singlemailviewer'];
+
+    return { component, router, rows };
+  }
+
+  it('uses the row folder when a search result updates the URL fragment', () => {
+    const { component, router } = createComponent('Archive');
+
+    component.rowSelected(0, 1, false);
+
+    expect(router.navigate).toHaveBeenCalledOnceWith(['/'], { fragment: 'Archive:42' });
+    expect(component.fragment).toBe('Archive:42');
+    expect(component.singlemailviewer.messageId).toBe(42);
+  });
+
+  it('falls back to the selected folder for rows without folder metadata', () => {
+    const { component, router } = createComponent(null);
+
+    component.rowSelected(0, 1, false);
+
+    expect(router.navigate).toHaveBeenCalledOnceWith(['/'], { fragment: 'Inbox:42' });
+    expect(component.fragment).toBe('Inbox:42');
+  });
+});

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -944,8 +944,10 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     this.showSelectOperations = this.canvastable.rows.anySelected();
 
     if (this.canvastable.rows.hasChanges) {
-      this.updateUrlFragment(this.canvastable.rows.getRowMessageId(rowIndex));
-      this.singlemailviewer.messageId = this.canvastable.rows.getRowMessageId(rowIndex);
+      const messageId = this.canvastable.rows.getRowMessageId(rowIndex);
+      const fragmentFolder = this.canvastable.rows.getRowFolder(rowIndex) || this.selectedFolder;
+      this.updateUrlFragment(messageId, fragmentFolder);
+      this.singlemailviewer.messageId = messageId;
 
       if (!this.mobileQuery.matches && !this.messageSubjectDragTipShown) {
         this.snackBar.open('Tip: Drag subject to a folder to move message(s)' , 'Got it');
@@ -1422,12 +1424,12 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     ).subscribe();
   }
 
-  private updateUrlFragment(messageId?: number): void {
+  private updateUrlFragment(messageId?: number, folder = this.selectedFolder): void {
     if (this.router.url.match('^/[^#]')) {
       // we're not actually on mailviewer, so don't try to be smart
       return;
     }
-    let fragment = this.selectedFolder;
+    let fragment = folder;
     if (fragment && messageId) { //  || this.singlemailviewer?.messageId) {
       //      fragment += `:${this.singlemailviewer.messageId}`;
       fragment += `:${messageId}`;

--- a/src/app/common/messagedisplay.ts
+++ b/src/app/common/messagedisplay.ts
@@ -166,6 +166,7 @@ export abstract class MessageDisplay {
   abstract getRowSeen(index: number): boolean;
   abstract getRowId(index: number): number;
   abstract getRowMessageId(index: number): number;
+  abstract getRowFolder(index: number): string;
 
   public getRow(index: number): any {
     return this.rows[index];

--- a/src/app/common/messagelist.ts
+++ b/src/app/common/messagelist.ts
@@ -44,6 +44,9 @@ export class MessageList extends MessageDisplay {
     return msg.id;
   }
 
+  getRowFolder(index: number): string {
+    return this.getRow(index).folder;
+  }
 
   // columns
   getFromColumnValueForRow(rowIndex: number): string {

--- a/src/app/websocketsearch/websocketsearchmaillist.ts
+++ b/src/app/websocketsearch/websocketsearchmaillist.ts
@@ -44,6 +44,10 @@ export class WebSocketSearchMailList extends MessageDisplay {
     return msg.id;
   }
 
+  getRowFolder(_index: number): string {
+    return null;
+  }
+
   filterBy(options: Map<string, any>) {
     this.rows = this._rows;
     if (options.has('unreadOnly') && options.get('unreadOnly')) {

--- a/src/app/xapian/searchmessagedisplay.ts
+++ b/src/app/xapian/searchmessagedisplay.ts
@@ -51,6 +51,10 @@ export class SearchMessageDisplay extends MessageDisplay {
     return msgId;
   }
 
+  getRowFolder(index: number): string {
+    return this.searchService.getDocData(this.getRowId(index)).folder;
+  }
+
   filterBy(options: Map<string, any>) {
   }
 


### PR DESCRIPTION
## Summary

- add a row-level folder accessor for message displays so URL fragments can use the actual clicked row folder
- update opened-message fragment generation to use a search result's folder instead of always using the currently selected folder
- cover search-result folder fragments and fallback rows without folder metadata

## Testing

- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/app.component.spec.ts --progress=false`
- `npx tsc -p tsconfig.json --noEmit`
- `npx eslint src/app/app.component.ts src/app/app.component.spec.ts src/app/common/messagedisplay.ts src/app/common/messagelist.ts src/app/xapian/searchmessagedisplay.ts src/app/websocketsearch/websocketsearchmaillist.ts`
- `git diff --check`
- `npx ng test --watch=false --browsers=FirefoxHeadless --progress=false`
- `npm run lint`
- `node src/build/pre-build.js; npx ng build --configuration production --base-href=/app/ runbox7; node src/build/post-build.js`
- `npm run policy`

## Notes

This PR was prepared with AI assistance.

Fixes #850.
