### PR TITLE
fix(help): point forum card to community

### DIFF
--- a/src/app/help/help.component.html
+++ b/src/app/help/help.component.html
@@ -62,7 +62,7 @@
 				</mat-card>
 
 				<mat-card class="settingsItem">
-					<a href="https://forum.runbox.com/" target="forum">
+					<a href="https://community.runbox.com/" target="forum">
 						<h3>
 							<mat-icon svgIcon="forum"></mat-icon> <strong>Forum</strong>
 						</h3>

--- a/src/app/help/help.component.spec.ts
+++ b/src/app/help/help.component.spec.ts
@@ -17,6 +17,7 @@
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
 
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { HelpComponent } from './help.component';
@@ -27,7 +28,8 @@ describe('HelpComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ HelpComponent ]
+      declarations: [ HelpComponent ],
+      schemas: [ NO_ERRORS_SCHEMA ]
     })
     .compileComponents();
   });
@@ -40,5 +42,12 @@ describe('HelpComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('links the forum card to the Runbox community', () => {
+    const forumLink = fixture.nativeElement.querySelector('a[target="forum"]') as HTMLAnchorElement | null;
+
+    expect(forumLink).not.toBeNull();
+    expect(forumLink?.getAttribute('href')).toBe('https://community.runbox.com/');
   });
 });


### PR DESCRIPTION
Closes #1769

## Summary
- update the Help Center Forum card to use the Runbox community URL
- add a HelpComponent regression spec for the Forum card href

## Tests
- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/help/help.component.spec.ts`
- `npx eslint src/app/help/help.component.spec.ts src/app/help/help.component.html`
- `npx ng lint`
- `npm run policy`
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npx ng build --configuration production --base-href=/app/ runbox7`
- `git diff --check`

## AI Disclosure
This PR was prepared with assistance from OpenAI Codex.
