### PR TITLE
Sort non-index message lists by table columns

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -870,10 +870,19 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
       }
     }
     if (displayType === 'messagelist') {
+      let createdMessageList = false;
       if (this.canvastable.rows instanceof MessageList) {
         this.canvastable.updateRows(args[0]);
       } else {
         this.canvastable.rows = new MessageList(...args);
+        createdMessageList = true;
+      }
+      (this.canvastable.rows as MessageList).sortBy(
+        this.canvastablecontainer.sortColumn,
+        this.canvastablecontainer.sortDescending,
+        this.selectedFolder
+      );
+      if (createdMessageList) {
         // messages updated, check if we need to select a message from the fragment
         this.selectMessageFromFragment(this.fragment);
       }

--- a/src/app/common/messagelist.spec.ts
+++ b/src/app/common/messagelist.spec.ts
@@ -1,0 +1,104 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2022 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { MailAddressInfo } from './mailaddressinfo';
+import { MessageInfo } from './messageinfo';
+import { MessageList } from './messagelist';
+
+describe('MessageList', () => {
+  it('should advertise sortable columns for non-index message lists', () => {
+    const list = new MessageList([]);
+    const columns = list.getCanvasTableColumns({ selectedFolder: 'Inbox' });
+
+    expect(columns.find(column => column.name === 'Date').sortColumn).toBe(2);
+    expect(columns.find(column => column.name === 'From').sortColumn).toBe(0);
+    expect(columns.find(column => column.name === 'Subject').sortColumn).toBe(1);
+    expect(columns.find(column => column.name === 'Size').sortColumn).toBe(3);
+  });
+
+  it('should sort non-index messages by subject, date, size, and address', () => {
+    const list = new MessageList([
+      createMessage(1, '2026-01-03T00:00:00Z', 'Charlie <charlie@example.com>', 'Zed <zed@example.com>', 'gamma', 300),
+      createMessage(2, '2026-01-01T00:00:00Z', 'alice@example.com', 'Yvonne <yvonne@example.com>', 'Alpha', 100),
+      createMessage(3, '2026-01-02T00:00:00Z', 'Bob <bob@example.com>', 'xavier@example.com', 'beta', 200),
+    ]);
+
+    list.sortBy(1, false, 'Inbox');
+    expect(rowIds(list)).toEqual([2, 3, 1]);
+
+    list.sortBy(2, true, 'Inbox');
+    expect(rowIds(list)).toEqual([1, 3, 2]);
+
+    list.sortBy(3, false, 'Inbox');
+    expect(rowIds(list)).toEqual([2, 3, 1]);
+
+    list.sortBy(0, false, 'Inbox');
+    expect(rowIds(list)).toEqual([2, 3, 1]);
+
+    list.sortBy(0, false, 'Sent');
+    expect(rowIds(list)).toEqual([3, 2, 1]);
+  });
+
+  it('should keep filtered rows in the current sorted order', () => {
+    const list = new MessageList([
+      createMessage(1, '2026-01-01T00:00:00Z', 'one@example.com', 'to@example.com', 'Zulu', 100, true),
+      createMessage(2, '2026-01-02T00:00:00Z', 'two@example.com', 'to@example.com', 'Alpha', 100, false),
+      createMessage(3, '2026-01-03T00:00:00Z', 'three@example.com', 'to@example.com', 'Beta', 100, false),
+    ]);
+    const options = new Map<string, boolean>();
+    options.set('unreadOnly', true);
+
+    list.sortBy(1, false, 'Inbox');
+    list.filterBy(options);
+
+    expect(rowIds(list)).toEqual([2, 3]);
+  });
+});
+
+function rowIds(list: MessageList): number[] {
+  return list.rows.map((row: MessageInfo) => row.id);
+}
+
+function createMessage(
+  id: number,
+  messageDate: string,
+  from: string,
+  to: string,
+  subject: string,
+  size: number,
+  seenFlag = false
+): MessageInfo {
+  return new MessageInfo(
+    id,
+    new Date(messageDate),
+    new Date(messageDate),
+    'Inbox',
+    seenFlag,
+    false,
+    false,
+    MailAddressInfo.parse(from),
+    MailAddressInfo.parse(to),
+    [],
+    [],
+    subject,
+    '',
+    size,
+    false
+  );
+}

--- a/src/app/common/messagelist.ts
+++ b/src/app/common/messagelist.ts
@@ -22,11 +22,24 @@ import { MessageInfo } from './messageinfo';
 import { MessageTableRowTool} from '../messagetable/messagetablerow';
 import { CanvasTableColumn } from '../canvastable/canvastablecolumn';
 
+const SORT_FROM_OR_TO = 0;
+const SORT_SUBJECT = 1;
+const SORT_DATE = 2;
+const SORT_SIZE = 3;
+
 export class MessageList extends MessageDisplay {
+  private sortColumn: number = null;
+  private sortDescending = false;
+  private sortSelectedFolder = '';
 
   // MessageDisplay implementations have different numbers of arguments..
   constructor(...args: any[]) {
     super(args[0]);
+  }
+
+  setRows(rows: MessageInfo[]) {
+    super.setRows(rows);
+    this.applyCurrentSort();
   }
 
   getRowSeen(index: number): boolean {
@@ -62,6 +75,62 @@ export class MessageList extends MessageDisplay {
     '';
   }
 
+  public sortBy(sortColumn: number, sortDescending: boolean, selectedFolder: string) {
+    this.sortColumn = sortColumn;
+    this.sortDescending = sortDescending;
+    this.sortSelectedFolder = selectedFolder || '';
+    this.applyCurrentSort();
+  }
+
+  private applyCurrentSort() {
+    if (this.sortColumn === null || this.sortColumn === undefined) {
+      return;
+    }
+
+    this._rows = [...this._rows].sort((first: MessageInfo, second: MessageInfo) =>
+      this.compareMessages(first, second) * (this.sortDescending ? -1 : 1)
+    );
+    this.rows = this._rows;
+  }
+
+  private compareMessages(first: MessageInfo, second: MessageInfo): number {
+    switch (this.sortColumn) {
+      case SORT_FROM_OR_TO:
+        return this.compareStrings(
+          this.getAddressColumnValue(first),
+          this.getAddressColumnValue(second)
+        );
+      case SORT_SUBJECT:
+        return this.compareStrings(first.subject, second.subject);
+      case SORT_DATE:
+        return this.compareNumbers(
+          first.messageDate ? first.messageDate.getTime() : 0,
+          second.messageDate ? second.messageDate.getTime() : 0
+        );
+      case SORT_SIZE:
+        return this.compareNumbers(first.size, second.size);
+      default:
+        return 0;
+    }
+  }
+
+  private getAddressColumnValue(row: MessageInfo): string {
+    const addressList = this.sortSelectedFolder === 'Sent' ? row.to : row.from;
+    const address = addressList && addressList.length > 0 ? addressList[0] : null;
+    return address ? address.name || address.address || '' : '';
+  }
+
+  private compareStrings(first: string, second: string): number {
+    return (first || '').localeCompare(second || '', undefined, {
+      sensitivity: 'base',
+      numeric: true
+    });
+  }
+
+  private compareNumbers(first: number, second: number): number {
+    return (first || 0) - (second || 0);
+  }
+
   // filter visible rows by whatever options the frontend has
   filterBy(options: Map<string, any>) {
     this.rows = this._rows;
@@ -84,7 +153,7 @@ export class MessageList extends MessageDisplay {
       {
         name: 'Date',
         cacheKey: 'date',
-        sortColumn: null,
+        sortColumn: SORT_DATE,
         rowWrapModeMuted: true,
         getValue: (rowIndex: number): string => this.getRow(rowIndex).messageDate.toJSON(),
         getFormattedValue: (datestring) => MessageTableRowTool.formatTimestamp(datestring),
@@ -93,7 +162,7 @@ export class MessageList extends MessageDisplay {
       {
         name: app.selectedFolder === 'Sent' ? 'To' : 'From',
         cacheKey: 'from',
-        sortColumn: null,
+        sortColumn: SORT_FROM_OR_TO,
         getValue: (rowIndex: number): any => app.selectedFolder === 'Sent'
           ? this.getToColumnValueForRow(rowIndex)
           : this.getFromColumnValueForRow(rowIndex),
@@ -102,7 +171,7 @@ export class MessageList extends MessageDisplay {
       {
         name: 'Subject',
         cacheKey: 'subject',
-        sortColumn: null,
+        sortColumn: SORT_SUBJECT,
         getValue: (rowIndex: number): string => this.getRow(rowIndex).subject,
         draggable: true,
         getContentPreviewText: (rowIndex): string => {
@@ -112,7 +181,7 @@ export class MessageList extends MessageDisplay {
         // tooltipText: 'Tip: Drag subject to a folder to move message(s)'
       },
       {
-        sortColumn: null,
+        sortColumn: SORT_SIZE,
         name: 'Size',
         cacheKey: 'size',
         rowWrapModeHidden: true,


### PR DESCRIPTION
## Summary

- make non-index message-list Date, From/To, Subject, and Size columns sortable
- apply the selected canvas sort to in-memory `MessageInfo` rows whenever the non-index display refreshes
- add focused coverage for sortable column metadata, row sorting, Sent-folder recipient sorting, and unread filtering after sort

Closes #1393.

## Validation

- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/common/messagelist.spec.ts --progress=false`
- `npx eslint src/app/common/messagelist.ts src/app/common/messagelist.spec.ts src/app/app.component.ts`
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `git diff --check`
- `npx ng lint`
- `npx ng build --configuration production --base-href=/app/ runbox7`
- `git diff --cached --check`
- `npm run policy`
- `git show --check --stat HEAD`
