### PR TITLE
fix(identities): remove signature from identity cards

### DIFF
--- a/src/app/profiles/profiles.lister.html
+++ b/src/app/profiles/profiles.lister.html
@@ -35,12 +35,6 @@
                 <mat-grid-tile colspan="4" rowspan="2">
                     <span class="float-left">{{item.reply_to}}</span>
                 </mat-grid-tile>
-                <mat-grid-tile colspan="2" rowspan="2">
-                    <span class="float-right">Signature:</span>
-                </mat-grid-tile>
-                <mat-grid-tile colspan="4" rowspan="2">
-                    <span class="float-left">{{item.signature}}</span>
-                </mat-grid-tile>
                 <mat-grid-tile colspan="{{mobile?6:7}}" rowspan="1"
                     *ngIf="item.reference_type === 'preference' && item.reference.status === 1">
                     <span class="warning">Email not validated.</span>

--- a/src/app/profiles/profiles.lister.scss
+++ b/src/app/profiles/profiles.lister.scss
@@ -24,7 +24,7 @@
     display: inline-flex;
     width: calc(100% - 10px);
     margin: 5px;
-    min-height: 200px;
+    min-height: 160px;
     @media only screen and (min-width: 769px) {
         width: calc(50% - 10px);
         max-width: 600px;

--- a/src/app/profiles/profiles.lister.spec.ts
+++ b/src/app/profiles/profiles.lister.spec.ts
@@ -1,0 +1,84 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatLegacyButtonModule as MatButtonModule } from '@angular/material/legacy-button';
+import { MatLegacyCardModule as MatCardModule } from '@angular/material/legacy-card';
+import { MatLegacyDialog as MatDialog } from '@angular/material/legacy-dialog';
+import { MatGridListModule } from '@angular/material/grid-list';
+import { MatLegacySnackBar as MatSnackBar } from '@angular/material/legacy-snack-bar';
+import { MatDividerModule } from '@angular/material/divider';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { Subject } from 'rxjs';
+import { MobileQueryService, ScreenSize } from '../mobile-query.service';
+import { ProfilesListerComponent } from './profiles.lister';
+
+class MockMobileQueryService {
+    screenSize = ScreenSize.Desktop;
+    screenSizeChanged: Subject<ScreenSize> = new Subject();
+}
+
+describe('ProfilesListerComponent', () => {
+    let fixture: ComponentFixture<ProfilesListerComponent>;
+    let component: ProfilesListerComponent;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            declarations: [
+                ProfilesListerComponent,
+            ],
+            imports: [
+                MatButtonModule,
+                MatCardModule,
+                MatDividerModule,
+                MatGridListModule,
+                NoopAnimationsModule,
+            ],
+            providers: [
+                { provide: MatDialog, useValue: { open: () => ({}) } },
+                { provide: MatSnackBar, useValue: { open: () => ({}) } },
+                { provide: MobileQueryService, useClass: MockMobileQueryService },
+            ],
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(ProfilesListerComponent);
+        component = fixture.componentInstance;
+    });
+
+    it('shows identity details without rendering the signature preview', () => {
+        component.profiles = [{
+            email: 'sender@example.com',
+            from_name: 'Sender Name',
+            reference: {},
+            reference_type: 'preference',
+            reply_to: 'reply@example.com',
+            signature: '<p>HTML signature</p>',
+            type: 'external_email',
+        }];
+
+        fixture.detectChanges();
+
+        const profileText = fixture.nativeElement.textContent;
+        expect(profileText).toContain('sender@example.com');
+        expect(profileText).toContain('Sender Name');
+        expect(profileText).toContain('reply@example.com');
+        expect(profileText).not.toContain('Signature:');
+        expect(profileText).not.toContain('<p>HTML signature</p>');
+    });
+});


### PR DESCRIPTION
## Summary

- Remove the signature preview row from identity overview cards.
- Reduce the identity card minimum height now that the signature row is gone.
- Add regression coverage that keeps email, sender name, and reply-to visible while ensuring raw HTML signatures are absent from the identity card text.

## Validation

- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/profiles/profiles.lister.spec.ts --progress=false` (`1 SUCCESS`)
- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/profiles/profile.service.spec.ts --include=src/app/profiles/profiles.lister.spec.ts --progress=false` (`9 SUCCESS`)
- `npx tsc -p tsconfig.json --noEmit`
- `npx eslint src/app/profiles/profiles.lister.ts src/app/profiles/profiles.lister.html src/app/profiles/profiles.lister.scss src/app/profiles/profiles.lister.spec.ts` (0 errors; warnings only: existing `any` warnings in `profiles.lister.ts` and ignored SCSS file)
- `git diff --check`
- `npx ng test --watch=false --browsers=FirefoxHeadless --progress=false` (`246 SUCCESS`, `2 skipped`, with existing console/template warnings)
- `npm run lint` (0 errors, 770 warnings)
- `node src/build/pre-build.js`
- `npx ng build --configuration production --base-href=/app/ runbox7`
- `node src/build/post-build.js`
- `git diff --cached --check`
- `npm run policy` (exited 0; reports known historical commit-message warnings)

Manual UI validation was not run because no live Runbox account/session is configured in this workspace.

This PR was prepared with AI-assisted source review and code generation; I reviewed the changes and ran the validations listed above.

Fixes #1006
