### PR TITLE
Show domain names on subscription renewals

### DIFF
--- a/src/app/account-app/account-renewals.component.html
+++ b/src/app/account-app/account-renewals.component.html
@@ -23,6 +23,9 @@
                 <td mat-cell *matCellDef="let p">
                   <span style="font-weight: bold;"> {{ p.name }} </span>
                     <span *ngIf="p.pid === current_subscription"> – your current subscription </span>
+                    <div *ngIf="p.subtype === 'domain'" style="font-size: smaller;">
+                        Domain: {{ domainDisplayText(p) }}
+                    </div>
                 </td>
                 <td mat-footer-cell *matFooterCellDef>
                   <span *ngIf="!showExpired">
@@ -113,6 +116,10 @@
                                         <mat-icon svgIcon="information-outline"></mat-icon>
                                     </button>
                                 </td>
+                            </tr>
+                            <tr *ngIf="p.subtype === 'domain'">
+                                <td> Domain </td>
+                                <td> {{ domainDisplayText(p) }} </td>
                             </tr>
                             <tr>
                                 <td> Active From </td>

--- a/src/app/account-app/account-renewals.component.spec.ts
+++ b/src/app/account-app/account-renewals.component.spec.ts
@@ -1,0 +1,149 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { Observable, of, Subject, throwError } from 'rxjs';
+
+import { AccountRenewalsComponent } from './account-renewals.component';
+
+describe('AccountRenewalsComponent', () => {
+    interface TestActiveProduct {
+        pid: number;
+        apid: number;
+        type: string;
+        subtype: string;
+        name: string;
+        quantity: number;
+        price: string;
+        currency: string;
+        active: boolean;
+        active_from: unknown;
+        active_until: unknown;
+        quotas: Record<string, unknown>;
+        associated_domain?: string;
+        associated_domain_loading?: boolean;
+        associated_domain_failed?: boolean;
+    }
+
+    function activeProduct(properties: Partial<TestActiveProduct> = {}): TestActiveProduct {
+        return {
+            pid: 2001,
+            apid: 3001,
+            type: 'subscription',
+            subtype: 'domain',
+            name: 'Domain hosting',
+            quantity: 1,
+            price: '19.95',
+            currency: 'USD',
+            active: true,
+            active_from: '2026-01-01T00:00:00Z',
+            active_until: '2027-01-01T00:00:00Z',
+            quotas: {},
+            ...properties,
+        };
+    }
+
+    function createComponent(products: TestActiveProduct[], domainResponse: Observable<string> = of('example.net')) {
+        const mobileQuery = {
+            matches: false,
+            changed: new Subject<boolean>(),
+        };
+        const cart = {
+            items: of([]),
+            add: jasmine.createSpy('add').and.returnValue(Promise.resolve()),
+            contains: jasmine.createSpy('contains').and.returnValue(Promise.resolve(false)),
+        };
+        const rmmapi = {
+            me: of({ subscription: 2001 }),
+            getActiveProducts: jasmine.createSpy('getActiveProducts').and.returnValue(of(products)),
+            getProductDomain: jasmine.createSpy('getProductDomain').and.returnValue(domainResponse),
+            setProductAutorenew: jasmine.createSpy('setProductAutorenew').and.returnValue(of({})),
+        };
+        const router = {
+            navigateByUrl: jasmine.createSpy('navigateByUrl'),
+        };
+        const snackbar = {
+            open: jasmine.createSpy('open'),
+        };
+        const rmm = {
+            account_storage: {
+                getUsage: jasmine.createSpy('getUsage').and.returnValue(of({ result: {} })),
+            },
+        };
+
+        const component = new AccountRenewalsComponent(
+            mobileQuery as unknown as ConstructorParameters<typeof AccountRenewalsComponent>[0],
+            cart as unknown as ConstructorParameters<typeof AccountRenewalsComponent>[1],
+            {} as unknown as ConstructorParameters<typeof AccountRenewalsComponent>[2],
+            rmmapi as unknown as ConstructorParameters<typeof AccountRenewalsComponent>[3],
+            router as unknown as ConstructorParameters<typeof AccountRenewalsComponent>[4],
+            snackbar as unknown as ConstructorParameters<typeof AccountRenewalsComponent>[5],
+            rmm as unknown as ConstructorParameters<typeof AccountRenewalsComponent>[6],
+        );
+
+        return { cart, component, rmmapi, router, snackbar };
+    }
+
+    it('loads associated domain names for domain subscriptions', () => {
+        const domainProduct = activeProduct();
+        const { component, rmmapi } = createComponent([domainProduct], of('example.net'));
+
+        expect(rmmapi.getProductDomain).toHaveBeenCalledWith(3001);
+        expect(rmmapi.getProductDomain.calls.count()).toBe(1);
+        expect(domainProduct.associated_domain).toBe('example.net');
+        expect(domainProduct.associated_domain_loading).toBe(false);
+        expect(domainProduct.associated_domain_failed).toBe(false);
+        expect(component.domainDisplayText(component.active_products[0])).toBe('example.net');
+    });
+
+    it('does not fetch domains for non-domain subscriptions', () => {
+        const subscriptionProduct = activeProduct({
+            apid: 3002,
+            subtype: 'main',
+            name: 'Runbox Medium',
+        });
+        const { component, rmmapi } = createComponent([subscriptionProduct]);
+
+        expect(rmmapi.getProductDomain).not.toHaveBeenCalled();
+        expect(component.domainDisplayText(component.active_products[0])).toBe('');
+    });
+
+    it('shows unavailable text when the associated domain cannot be loaded', () => {
+        const domainProduct = activeProduct();
+        const { component } = createComponent(
+            [domainProduct],
+            throwError(() => new Error('domain lookup failed')),
+        );
+
+        expect(domainProduct.associated_domain).toBeUndefined();
+        expect(domainProduct.associated_domain_loading).toBe(false);
+        expect(domainProduct.associated_domain_failed).toBe(true);
+        expect(component.domainDisplayText(component.active_products[0])).toBe('Domain unavailable');
+    });
+
+    it('uses the loaded associated domain when renewing a domain subscription', () => {
+        const domainProduct = activeProduct();
+        const { component, rmmapi, router } = createComponent([domainProduct], of('example.net'));
+        rmmapi.getProductDomain.calls.reset();
+
+        component.renewDomain(component.active_products[0]);
+
+        expect(rmmapi.getProductDomain).not.toHaveBeenCalled();
+        expect(router.navigateByUrl).toHaveBeenCalledWith('/domainregistration?renew_domain=example.net');
+    });
+});

--- a/src/app/account-app/account-renewals.component.ts
+++ b/src/app/account-app/account-renewals.component.ts
@@ -30,14 +30,42 @@ import { SubAccountRenewalDialogComponent } from './sub-account-renewal-dialog';
 import { DataUsageInterface } from '../rmm/account-storage';
 import { AsyncSubject } from 'rxjs';
 import { RMM } from '../rmm';
+import { Decimal } from 'decimal.js-light';
 
 import moment from 'moment';
 
 const columnsDefault = ['renewal_name', 'quantity', 'price', 'active_from', 'active_until', 'hints', 'recur', 'renew'];
 const columnsMobile = ['renewal_name'];
 
-// TODO define it as an interface
-type ActiveProduct = any;
+interface ActiveProduct {
+    [property: string]: unknown;
+    active: boolean;
+    active_from: moment.Moment;
+    active_until: moment.Moment;
+    apid: number;
+    associated_domain?: string;
+    associated_domain_failed?: boolean;
+    associated_domain_loading?: boolean;
+    can_renew?: boolean;
+    changingAutorenew?: Promise<unknown>;
+    currency: string;
+    expired?: boolean;
+    expired_over_2_years?: boolean;
+    expires_soon?: boolean;
+    name: string;
+    ordered?: boolean;
+    pid: number;
+    price: string;
+    quantity: Decimal;
+    quotas: {
+        [quota: string]: {
+            quota: number;
+        };
+    };
+    subaccounts?: string[];
+    subtype?: string;
+    type: string;
+}
 
 @Component({
     selector: 'app-account-renewals-component',
@@ -91,6 +119,8 @@ export class AccountRenewalsComponent {
                 // no renewals for trials; domains handled separately
                 p.can_renew = (p.pid !== 1000) && (p.subtype !== 'domain');
 
+                this.loadAssociatedDomain(p);
+
                 return p;
             });
 
@@ -122,9 +152,14 @@ export class AccountRenewalsComponent {
     }
 
     renewDomain(p: ActiveProduct) {
+        if (p.associated_domain) {
+            this.openDomainRenewal(p.associated_domain);
+            return;
+        }
+
         this.rmmapi.getProductDomain(p.apid).subscribe(
             domain => {
-                this.router.navigateByUrl('/domainregistration?renew_domain=' + domain);
+                this.openDomainRenewal(domain);
             },
             _err => {
                 this.snackbar.open('Failed to determine domain for the product. Try again later or contact Runbox Support', 'Okay');
@@ -181,6 +216,43 @@ export class AccountRenewalsComponent {
                 }
             );
         });
+    }
+
+    domainDisplayText(p: ActiveProduct): string {
+        if (p.associated_domain) {
+            return p.associated_domain;
+        }
+        if (p.associated_domain_loading) {
+            return 'Loading domain...';
+        }
+        if (p.associated_domain_failed) {
+            return 'Domain unavailable';
+        }
+        return '';
+    }
+
+    private loadAssociatedDomain(p: ActiveProduct) {
+        if (p.subtype !== 'domain') {
+            return;
+        }
+
+        p.associated_domain_loading = true;
+        p.associated_domain_failed = false;
+
+        this.rmmapi.getProductDomain(p.apid).subscribe(
+            domain => {
+                p.associated_domain = domain;
+                p.associated_domain_loading = false;
+            },
+            _err => {
+                p.associated_domain_failed = true;
+                p.associated_domain_loading = false;
+            },
+        );
+    }
+
+    private openDomainRenewal(domain: string) {
+        this.router.navigateByUrl('/domainregistration?renew_domain=' + encodeURIComponent(domain));
     }
 }
 


### PR DESCRIPTION
## Summary

- load the associated domain name for each domain subscription using the existing `account_product/product_domain/<apid>` endpoint
- show that domain under the product name in the subscriptions table and in the mobile expanded details
- reuse the loaded domain when opening the domain renewal flow, with the existing lookup as a fallback
- add focused coverage for successful lookups, failed lookups, non-domain products, and cached renewal navigation

Closes #1508.
Closes #1261.

## Testing

- `npx ng test runbox7 --watch=false --include src/app/account-app/account-renewals.component.spec.ts` (`4 SUCCESS`)
- `npx eslint src/app/account-app/account-renewals.component.ts src/app/account-app/account-renewals.component.html src/app/account-app/account-renewals.component.spec.ts`
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npm run lint -- --quiet`
- `npm run policy` (exits 0; reports existing historical upstream commit-message warnings)
- `npx ng test runbox7 --watch=false` (`249 SUCCESS`, `2 skipped`; existing Angular template warnings from unrelated specs)
- `npx ng build --configuration production --base-href=/app/ runbox7` (passes with existing CommonJS/theme/unused-file warnings)
- `node src/build/post-build.js`

Note: `npm run build` is Bash-shaped and fails under this PowerShell shell by passing `RES=$?` through to Angular, so I ran the production build steps directly.
