### PR TITLE
Support shift-click range selection in canvas tables

### DIFF
--- a/src/app/canvastable/canvastable.spec.ts
+++ b/src/app/canvastable/canvastable.spec.ts
@@ -33,11 +33,8 @@ describe('canvastable', () => {
     it('should activate draggable column overlay on mouseover', async () => {
         const fixture = TestBed.createComponent(CanvasTableContainerComponent);
         fixture.componentInstance.canvastableselectlistener = {
-            rowSelected: (rowIndex: number, colIndex: number, rowContent: any, multiSelect?: boolean): void => {
-
-            },
-            saveColumnWidthsPreference: (widths: any): void => {
-            }
+            rowSelected: (): void => undefined,
+            saveColumnWidthsPreference: (): void => undefined
         };
         fixture.componentInstance.canvastable.columns = [
             {
@@ -73,4 +70,79 @@ describe('canvastable', () => {
         expect(fixture.componentInstance.canvastable.floatingTooltip).toBeTruthy();
         expect(fixture.componentInstance.canvastable.columnOverlay).toBeTruthy();
     });
+
+    it('should select a checkbox range with shift click', () => {
+        const fixture = TestBed.createComponent(CanvasTableContainerComponent);
+        const messageList = new MessageList([
+            { id: 1, seenFlag: false, subject: 'one' },
+            { id: 2, seenFlag: false, subject: 'two' },
+            { id: 3, seenFlag: false, subject: 'three' },
+            { id: 4, seenFlag: false, subject: 'four' },
+            { id: 5, seenFlag: false, subject: 'five' },
+        ]);
+
+        fixture.componentInstance.canvastableselectlistener = {
+            rowSelected: (rowIndex: number, colIndex: number, multiSelect?: boolean): void => {
+                messageList.rowSelected(rowIndex, colIndex, multiSelect);
+            },
+            saveColumnWidthsPreference: (): void => undefined
+        };
+        fixture.componentInstance.canvastable.columns = [
+            {
+                name: '',
+                cacheKey: 'selectbox',
+                sortColumn: null,
+                getValue: (rowIndex: number) => messageList.isSelectedRow(rowIndex),
+                width: 40,
+                checkbox: true
+            },
+            {
+                name: 'Subject',
+                cacheKey: 'subject',
+                sortColumn: null,
+                getValue: (rowIndex: number) => messageList.getRow(rowIndex).subject,
+                width: 200
+            },
+        ];
+        fixture.componentInstance.canvastable.rows = messageList;
+        fixture.componentInstance.canvastable.rowWrapMode = false;
+        fixture.detectChanges();
+
+        const canvas = fixture.componentInstance.canvastable.canvRef.nativeElement;
+        spyOn(canvas, 'getBoundingClientRect').and.returnValue({
+            left: 0,
+            top: 0,
+            right: 300,
+            bottom: 200,
+            width: 300,
+            height: 200,
+            x: 0,
+            y: 0,
+            toJSON: () => ({})
+        } as DOMRect);
+
+        clickCanvas(canvas, 5, 14);
+        clickCanvas(canvas, 5, 98, true);
+
+        expect(messageList.isSelectedRow(0)).toBeTrue();
+        expect(messageList.isSelectedRow(1)).toBeTrue();
+        expect(messageList.isSelectedRow(2)).toBeTrue();
+        expect(messageList.isSelectedRow(3)).toBeTrue();
+        expect(messageList.isSelectedRow(4)).toBeFalse();
+    });
 });
+
+function clickCanvas(canvas: HTMLCanvasElement, clientX: number, clientY: number, shiftKey = false): void {
+    canvas.dispatchEvent(new MouseEvent('mousedown', {
+        bubbles: true,
+        clientX,
+        clientY,
+        shiftKey
+    }));
+    canvas.dispatchEvent(new MouseEvent('mouseup', {
+        bubbles: true,
+        clientX,
+        clientY,
+        shiftKey
+    }));
+}

--- a/src/app/canvastable/canvastable.ts
+++ b/src/app/canvastable/canvastable.ts
@@ -195,6 +195,7 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
   }
 
   private dragSelectionDirectionIsDown: boolean = null;
+  private lastCheckboxSelectedRowIndex: number = null;
 
   // Auto row wrap mode (width based on iphone 5) - set to 0 to disable row wrap mode
   public autoRowWrapModeWidth = 540;
@@ -533,7 +534,7 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
         const lastrow = this.getRowIndexByClientY(this.lastMouseDownEvent.clientY);
         const thisrow = this.getRowIndexByClientY(event.clientY);
         if (lastcol === thiscol && lastrow === thisrow) {
-          this.selectRow(event.clientX, event.clientY);
+          this.selectRow(event.clientX, event.clientY, undefined, event.shiftKey);
         }
       }
 
@@ -655,7 +656,7 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
 
   public columnOverlayClicked(event: MouseEvent) {
     this.lastMouseDownEvent = null;
-    this.selectRow(event.clientX, event.clientY);
+    this.selectRow(event.clientX, event.clientY, undefined, event.shiftKey);
   }
 
   public doScrollBarDrag(clientY: number) {
@@ -759,18 +760,47 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
     this.hasChanges = true;
   }
 
-  public selectRow(clientX: number, clientY: number, multiSelect?: boolean) {
+  public selectRow(clientX: number, clientY: number, multiSelect?: boolean, rangeSelect?: boolean) {
     const selectedRowIndex = this.getRowIndexByClientY(clientY);
+    const selectedColIndex = this.getSelectedColIndex(clientX);
+
+    if (
+      rangeSelect &&
+      selectedColIndex === 0 &&
+      this.lastCheckboxSelectedRowIndex !== null &&
+      this.rows.rowExists(this.lastCheckboxSelectedRowIndex) &&
+      this.rows.rowExists(selectedRowIndex)
+    ) {
+      this.selectCheckboxRange(clientX, this.lastCheckboxSelectedRowIndex, selectedRowIndex);
+      return;
+    }
+
     this.selectRowByIndex(clientX, selectedRowIndex, multiSelect);
+    if (selectedColIndex === 0 && this.rows.rowExists(selectedRowIndex)) {
+      this.lastCheckboxSelectedRowIndex = selectedRowIndex;
+    }
   }
 
   public selectRowByIndex(clientX: number, selectedRowIndex: number, multiSelect?: boolean) {
-    const canvrect = this.canv.getBoundingClientRect();
-    clientX -= canvrect.left;
-
     this.selectListener.rowSelected(selectedRowIndex,
-      this.getColIndexByClientX(clientX),
+      this.getSelectedColIndex(clientX),
       multiSelect);
+
+    this.hasChanges = true;
+  }
+
+  private getSelectedColIndex(clientX: number): number {
+    const canvrect = this.canv.getBoundingClientRect();
+    return this.getColIndexByClientX(clientX - canvrect.left);
+  }
+
+  private selectCheckboxRange(clientX: number, startRowIndex: number, endRowIndex: number) {
+    const firstRowIndex = Math.min(startRowIndex, endRowIndex);
+    const lastRowIndex = Math.max(startRowIndex, endRowIndex);
+
+    for (let rowIndex = firstRowIndex; rowIndex <= lastRowIndex; rowIndex++) {
+      this.selectRowByIndex(clientX, rowIndex, true);
+    }
 
     this.hasChanges = true;
   }


### PR DESCRIPTION
## Summary

- add Shift-click range selection for checkbox clicks in the canvas table
- keep the existing single-click selection anchor and click-drag behavior intact
- cover the behavior with a canvas mouse event spec

Closes #1646.

## Validation

- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/canvastable/canvastable.spec.ts --progress=false`
- `npx eslint src/app/canvastable/canvastable.ts src/app/canvastable/canvastable.spec.ts`
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `git diff --check`
- `npx ng lint`
- `npx ng build --configuration production --base-href=/app/ runbox7`
- `git diff --cached --check`
- `npm run policy`
- `git show --check --stat HEAD`
