### PR TITLE
Fix callback tooltip display outside rows

### DIFF
--- a/src/app/canvastable/canvastable.spec.ts
+++ b/src/app/canvastable/canvastable.spec.ts
@@ -73,4 +73,79 @@ describe('canvastable', () => {
         expect(fixture.componentInstance.canvastable.floatingTooltip).toBeTruthy();
         expect(fixture.componentInstance.canvastable.columnOverlay).toBeTruthy();
     });
+
+    it('should resolve function tooltip text for an existing row', async () => {
+        const fixture = TestBed.createComponent(CanvasTableContainerComponent);
+        const tooltipText = jasmine.createSpy('tooltipText').and.returnValue('Function tooltip');
+        fixture.componentInstance.canvastable.columns = [
+            {
+                name: 'Column1',
+                cacheKey: 'col1',
+                sortColumn: null,
+                getValue: (row) => row.col1,
+                width: 200
+            },
+            {
+                name: 'Column2',
+                cacheKey: 'col2',
+                sortColumn: null,
+                getValue: (row) => row.col2,
+                width: 200,
+                tooltipText
+            },
+        ];
+        fixture.componentInstance.canvastable.rows = new MessageList([
+            { id: 1, col1: 'subject1', col2: 'hello' },
+            { id: 2, col1: 'subject2', col2: 'world' }
+        ]);
+        fixture.componentInstance.canvastable.rowWrapMode = false;
+        fixture.detectChanges();
+
+        fixture.componentInstance.canvastable.canvRef.nativeElement.dispatchEvent(new MouseEvent('mousemove', {
+            clientX: 270,
+            clientY: 50
+        }));
+
+        await new Promise(resolve => setTimeout(resolve, 0));
+        fixture.detectChanges();
+        expect(tooltipText).toHaveBeenCalledWith(0);
+        expect(fixture.componentInstance.canvastable.floatingTooltip.tooltipText).toEqual('Function tooltip');
+    });
+
+    it('should not expose function tooltip source when hovering outside rows', async () => {
+        const fixture = TestBed.createComponent(CanvasTableContainerComponent);
+        const tooltipText = jasmine.createSpy('tooltipText').and.returnValue('Function tooltip');
+        fixture.componentInstance.canvastable.columns = [
+            {
+                name: 'Column1',
+                cacheKey: 'col1',
+                sortColumn: null,
+                getValue: (row) => row.col1,
+                width: 200
+            },
+            {
+                name: 'Column2',
+                cacheKey: 'col2',
+                sortColumn: null,
+                getValue: (row) => row.col2,
+                width: 200,
+                tooltipText
+            },
+        ];
+        fixture.componentInstance.canvastable.rows = new MessageList([
+            { id: 1, col1: 'subject1', col2: 'hello' }
+        ]);
+        fixture.componentInstance.canvastable.rowWrapMode = false;
+        fixture.detectChanges();
+
+        fixture.componentInstance.canvastable.canvRef.nativeElement.dispatchEvent(new MouseEvent('mousemove', {
+            clientX: 270,
+            clientY: 100
+        }));
+
+        await new Promise(resolve => setTimeout(resolve, 0));
+        fixture.detectChanges();
+        expect(tooltipText).not.toHaveBeenCalled();
+        expect(fixture.componentInstance.canvastable.floatingTooltip).toBeNull();
+    });
 });

--- a/src/app/canvastable/canvastable.ts
+++ b/src/app/canvastable/canvastable.ts
@@ -465,12 +465,14 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
         const colIndex = this.getColIndexByClientX(clientX);
         let colStartX = this.columns.reduce((prev, curr, ndx) => ndx < colIndex ? prev + curr.width : prev, 0);
 
-        let tooltipText: string | ((rowIndex: any) => string) =
-              this.columns[colIndex] && this.columns[colIndex].tooltipText;
+        const columnTooltipText = this.columns[colIndex] && this.columns[colIndex].tooltipText;
+        let tooltipText: string = null;
 
         // FIXME: message display class
-        if (typeof tooltipText === 'function' && this.rows.rowExists(this.hoverRowIndex)) {
-          tooltipText = tooltipText(this.hoverRowIndex);
+        if (typeof columnTooltipText === 'function') {
+          tooltipText = this.rows.rowExists(this.hoverRowIndex) ? columnTooltipText(this.hoverRowIndex) : null;
+        } else {
+          tooltipText = columnTooltipText;
         }
 
         if (!event.shiftKey && !this.lastMouseDownEvent &&


### PR DESCRIPTION
## Summary

- Resolve function-valued CanvasTable tooltips before the hover overlay truthiness check, so callback functions are never passed through as display text.
- Suppress callback tooltips when the current hover row does not exist, matching the blank-space hover scenario from #544.
- Add regression coverage for both valid callback tooltip resolution and out-of-row hover suppression.

## Validation

- `npx ng test --include src/app/canvastable/canvastable.spec.ts --watch=false --browsers=Firefox` (`3 SUCCESS`)
- `npx eslint src/app/canvastable/canvastable.ts src/app/canvastable/canvastable.spec.ts` (0 errors; existing warnings only)
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npx ng lint` (0 errors, 769 warnings)
- `npm run policy` (exited 0; reports known historical commit-message warnings)
- `npx ng build --configuration production --base-href=/app/ runbox7` (passes with existing Angular/CommonJS/theming warnings)
- `git diff --check`
- `git show --check --stat HEAD`

Manual UI validation was not run because no live Runbox account/session is configured in this workspace.

This PR was prepared with AI-assisted source review and code generation; I reviewed the changes and ran the validations listed above.

Fixes #544
