### PR TITLE
fix(calendar): show import progress feedback

### DIFF
--- a/src/app/calendar-app/calendar-app.component.spec.ts
+++ b/src/app/calendar-app/calendar-app.component.spec.ts
@@ -32,8 +32,12 @@ import { UsageReportsService } from '../common/usage-reports.service';
 import { PreferencesService } from '../common/preferences.service';
 import { RouterTestingModule } from '@angular/router/testing';
 import { take } from 'rxjs/operators';
-import { of, Observable, ReplaySubject } from 'rxjs';
-import { MatLegacySnackBar as MatSnackBar } from '@angular/material/legacy-snack-bar';
+import { of, Observable, ReplaySubject, Subject } from 'rxjs';
+import {
+    MatLegacySnackBar as MatSnackBar,
+    MatLegacySnackBarRef as MatSnackBarRef,
+    LegacyTextOnlySnackBar,
+} from '@angular/material/legacy-snack-bar';
 import { RunboxCalendar } from './runbox-calendar';
 import { RunboxCalendarEvent } from './runbox-calendar-event';
 import { MatIcon } from '@angular/material/icon';
@@ -44,6 +48,8 @@ import ICAL from 'ical.js';
 describe('CalendarAppComponent', () => {
     let component: CalendarAppComponent;
     let fixture: ComponentFixture<CalendarAppComponent>;
+    let snackBar: jasmine.SpyObj<MatSnackBar>;
+    let snackBarRef: jasmine.SpyObj<MatSnackBarRef<LegacyTextOnlySnackBar>>;
 
     // jCal spec: https://tools.ietf.org/html/rfc7265
     const simpleEvents = [
@@ -160,6 +166,10 @@ END:VCALENDAR
 `    };
 
     beforeEach(waitForAsync(() => {
+        snackBarRef = jasmine.createSpyObj('MatSnackBarRef', ['dismiss']);
+        snackBar = jasmine.createSpyObj('MatSnackBar', ['open']);
+        snackBar.open.and.returnValue(snackBarRef);
+
         TestBed.configureTestingModule({
                 imports: [
                     NoopAnimationsModule,
@@ -193,8 +203,7 @@ END:VCALENDAR
                     } },
                     { provide: HttpClient, useValue: {
                     } },
-                    { provide: MatSnackBar, useValue: {
-                    } },
+                    { provide: MatSnackBar, useValue: snackBar },
                     { provide: LogoutService, useValue: {
                     } },
                     { provide: SearchService, useValue: {
@@ -308,5 +317,34 @@ END:VCALENDAR
         expect(first_occurence.getDate()).toBe(1, 'day matches');
         expect(first_occurence.getHours()).toBe(12, 'hour matches');
         expect(first_occurence.getMinutes()).toBe(34, 'minute matches');
+    });
+
+    it('should show progress feedback while importing calendar events', () => {
+        const importResult = new Subject<{ events_imported: number }>();
+        spyOn(component.calendarservice, 'importCalendar').and.returnValue(importResult);
+
+        component.importEvents('test-calendar',
+            'BEGIN:VCALENDAR\nBEGIN:VEVENT\nEND:VEVENT\nBEGIN:VEVENT\nEND:VEVENT\nEND:VCALENDAR\n');
+
+        expect(snackBar.open.calls.argsFor(0)).toEqual(['Importing 2 calendar events...', 'Dismiss']);
+        expect(snackBarRef.dismiss).not.toHaveBeenCalled();
+
+        importResult.next({ events_imported: 2 });
+
+        expect(snackBarRef.dismiss).toHaveBeenCalled();
+        expect(snackBar.open.calls.argsFor(1)).toEqual(['2 events imported', 'Ok', { duration: 3000 }]);
+    });
+
+    it('should dismiss import progress feedback on import failure', () => {
+        const importResult = new Subject<{ events_imported: number }>();
+        spyOn(component.calendarservice, 'importCalendar').and.returnValue(importResult);
+
+        component.importEvents('test-calendar', 'BEGIN:VCALENDAR\nEND:VCALENDAR\n');
+
+        expect(snackBar.open.calls.argsFor(0)).toEqual(['Importing calendar events...', 'Dismiss']);
+
+        importResult.error(new Error('Import failed'));
+
+        expect(snackBarRef.dismiss).toHaveBeenCalled();
     });
 });

--- a/src/app/calendar-app/calendar-app.component.ts
+++ b/src/app/calendar-app/calendar-app.component.ts
@@ -252,9 +252,23 @@ export class CalendarAppComponent implements OnDestroy {
     }
 
     importEvents(calendarId: string, ics: string): void {
-        this.calendarservice.importCalendar(calendarId, ics).subscribe(res => {
-            this.showInfo(res['events_imported'] + ' events imported');
+        const progressSnackBar = this.snackBar.open(this.importProgressMessage(ics), 'Dismiss');
+        this.calendarservice.importCalendar(calendarId, ics).subscribe({
+            next: res => {
+                progressSnackBar.dismiss();
+                this.showInfo(res['events_imported'] + ' events imported');
+            },
+            error: () => progressSnackBar.dismiss(),
         });
+    }
+
+    importProgressMessage(ics: string): string {
+        const eventCount = (ics.match(/^BEGIN:VEVENT$/gmi) || []).length;
+        if (eventCount === 0) {
+            return 'Importing calendar events...';
+        }
+
+        return 'Importing ' + eventCount + ' calendar event' + (eventCount === 1 ? '' : 's') + '...';
     }
 
     onIcsUploaded(uploadEvent: any) {

--- a/src/app/calendar-app/calendar.service.spec.ts
+++ b/src/app/calendar-app/calendar.service.spec.ts
@@ -21,7 +21,8 @@ import { StorageService } from '../storage.service';
 import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
 import { CalendarService } from './calendar.service';
 import { RunboxCalendarEvent } from './runbox-calendar-event';
-import { of } from 'rxjs';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Observable, of, throwError } from 'rxjs';
 import { take } from 'rxjs/operators';
 import moment from 'moment';
 import ICAL from 'ical.js';
@@ -96,6 +97,7 @@ END:VCALENDAR
 
     let storage: StorageService;
     let sut: CalendarService;
+    let importCalendarResponse: Observable<{ events_imported: number }>;
 
     const rmmapi = <unknown>{
         me: of({ uid: 1, timezone: 'Europe/London' }),
@@ -121,6 +123,7 @@ END:VCALENDAR
             delete dav_events[id];
             return of('mmm coffee');
         },
+        importCalendar: (_calendarId: string, _ics: string) => importCalendarResponse,
     } as RunboxWebmailAPI;
 
     // This is a deliberate mess, rrules and their exceptions should not be
@@ -149,6 +152,7 @@ END:VCALENDAR
         for (const key of Object.keys(calls)) {
             calls[key] = 0;
         }
+        importCalendarResponse = of({ events_imported: 1 });
 
         localStorage.clear();
         storage = new StorageService(rmmapi);
@@ -271,6 +275,28 @@ END:VCALENDAR
         // Produces multiple CalendarEvents which refer to the same ICal.Event
         expect(rbevents.length).toEqual(5, 'Recurring event contains 5 instances');
         expect(rbevents[0].recurringFrequency).toEqual('DAILY', 'recurrence is DAILY');
+    });
+
+    it('should complete after importing an .ics file through the API', (done) => {
+        sut.importCalendar('test', 'BEGIN:VCALENDAR\nEND:VCALENDAR\n').subscribe({
+            next: res => expect(res.events_imported).toBe(1),
+            complete: done,
+            error: done.fail,
+        });
+    });
+
+    it('should propagate calendar import API errors after logging them', (done) => {
+        const error = { status: 500 } as HttpErrorResponse;
+        importCalendarResponse = throwError(() => error);
+
+        sut.errorLog.pipe(take(1)).subscribe(logged => expect(logged).toBe(error));
+        sut.importCalendar('test', 'BEGIN:VCALENDAR\nEND:VCALENDAR\n').subscribe({
+            next: () => done.fail('import should not emit a successful result'),
+            error: err => {
+                expect(err).toBe(error);
+                done();
+            },
+        });
     });
 
     it('should be possible to import an .ics file with exceptions', () => {

--- a/src/app/calendar-app/calendar.service.ts
+++ b/src/app/calendar-app/calendar.service.ts
@@ -467,7 +467,11 @@ export class CalendarService implements OnDestroy {
             this.rmmapi.importCalendar(calendarId, ics).subscribe(res => {
                 this.reloadEvents();
                 o.next(res);
-            }, e => this.apiErrorHandler(e));
+                o.complete();
+            }, e => {
+                this.apiErrorHandler(e);
+                o.error(e);
+            });
         });
     }
 


### PR DESCRIPTION
Closes #1271

## Summary
- Show a persistent snackbar while an `.ics` calendar import is in progress.
- Estimate the number of imported calendar events from `BEGIN:VEVENT` blocks for more useful import feedback.
- Complete successful import observables and propagate import API errors after logging them so callers can clean up progress UI.

## Tests
- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/calendar-app/calendar-app.component.spec.ts --include=src/app/calendar-app/calendar.service.spec.ts`
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npx eslint src/app/calendar-app/calendar-app.component.ts src/app/calendar-app/calendar.service.ts src/app/calendar-app/calendar-app.component.spec.ts src/app/calendar-app/calendar.service.spec.ts`
- `npx ng test --watch=false --browsers=FirefoxHeadless`
- `npm run lint`
- `npm run policy`
- `node src/build/pre-build.js`
- `npx ng build --configuration production --base-href=/app/ runbox7`
- `node src/build/post-build.js`

## AI Disclosure
This PR was prepared with assistance from OpenAI Codex.
