### PR TITLE
Preserve expanded message header order

### DIFF
--- a/src/app/mailviewer/singlemailviewer.component.html
+++ b/src/app/mailviewer/singlemailviewer.component.html
@@ -257,7 +257,7 @@
           </div>
         </ng-container>
         <table *ngIf="showAllHeaders">
-          <tr *ngFor="let header of mailObj.headers | keyvalue" style="font-size: 12px;">
+          <tr *ngFor="let header of mailObj.headers | keyvalue: keepHeaderOrder" style="font-size: 12px;">
             <td style="vertical-align: top; white-space: nowrap; font-weight: bold;">{{header.key}}</td>
             <td style="vertical-align: top;">
               <span *ngIf="header.value.html" [innerHTML]="header.value.html"></span>

--- a/src/app/mailviewer/singlemailviewer.component.spec.ts
+++ b/src/app/mailviewer/singlemailviewer.component.spec.ts
@@ -231,6 +231,21 @@ describe('SingleMailViewerComponent', () => {
       expect(component.mailObj.attachments[1].downloadURL.indexOf('blob:')).toBe(0);
     }));
 
+  it('shows expanded headers in message order', fakeAsync(() => {
+      component.messageId = 22;
+      component.showAllHeaders = true;
+      fixture.detectChanges();
+      tick(1);
+      fixture.detectChanges();
+
+      const headerRows: HTMLTableRowElement[] = Array.from(
+        fixture.nativeElement.querySelectorAll('#messageHeader table tr')
+      );
+      const headerNames = headerRows.map(row => row.cells[0].textContent.trim());
+
+      expect(headerNames.slice(0, 3)).toEqual(['from', 'date', 'subject']);
+    }));
+
   describe('mailto: link interceptor', () => {
     let messageContentsElement: HTMLElement;
     let mailtoLink: HTMLAnchorElement;

--- a/src/app/mailviewer/singlemailviewer.component.ts
+++ b/src/app/mailviewer/singlemailviewer.component.ts
@@ -27,6 +27,7 @@ import {
   DoCheck
 } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
+import { KeyValue } from '@angular/common';
 import DOMPurify from 'dompurify';
 import { HttpClient, HttpEvent, HttpEventType } from '@angular/common/http';
 
@@ -119,6 +120,10 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
   contacts: Contact[] = [];
 
   public SUPPORTS_IFRAME_SANDBOX = 'sandbox' in document.createElement('iframe');
+
+  public keepHeaderOrder(_a: KeyValue<string, unknown>, _b: KeyValue<string, unknown>): number {
+    return 0;
+  }
 
   height = 0;
   previousHeight: number;


### PR DESCRIPTION
## Summary

- preserve the message payload order when rendering the expanded header table
- keep the existing `keyvalue` pipe rendering, but give it a comparator that does not alphabetize header names
- add focused coverage proving expanded headers render as `from`, `date`, `subject` in the same order as the message data

Closes #1110.

## Testing

- `npx ng test runbox7 --watch=false --include src/app/mailviewer/singlemailviewer.component.spec.ts` (`9 SUCCESS`; existing `mat-list` test-template warnings)
- `npx eslint src/app/mailviewer/singlemailviewer.component.ts src/app/mailviewer/singlemailviewer.component.html src/app/mailviewer/singlemailviewer.component.spec.ts` (exits 0 with existing warnings in these files)
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npm run lint -- --quiet`
- `npm run policy` (exits 0; reports existing historical upstream commit-message warnings)
- `npx ng test runbox7 --watch=false` (`246 SUCCESS`, `2 skipped`; existing unrelated template/console warnings)
- `npx ng build --configuration production --base-href=/app/ runbox7` (passes with existing CommonJS/theme/unused-file warnings)
- `node src/build/post-build.js`
