### PR TITLE
fix(identities): improve identity validation errors

### DIFF
--- a/src/app/profiles/profile.service.spec.ts
+++ b/src/app/profiles/profile.service.spec.ts
@@ -40,6 +40,8 @@ describe('Identity', () => {
 
 describe('ProfileService', () => {
     let service: ProfileService;
+    let createFieldErrors;
+    let updateFieldErrors;
 
     const DEFAULT_EMAIL = 'a2@example.com';
     const PROFILES =        [{
@@ -137,6 +139,9 @@ describe('ProfileService', () => {
     const ALLOWED_DOMAINS = ['runbox.com', 'example.com'];
 
     beforeEach(waitForAsync(() => {
+        createFieldErrors = undefined;
+        updateFieldErrors = undefined;
+
         TestBed.configureTestingModule({
             imports: [
                 HttpClientTestingModule,
@@ -145,10 +150,15 @@ describe('ProfileService', () => {
                 { provide: RunboxWebmailAPI, useValue: {
                     me: of({first_name: 'Test', last_name: 'User'}),
                     getProfiles: () => of(PROFILES),
-                    createProfile: (newprofile) => {
+                    createProfile: (newprofile, fieldErrors?) => {
+                        createFieldErrors = fieldErrors;
                         newprofile['reference_type'] = 'aliases';
                         PROFILES.unshift(newprofile);
                         return of(PROFILES.length);
+                    },
+                    updateProfile: (_id, _values, fieldErrors?) => {
+                        updateFieldErrors = fieldErrors;
+                        return of(true);
                     },
                     getRunboxDomains: () => of([{ 'id': 1, name: 'runbox.com'}]),
                 } },
@@ -198,6 +208,33 @@ describe('ProfileService', () => {
                 expect(PROFILES.length).toBe(PROFILES.length);
                 done();
             });
-                             
+
+    });
+
+    it('passes field errors through on create', (done) => {
+        const fieldErrors = {};
+        service.create({
+            name: 'New Profile Name',
+            email: 'newp@runbox.com',
+            from_name: 'New Profile',
+            signature: 'My sig'
+        }, fieldErrors)
+            .subscribe(() => {
+                expect(createFieldErrors).toBe(fieldErrors);
+                done();
+            });
+    });
+
+    it('passes field errors through on update', (done) => {
+        const fieldErrors = {};
+        service.update(16448, {
+            name: 'Updated Profile Name',
+            email: 'updated@runbox.com',
+            from_name: 'Updated Profile',
+        }, fieldErrors)
+            .subscribe(() => {
+                expect(updateFieldErrors).toBe(fieldErrors);
+                done();
+            });
     });
 });

--- a/src/app/profiles/profile.service.ts
+++ b/src/app/profiles/profile.service.ts
@@ -21,6 +21,8 @@ import { map } from 'rxjs/operators';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { RunboxMe, RunboxWebmailAPI } from '../rmmapi/rbwebmail';
 
+export type ProfileFieldErrors = { [field: string]: string[] };
+
 export interface FromPriority {
     from_priority: number;
     id: number;
@@ -99,8 +101,8 @@ export class ProfileService {
         );
     }  
     
-    create(values): Observable<boolean> {
-      return this.rmmapi.createProfile(values).pipe(
+    create(values, fieldErrors?: ProfileFieldErrors): Observable<boolean> {
+      return this.rmmapi.createProfile(values, fieldErrors).pipe(
           map((res: boolean) => {
               this.refresh();
               return res;
@@ -116,8 +118,8 @@ export class ProfileService {
         );
     }
 
-    update(id, values): Observable<boolean> {
-        return this.rmmapi.updateProfile(id, values).pipe(
+    update(id, values, fieldErrors?: ProfileFieldErrors): Observable<boolean> {
+        return this.rmmapi.updateProfile(id, values, fieldErrors).pipe(
           map((res: boolean) => {
               this.refresh();
               return res;

--- a/src/app/profiles/profiles.editor.modal.spec.ts
+++ b/src/app/profiles/profiles.editor.modal.spec.ts
@@ -1,0 +1,125 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { Location } from '@angular/common';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import {
+    MatLegacyDialogRef as MatDialogRef,
+    MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA
+} from '@angular/material/legacy-dialog';
+import { MatLegacySnackBar as MatSnackBar } from '@angular/material/legacy-snack-bar';
+import { of } from 'rxjs';
+import { DraftDeskService } from '../compose/draftdesk.service';
+import { RMM } from '../rmm';
+import { Identity, ProfileService } from './profile.service';
+import { ProfilesEditorModalComponent } from './profiles.editor.modal';
+
+describe('ProfilesEditorModalComponent', () => {
+    let component: ProfilesEditorModalComponent;
+    let fixture: ComponentFixture<ProfilesEditorModalComponent>;
+    let dialogRef;
+    let identity: Identity;
+    let profileService;
+
+    beforeEach(waitForAsync(() => {
+        identity = Object.assign(new Identity(), {
+            email: 'identity@example.com',
+            from_name: 'Identity User',
+            name: 'Identity',
+            reference: {},
+            reference_type: 'preference',
+            is_signature_html: false,
+        });
+        dialogRef = jasmine.createSpyObj('MatDialogRef', ['close']);
+        profileService = {
+            me: {first_name: 'Test', last_name: 'User'},
+            global_domains: [],
+            create: jasmine.createSpy('create').and.returnValue(of(true)),
+            update: jasmine.createSpy('update').and.returnValue(of(true)),
+            delete: jasmine.createSpy('delete').and.returnValue(of(true)),
+            reValidate: jasmine.createSpy('reValidate'),
+        };
+
+        TestBed.configureTestingModule({
+            declarations: [
+                ProfilesEditorModalComponent,
+            ],
+            imports: [
+                FormsModule,
+            ],
+            providers: [
+                { provide: ProfileService, useValue: profileService },
+                { provide: RMM, useValue: {} },
+                { provide: Location, useValue: { prepareExternalUrl: url => url } },
+                { provide: MatSnackBar, useValue: jasmine.createSpyObj('MatSnackBar', ['open']) },
+                { provide: MatDialogRef, useValue: dialogRef },
+                { provide: DraftDeskService, useValue: {} },
+                { provide: MAT_DIALOG_DATA, useFactory: () => identity },
+            ],
+            schemas: [NO_ERRORS_SCHEMA],
+        }).compileComponents();
+    }));
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(ProfilesEditorModalComponent);
+        component = fixture.componentInstance;
+    });
+
+    it('shows clear field errors for missing name and incomplete email', () => {
+        component.is_create = true;
+        component.identity.from_name = '';
+        component.identity.email = 'test';
+
+        component.save();
+
+        expect(component.field_errors.from_name).toEqual(['Please enter a name.']);
+        expect(component.field_errors.email).toEqual(['Please enter an email address.']);
+        expect(profileService.create).not.toHaveBeenCalled();
+        expect(dialogRef.close).not.toHaveBeenCalled();
+    });
+
+    it('shows a clear field error for invalid reply-to addresses', () => {
+        component.is_create = true;
+        component.is_different_reply_to = true;
+        component.identity.reply_to = 'reply-to';
+
+        component.save();
+
+        expect(component.field_errors.reply_to).toEqual(['Please enter an email address.']);
+        expect(profileService.create).not.toHaveBeenCalled();
+        expect(dialogRef.close).not.toHaveBeenCalled();
+    });
+
+    it('passes the field errors object to profile creation', () => {
+        component.is_create = true;
+
+        component.save();
+
+        expect(profileService.create).toHaveBeenCalledWith(
+            jasmine.objectContaining({
+                email: 'identity@example.com',
+                from_name: 'Identity User',
+            }),
+            component.field_errors
+        );
+        expect(dialogRef.close).toHaveBeenCalledWith({});
+    });
+});

--- a/src/app/profiles/profiles.editor.modal.ts
+++ b/src/app/profiles/profiles.editor.modal.ts
@@ -20,11 +20,12 @@ import { Component, Input, Inject, OnDestroy } from '@angular/core';
 
 import { MatLegacyDialogRef as MatDialogRef, MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA } from '@angular/material/legacy-dialog';
 import { MatLegacySnackBar as MatSnackBar } from '@angular/material/legacy-snack-bar';
-import { Identity, ProfileService } from './profile.service';
+import { Identity, ProfileFieldErrors, ProfileService } from './profile.service';
 import { RMM } from '../rmm';
 import { Location } from '@angular/common';
 import { DraftDeskService } from '../compose/draftdesk.service';
 import { TinyMCEPlugin } from '../rmm/plugin/tinymce.plugin';
+import { isValidEmail } from '../compose/emailvalidator';
 
 @Component({
     selector: 'app-profiles-edit',
@@ -34,7 +35,7 @@ import { TinyMCEPlugin } from '../rmm/plugin/tinymce.plugin';
 
 export class ProfilesEditorModalComponent implements OnDestroy {
     @Input() value: any[];
-    field_errors: Identity;
+    field_errors: ProfileFieldErrors = {};
     allowed_domains = [];
     is_valid = false;
 
@@ -93,6 +94,11 @@ export class ProfilesEditorModalComponent implements OnDestroy {
         }
     }
     save() {
+        this.field_errors = {};
+        if (!this.validate_identity()) {
+            return;
+        }
+
         if (this.is_create) {
             this.create();
         } else { this.update(); }
@@ -113,7 +119,7 @@ export class ProfilesEditorModalComponent implements OnDestroy {
             is_signature_html: (identity.is_signature_html ? 1 : 0),
             is_smtp_enabled: (identity.is_smtp_enabled ? 1 : 0),
         };
-        this.profileService.create(values).subscribe(
+        this.profileService.create(values, this.field_errors).subscribe(
             res => this.close()
         );
     }
@@ -138,7 +144,7 @@ export class ProfilesEditorModalComponent implements OnDestroy {
             is_signature_html: (identity.is_signature_html ? 1 : 0),
             is_smtp_enabled: (identity.is_smtp_enabled ? 1 : 0),
         };
-      this.profileService.update(this.identity.id, values).subscribe(
+      this.profileService.update(this.identity.id, values, this.field_errors).subscribe(
         res => this.close()
       );
     }
@@ -164,6 +170,22 @@ export class ProfilesEditorModalComponent implements OnDestroy {
                 this.identity.reply_to = '';
             }
         }
+    }
+    validate_identity(): boolean {
+        if (!this.identity.from_name || !this.identity.from_name.trim()) {
+            this.field_errors.from_name = ['Please enter a name.'];
+        }
+
+        if (!this.identity.email || !isValidEmail(this.identity.email)) {
+            this.field_errors.email = ['Please enter an email address.'];
+        }
+
+        if (this.is_different_reply_to &&
+            (!this.identity.reply_to || !isValidEmail(this.identity.reply_to))) {
+            this.field_errors.reply_to = ['Please enter an email address.'];
+        }
+
+        return !Object.keys(this.field_errors).some(field => this.field_errors[field].length > 0);
     }
     get_form_field_style() {
         const styles = {};

--- a/src/app/rmmapi/rbwebmail.spec.ts
+++ b/src/app/rmmapi/rbwebmail.spec.ts
@@ -21,7 +21,10 @@ import { TestBed } from '@angular/core/testing';
 import { RunboxWebmailAPI } from './rbwebmail';
 import { FolderListEntry } from '../common/folderlistentry';
 import { MatLegacyDialogModule as MatDialogModule } from '@angular/material/legacy-dialog';
-import { MatLegacySnackBarModule as MatSnackBarModule } from '@angular/material/legacy-snack-bar';
+import {
+    MatLegacySnackBar as MatSnackBar,
+    MatLegacySnackBarModule as MatSnackBarModule
+} from '@angular/material/legacy-snack-bar';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { MessageCache } from './messagecache';
 import { firstValueFrom } from 'rxjs';
@@ -45,6 +48,69 @@ describe('RBWebMail', () => {
                 } },
             ]
         });
+    });
+
+    it('maps profile validation errors to field errors', async () => {
+        const rmmapi = TestBed.inject(RunboxWebmailAPI);
+        const httpTestingController = TestBed.inject(HttpTestingController);
+        const snackBar = TestBed.inject(MatSnackBar);
+        const fieldErrors = {};
+        let emitted = false;
+        let completed = false;
+        spyOn(snackBar, 'open');
+        spyOn(rmmapi.rblocale, 'translate').and.callFake(key => key);
+
+        rmmapi.createProfile({
+            email: 'test',
+            from_name: '',
+        }, fieldErrors).subscribe({
+            next: () => emitted = true,
+            complete: () => completed = true,
+        });
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        const req = httpTestingController.expectOne('/rest/v1/profile');
+        req.flush({
+            status: 'error',
+            field_errors: {
+                email: ['Invalid email address'],
+                from_name: ['Required'],
+            },
+        });
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(fieldErrors['email']).toEqual(['Please enter an email address.']);
+        expect(fieldErrors['from_name']).toEqual(['Please enter a name.']);
+        expect(emitted).toBeFalse();
+        expect(completed).toBeTrue();
+        expect(snackBar.open).not.toHaveBeenCalled();
+    });
+
+    it('maps profile alias ownership errors to the email field', async () => {
+        const rmmapi = TestBed.inject(RunboxWebmailAPI);
+        const httpTestingController = TestBed.inject(HttpTestingController);
+        const snackBar = TestBed.inject(MatSnackBar);
+        const fieldErrors = {};
+        spyOn(snackBar, 'open');
+        spyOn(rmmapi.rblocale, 'translate').and.callFake(key => key);
+
+        rmmapi.updateProfile(11, {
+            email: 'alias@runbox.com',
+            from_name: 'Alias User',
+        }, fieldErrors).subscribe();
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        const req = httpTestingController.expectOne('/rest/v1/profile/11');
+        req.flush({
+            status: 'error',
+            errors: ['Please create the alias first.'],
+        });
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(fieldErrors['email']).toEqual([
+            'Please enter an email address that belongs to this account, or create it on the Email Aliases screen first.'
+        ]);
+        expect(snackBar.open).not.toHaveBeenCalled();
     });
 
     it('should cache message contents', async () => {

--- a/src/app/rmmapi/rbwebmail.ts
+++ b/src/app/rmmapi/rbwebmail.ts
@@ -41,6 +41,14 @@ import { SavedSearchStorage } from '../saved-searches/saved-searches.service';
 import { PreferencesResult } from '../common/preferences.service';
 import { Domain } from '../dkim/domain.service';
 
+type FieldErrors = { [field: string]: string[] };
+
+interface BackendResponse {
+    status?: string;
+    errors?: unknown;
+    field_errors?: { [field: string]: unknown };
+}
+
 export class MessageFields {
     id: number;
     subject: string;
@@ -167,6 +175,9 @@ export class RunboxWebmailAPI {
     public messageFlagChangeSubject: Subject<MessageFlagChange> = new Subject();
     public me: AsyncSubject<RunboxMe> = new AsyncSubject();
     public rblocale: any;
+
+    private readonly profileAliasOwnershipMessage =
+        'Please enter an email address that belongs to this account, or create it on the Email Aliases screen first.';
 
     public last_on_interval;
 
@@ -417,22 +428,22 @@ export class RunboxWebmailAPI {
             );
         }
 
-    subscribeShowBackendErrors(req: any) {
-        req.subscribe((res: any) => {
+    subscribeShowBackendErrors(req: Observable<BackendResponse>, responseErrorHandler?: (res: BackendResponse) => boolean) {
+        req.subscribe((res: BackendResponse) => {
+            if (responseErrorHandler && responseErrorHandler(res)) {
+                return;
+            }
             this.showBackendErrors(res);
         });
     }
 
-    showBackendErrors(res: any) {
+    showBackendErrors(res: BackendResponse) {
         if (res.status === 'error' || res.status === 'warning') {
             console.log(res);
-            if (res.errors && res.errors.length) {
-                const error_msg = res.errors.map((key) => {
-                    let loc = this.rblocale.translate(key).replace('_', ' ');
-                    if (loc.length === 0) {
-                        loc = key;
-                    }
-                    return loc;
+            const errors = this.asErrorList(res.errors);
+            if (errors.length) {
+                const error_msg = errors.map((key) => {
+                    return this.localizeBackendError(key);
                 }).join('. ');
                 const error_formatted = error_msg.charAt(0).toUpperCase() + error_msg.slice(1);
                 this.snackBar.open(error_formatted, 'Dismiss');
@@ -440,6 +451,105 @@ export class RunboxWebmailAPI {
                 this.snackBar.open('There was an unknown error and this action cannot be completed.', 'Dismiss');
             }
         }
+    }
+
+    private handleProfileFieldErrors(res: BackendResponse, fieldErrors?: FieldErrors): boolean {
+        if (!fieldErrors || res.status !== 'error') {
+            return false;
+        }
+
+        const mappedErrors = this.profileFieldErrors(res);
+        const mappedFields = Object.keys(mappedErrors);
+
+        if (!mappedFields.length) {
+            return false;
+        }
+
+        mappedFields.forEach(field => fieldErrors[field] = mappedErrors[field]);
+        return true;
+    }
+
+    private profileFieldErrors(res: BackendResponse): FieldErrors {
+        const fieldErrors: FieldErrors = {};
+
+        if (res.field_errors) {
+            Object.keys(res.field_errors).forEach(field => {
+                const messages = this.asErrorList(res.field_errors[field])
+                    .map(error => this.normalizeProfileFieldError(field, error))
+                    .filter(error => error.length > 0);
+
+                if (messages.length) {
+                    fieldErrors[field] = messages;
+                }
+            });
+        }
+
+        const generalMessages = this.asErrorList(res.errors)
+            .map(error => this.localizeBackendError(error));
+        if (generalMessages.some(message => this.isProfileAliasOwnershipError(message))) {
+            fieldErrors.email = [this.profileAliasOwnershipMessage];
+        }
+
+        return fieldErrors;
+    }
+
+    private normalizeProfileFieldError(field: string, error: unknown): string {
+        const message = this.localizeBackendError(error);
+        const normalized = message.toLowerCase();
+
+        if (field === 'email') {
+            if (this.isProfileAliasOwnershipError(message)) {
+                return this.profileAliasOwnershipMessage;
+            }
+            if (this.isRequiredOrInvalid(normalized)) {
+                return 'Please enter an email address.';
+            }
+        }
+
+        if (field === 'reply_to' && this.isRequiredOrInvalid(normalized)) {
+            return 'Please enter an email address.';
+        }
+
+        if ((field === 'from_name' || field === 'name') && this.isRequiredOrInvalid(normalized)) {
+            return 'Please enter a name.';
+        }
+
+        return message;
+    }
+
+    private asErrorList(errors: unknown): unknown[] {
+        if (!errors) {
+            return [];
+        }
+
+        return Array.isArray(errors) ? errors : [errors];
+    }
+
+    private localizeBackendError(error: unknown): string {
+        const key = String(error || '');
+        let translated = this.rblocale.translate(key);
+        translated = translated ? String(translated).replace(/_/g, ' ') : '';
+
+        if (!translated.length) {
+            translated = key;
+        }
+
+        return translated;
+    }
+
+    private isProfileAliasOwnershipError(message: string): boolean {
+        const normalized = message.toLowerCase();
+        return normalized.includes('create') &&
+            normalized.includes('alias') &&
+            normalized.includes('first');
+    }
+
+    private isRequiredOrInvalid(message: string): boolean {
+        return message.includes('required') ||
+            message.includes('valid') ||
+            message.includes('invalid') ||
+            message.includes('missing') ||
+            message.includes('empty');
     }
 
     createFolder(parentFolderId: number, newFolderName: string, order: number[]): Observable<boolean> {
@@ -575,22 +685,22 @@ export class RunboxWebmailAPI {
             }));
     }
 
-    public createProfile(profileData: any): Observable<boolean> {
+    public createProfile(profileData: any, fieldErrors?: FieldErrors): Observable<boolean> {
         const req = this.http.post(
             '/rest/v1/profile',
             profileData
         ).pipe(share());
-        this.subscribeShowBackendErrors(req);
+        this.subscribeShowBackendErrors(req, res => this.handleProfileFieldErrors(res, fieldErrors));
         return req.pipe(filter((res: any) => res.status === 'success'));
     }
 
     // FIXME: This should be PATCH
-    public updateProfile(profileId: number, profileData: any): Observable<boolean> {
+    public updateProfile(profileId: number, profileData: any, fieldErrors?: FieldErrors): Observable<boolean> {
         const req = this.http.put(
             '/rest/v1/profile/' + profileId,
             profileData
         ).pipe(share());
-        this.subscribeShowBackendErrors(req);
+        this.subscribeShowBackendErrors(req, res => this.handleProfileFieldErrors(res, fieldErrors));
         return req.pipe(filter((res: any) => res.status === 'success'));
     }
 


### PR DESCRIPTION
Fixes #1098

## Summary
- validate the identity editor's From Name, Email, and Reply-to fields before submitting, with clear field-level messages for empty names and incomplete email addresses
- pass the editor's field-error state through `ProfileService` to profile create/update requests so backend validation errors render in the relevant field instead of only as a generic snackbar
- map profile backend validation and the "create alias first" ownership error to clearer identity-editor messages, including the Email Aliases screen guidance requested in the issue

## Tests
- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/profiles/profiles.editor.modal.spec.ts --include=src/app/profiles/profile.service.spec.ts --include=src/app/rmmapi/rbwebmail.spec.ts` (`18 SUCCESS`; existing locale 404 warnings)
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npx eslint src/app/profiles/profile.service.ts src/app/profiles/profiles.editor.modal.ts src/app/rmmapi/rbwebmail.ts src/app/profiles/profile.service.spec.ts src/app/profiles/profiles.editor.modal.spec.ts src/app/rmmapi/rbwebmail.spec.ts` (0 errors; existing warnings)
- `git diff --check`
- `npx ng lint` (0 errors; 767 existing warnings)
- `npm run policy` (passes; historical commit-message warnings only, current commit OK)
- `npx ng test --watch=false --browsers=FirefoxHeadless` (`252 SUCCESS`, `2 skipped`; existing console/template warnings)
- `node src/build/pre-build.js; npx ng build --configuration production --base-href=/app/ runbox7; $buildExit=$LASTEXITCODE; node src/build/post-build.js; exit $buildExit` (passes; existing Angular/CommonJS/theme warnings)
