### PR TITLE
fix(calendar): show stable event sync totals

### DIFF
--- a/src/app/calendar-app/calendar.service.spec.ts
+++ b/src/app/calendar-app/calendar.service.spec.ts
@@ -21,6 +21,7 @@ import { StorageService } from '../storage.service';
 import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
 import { CalendarService } from './calendar.service';
 import { RunboxCalendarEvent } from './runbox-calendar-event';
+import { ActivityProgress } from '../common/background-activity.service';
 import { of } from 'rxjs';
 import { take } from 'rxjs/operators';
 import moment from 'moment';
@@ -224,6 +225,24 @@ END:VCALENDAR
             expect(calls.deleteCalendarEvent).toBe(1, '1 event was deleted');
             r(null);
         }));
+    });
+
+    it('should report calendar refresh progress against the total number of raw events', () => {
+        const eventRefreshProgress: ActivityProgress[] = [];
+        sut.activities.observable.subscribe(activityMap => {
+            activityMap.forEach((progress, activity) => {
+                if (activity.toString() === 'Refreshing Events' && progress[1] > 1) {
+                    eventRefreshProgress.push([...progress] as ActivityProgress);
+                }
+            });
+        });
+
+        sut.reloadEvents();
+
+        expect(eventRefreshProgress.length).toBeGreaterThan(0);
+        expect(eventRefreshProgress[0]).toEqual([0, 3, 'events']);
+        expect(eventRefreshProgress[1]).toEqual([1, 3, 'events']);
+        expect(eventRefreshProgress.every(progress => progress[1] === 3)).toBeTrue();
     });
 
     it('should be possible to  import an .ics file', () => {

--- a/src/app/calendar-app/calendar.service.ts
+++ b/src/app/calendar-app/calendar.service.ts
@@ -501,11 +501,16 @@ export class CalendarService implements OnDestroy {
         console.log('Fetching events');
         this.activities.begin(Activity.RefreshingEvents);
         this.rmmapi.getCalendarEvents().subscribe(events => {
+            this.activities.end(Activity.RefreshingEvents);
             this.events = [];
             this.icalevents = [];
+            if (events.length > 0) {
+                this.activities.begin(Activity.RefreshingEvents, events.length, 'events');
+            }
             events.forEach((e: any) => {
                 // store events into this.icalevents
                 this.importFromIcal(e.id, e.ical);
+                this.activities.end(Activity.RefreshingEvents);
             });
 
             // generate RBE events for just this set, for current month+1:
@@ -514,7 +519,6 @@ export class CalendarService implements OnDestroy {
             const runboxevents = this.generateEvents();
             this.events = this.events.concat(runboxevents);
             this.eventSubject.next(this.events);
-            this.activities.end(Activity.RefreshingEvents);
         }, e => {
             this.apiErrorHandler(e);
             this.activities.end(Activity.RefreshingEvents);

--- a/src/app/common/background-activity-indicator.component.spec.ts
+++ b/src/app/common/background-activity-indicator.component.spec.ts
@@ -89,4 +89,14 @@ describe('BackgroundActivityIndicatorComponent', () => {
         await new Promise(r => setTimeout(r, 0));
         expect(comp.shownActivities.length).toBe(0);
     });
+
+    it('should display a unit label for multipart activities when provided', async () => {
+        service.begin(TestActivity.Activity1, 3, 'items');
+        await new Promise(r => setTimeout(r, 0));
+        expect(comp.shownActivities[0]).toBe('processing (1/3 items)');
+
+        service.end(TestActivity.Activity1);
+        await new Promise(r => setTimeout(r, 0));
+        expect(comp.shownActivities[0]).toBe('processing (2/3 items)');
+    });
 });

--- a/src/app/common/background-activity-indicator.component.ts
+++ b/src/app/common/background-activity-indicator.component.ts
@@ -43,7 +43,11 @@ export class BackgroundActivityIndicatorComponent implements OnChanges {
             activityMap.forEach((progress: ActivityProgress, activity: any) => {
                 let description = activity.toString();
                 if (progress[1] !== 1) {
-                    description += ` ${progress[0] + 1}/${progress[1]}`;
+                    if (progress[2]) {
+                        description += ` (${progress[0] + 1}/${progress[1]} ${progress[2]})`;
+                    } else {
+                        description += ` ${progress[0] + 1}/${progress[1]}`;
+                    }
                 }
                 this.shownActivities.push(description);
             });

--- a/src/app/common/background-activity.service.ts
+++ b/src/app/common/background-activity.service.ts
@@ -19,8 +19,8 @@
 
 import { Subject } from 'rxjs';
 
-// a glorified fraction
-export type ActivityProgress = [number, number];
+// a glorified fraction with an optional unit label
+export type ActivityProgress = [number, number, string?];
 
 // not @Injectable on purpose: each app/service is expected to have its own,
 // implemented with its own relevant type
@@ -28,13 +28,16 @@ export class BackgroundActivityService<ActivityType> {
     activityMap = new Map<ActivityType, ActivityProgress>();
     observable  = new Subject<Map<ActivityType, ActivityProgress>>();
 
-    public begin(activity: ActivityType, parts = 1) {
+    public begin(activity: ActivityType, parts = 1, unit?: string) {
         const existingProgress = this.activityMap.get(activity);
         if (existingProgress) {
             existingProgress[1] += parts;
+            if (unit) {
+                existingProgress[2] = unit;
+            }
             this.activityMap.set(activity, existingProgress);
         } else {
-            this.activityMap.set(activity, [0, parts]);
+            this.activityMap.set(activity, [0, parts, unit]);
         }
         this.observable.next(this.activityMap);
     }


### PR DESCRIPTION
Closes #1268

## Summary
- Track calendar event refresh as a multipart activity after the raw event list is loaded.
- Keep the event refresh denominator fixed to the total number of raw calendar events while each item is imported.
- Add optional unit labels to multipart activity display so calendar refresh can show e.g. `Refreshing Events (1/3 events)` without changing existing unlabeled activity formatting.

## Tests
- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/calendar-app/calendar.service.spec.ts --include=src/app/common/background-activity-indicator.component.spec.ts`
- `npx eslint src/app/common/background-activity-indicator.component.ts src/app/common/background-activity-indicator.component.spec.ts src/app/common/background-activity.service.ts src/app/calendar-app/calendar.service.ts src/app/calendar-app/calendar.service.spec.ts`
- `npx ng lint`
- `npm run policy`
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npx ng build --configuration production --base-href=/app/ runbox7`

## AI Disclosure
This PR was prepared with assistance from OpenAI Codex.
