### PR TITLE
fix(folders): mention contents in delete warning

### DIFF
--- a/src/app/folder/folderlist.component.spec.ts
+++ b/src/app/folder/folderlist.component.spec.ts
@@ -28,7 +28,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { MatLegacyDialogModule as MatDialogModule } from '@angular/material/legacy-dialog';
 import { MatLegacySnackBarModule as MatSnackBarModule } from '@angular/material/legacy-snack-bar';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { DialogModule } from '../dialog/dialog.module';
+import { ConfirmDialog, DialogModule } from '../dialog/dialog.module';
 import { HotkeysService } from 'angular2-hotkeys';
 
 class MatDialogMock {
@@ -251,5 +251,25 @@ describe('FolderListComponent', () => {
         expect(newListOfFolders.length).toEqual(3);
         expect(newListOfFolders[2].folderName).toEqual('testtest');
         expect(newListOfFolders[2].folderLevel).toEqual(0);
+    });
+
+    it('warns that deleting a folder also deletes its contents', () => {
+        const componentInstance: Partial<ConfirmDialog> = {};
+        const dialogRef = {
+            componentInstance,
+            afterClosed: () => of(false)
+        };
+        const deleteDialog = {
+            open: jasmine.createSpy('open').and.returnValue(dialogRef)
+        } as unknown as MatDialog;
+        const comp = new FolderListComponent(deleteDialog, hotkeyMock);
+        const folder = new FolderListEntry(2, 50, 40, 'user', 'Clients', 'Clients', 0);
+
+        comp.deleteFolderDialog(folder);
+
+        expect(componentInstance.title).toEqual('Delete folder Clients?');
+        expect(componentInstance.question).toEqual(
+            'Are you sure that you want to delete the folder named Clients and its contents?'
+        );
     });
 });

--- a/src/app/folder/folderlist.component.ts
+++ b/src/app/folder/folderlist.component.ts
@@ -350,7 +350,7 @@ export class FolderListComponent implements OnChanges {
         const confirmDialog = this.dialog.open(ConfirmDialog);
         confirmDialog.componentInstance.title = `Delete folder ${folder.folderName}?`;
         confirmDialog.componentInstance.question =
-        `Are you sure that you want to delete the folder named ${folder.folderName}?`;
+        `Are you sure that you want to delete the folder named ${folder.folderName} and its contents?`;
         confirmDialog.componentInstance.noOptionTitle = 'cancel';
         confirmDialog.componentInstance.yesOptionTitle = 'ok';
         confirmDialog.afterClosed().pipe(


### PR DESCRIPTION
Closes #1382

## Summary
- mention that deleting a folder also deletes its contents in the delete-folder confirmation
- add a focused FolderListComponent regression spec for the updated warning text

## Tests
- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/folder/folderlist.component.spec.ts`
- `npx eslint src/app/folder/folderlist.component.ts src/app/folder/folderlist.component.spec.ts`
- `npx ng lint`
- `npm run policy`
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npx ng build --configuration production --base-href=/app/ runbox7`
- `git diff --check`

## AI Disclosure
This PR was prepared with assistance from OpenAI Codex.
