### PR TITLE
fix(updates): keep update prompt non-modal

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -151,13 +151,6 @@
     <p style="text-align: center; font-size: 12px">
         Runbox 7 build time: {{buildtimestampstring}} <br>
         <a routerLink="/changelog"> Read the changelog </a>
-        <ng-container *ngIf="updateService.updateIsReady | async">
-          <br><span>An update of the application is available, and you may reload the app now to use the latest version.</span>
-          <br>
-          <button mat-raised-button (click)="reload()" color="primary">
-            Reload app
-          </button>
-        </ng-container>
     </p>
   </mat-sidenav>
   <mat-sidenav *ngIf="mailViewerOnRightSide" position="end" mode="side"

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -497,10 +497,6 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     this.calculateWidthDependentElements();
   }
 
-  reload(): void {
-    location.reload();
-  }
-
   selectMessageFromFragment(fragment: string): void {
     const fragmentTarget = this.parseFragment(fragment);
     if (fragmentTarget) {

--- a/src/app/updatealert/updatealert.component.spec.ts
+++ b/src/app/updatealert/updatealert.component.spec.ts
@@ -1,0 +1,83 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { Component } from '@angular/core';
+import { ComponentFixture, fakeAsync, flush, TestBed, tick, waitForAsync } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatLegacySnackBar as MatSnackBar } from '@angular/material/legacy-snack-bar';
+import { SwUpdate } from '@angular/service-worker';
+import { Subject } from 'rxjs';
+import { UpdateAlertComponent } from './updatealert.component';
+import { UpdateAlertModule } from './updatealert.module';
+
+@Component({
+    template: 'test'
+})
+class TestAppComponent {}
+
+describe('UpdateAlertComponent', () => {
+    let fixture: ComponentFixture<TestAppComponent>;
+    let snackbar: MatSnackBar;
+
+    beforeEach(waitForAsync(() => {
+        TestBed.configureTestingModule({
+            imports: [
+                NoopAnimationsModule,
+                UpdateAlertModule
+            ],
+            declarations: [TestAppComponent],
+            providers: [
+                {
+                    provide: SwUpdate,
+                    useValue: {
+                        isEnabled: false,
+                        versionUpdates: new Subject(),
+                        checkForUpdate: () => Promise.resolve(false),
+                    }
+                }
+            ]
+        }).compileComponents();
+        fixture = TestBed.createComponent(TestAppComponent);
+        snackbar = TestBed.inject(MatSnackBar);
+    }));
+
+    it('opens as a non-modal snackbar with update details', fakeAsync(() => {
+        const snackbarRef = snackbar.openFromComponent(UpdateAlertComponent, {
+            data: {
+                current: { hash: 'old-version', appData: { build_epoch: '1000' } },
+                available: { hash: 'new-version', appData: { commit: 'abc1234', build_time: '2026-06-10' } },
+            }
+        });
+
+        fixture.detectChanges();
+        tick();
+
+        const snackbarElement = document.querySelector('snack-bar-container') as HTMLElement;
+
+        expect(snackbarElement).not.toBeNull();
+        expect(snackbarElement.innerText).toContain('An update of the application is available');
+        expect(snackbarElement.innerText).toContain('abc1234');
+        expect(snackbarElement.innerText).toContain('Reload now');
+        expect(snackbarElement.innerText).toContain('Later');
+        expect(document.querySelector('mat-dialog-container')).toBeNull();
+
+        snackbarRef.dismiss();
+        flush();
+    }));
+});

--- a/src/app/updatealert/updatealert.component.ts
+++ b/src/app/updatealert/updatealert.component.ts
@@ -18,14 +18,15 @@
 // ---------- END RUNBOX LICENSE ----------
 
 import { Component, Inject } from '@angular/core';
-import { MatSnackBarRef, MAT_SNACK_BAR_DATA } from '@angular/material/snack-bar';
+import { MatLegacySnackBarRef as MatSnackBarRef, MAT_LEGACY_SNACK_BAR_DATA as MAT_SNACK_BAR_DATA } from '@angular/material/legacy-snack-bar';
+import { UpdateStatus } from './updatealert.service';
 
 @Component({
     templateUrl: 'updatealert.component.html'
 })
 export class UpdateAlertComponent {
     constructor(
-        @Inject(MAT_SNACK_BAR_DATA) public data: any,
+        @Inject(MAT_SNACK_BAR_DATA) public data: UpdateStatus,
         public snackBarRef: MatSnackBarRef<UpdateAlertComponent>,
     ) {
     }

--- a/src/app/updatealert/updatealert.module.ts
+++ b/src/app/updatealert/updatealert.module.ts
@@ -18,7 +18,7 @@
 // ---------- END RUNBOX LICENSE ----------
 
 import { MatLegacyButtonModule as MatButtonModule } from '@angular/material/legacy-button';
-import { MatLegacyDialogModule as MatDialogModule } from '@angular/material/legacy-dialog';
+import { MatLegacySnackBarModule as MatSnackBarModule } from '@angular/material/legacy-snack-bar';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { UpdateAlertComponent } from './updatealert.component';
@@ -27,7 +27,7 @@ import { UpdateAlertService } from './updatealert.service';
 @NgModule({
     imports: [
         CommonModule,
-        MatDialogModule,
+        MatSnackBarModule,
         MatButtonModule
     ],
     declarations: [
@@ -38,7 +38,7 @@ import { UpdateAlertService } from './updatealert.service';
     ]
 })
 export class UpdateAlertModule {
-    constructor(alertservice: UpdateAlertService) {
-
+    constructor(_alertservice: UpdateAlertService) {
+        void _alertservice;
     }
 }

--- a/src/app/updatealert/updatealert.service.ts
+++ b/src/app/updatealert/updatealert.service.ts
@@ -19,21 +19,32 @@
 
 import { Injectable, NgZone } from '@angular/core';
 import { SwUpdate, VersionReadyEvent } from '@angular/service-worker';
-import { MatLegacyDialog as MatDialog } from '@angular/material/legacy-dialog';
 import { environment } from '../../environments/environment';
 import { BehaviorSubject } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
 
-interface UpdateStatus {
+export interface UpdateAppData {
+    commit?: string;
+    build_time?: string;
+    build_epoch?: string;
+}
+
+interface UpdateVersion {
+    hash: string;
+    appData?: UpdateAppData;
+}
+
+function toUpdateVersion(version: VersionReadyEvent['currentVersion']): UpdateVersion {
+    return {
+        hash: version.hash,
+        appData: version.appData as UpdateAppData | undefined,
+    };
+}
+
+export interface UpdateStatus {
     type: string;
-    current: {
-        hash: string;
-        appData?: object;
-    };
-    available: {
-        hash: string;
-        appData?: object;
-    };
+    current: UpdateVersion;
+    available: UpdateVersion;
 }
 
 @Injectable()
@@ -48,8 +59,7 @@ export class UpdateAlertService {
     };
     constructor(
         private ngZone: NgZone,
-        private swupdate: SwUpdate,
-        dialog: MatDialog
+        private swupdate: SwUpdate
     ) {
         if (environment.production && swupdate.isEnabled) {
             console.log('UpdateAlertService started');
@@ -59,8 +69,8 @@ export class UpdateAlertService {
                 map(evt => {
                     const update: UpdateStatus = {
                         type: 'UPDATE_AVAILABLE',
-                        current: evt.currentVersion,
-                        available: evt.latestVersion,
+                        current: toUpdateVersion(evt.currentVersion),
+                        available: toUpdateVersion(evt.latestVersion),
                     };
                     return update;
                 })


### PR DESCRIPTION
Closes #1390.

## Summary

- Keep the update notification on the existing non-modal snackbar path by importing the snackbar module and removing the stale side-nav update prompt fallback.
- Align the snackbar component with the legacy snackbar injection tokens used by `MatLegacySnackBar.openFromComponent()`.
- Type the update-status data passed into the snackbar so the commit and build timestamp render safely.
- Add focused coverage that opens the update alert through `MatLegacySnackBar` and asserts it is not rendered as a Material dialog.

## Validation

- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/updatealert/updatealert.component.spec.ts`
- `npx eslint src/app/app.component.ts src/app/app.component.html src/app/updatealert/updatealert.component.ts src/app/updatealert/updatealert.component.html src/app/updatealert/updatealert.module.ts src/app/updatealert/updatealert.service.ts src/app/updatealert/updatealert.component.spec.ts`
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npx ng lint`
- `npm run policy`
- `npx ng build --configuration production --base-href=/app/ runbox7`
- `git diff --check`
