### PR TITLE
fix(compose): handle reply all without to header

### DIFF
--- a/src/app/compose/draftdesk.service.spec.ts
+++ b/src/app/compose/draftdesk.service.spec.ts
@@ -302,6 +302,38 @@ Subject: Test subject <br />
         expect(draft.isUnsaved()).toBe(true);
         done();
     });
+    it('Reply: Address with object, reply to all with empty To and CC', (done) => {
+        console.log('Reply test: Address with object, reply to all with empty To and CC');
+        const draft = DraftFormModel.reply({
+            headers: {
+                'message-id': 'themessageid12123abcdef',
+            },
+            from: [
+                {address: 'from@runbox.com', name: 'From'}
+            ],
+            to: '',
+            cc: [
+                {address: 'to@runbox.com', name: 'To'},
+                {address: 'cc@runbox.com', name: 'CC'}
+            ],
+            date: mailDate,
+            subject: 'Test subject',
+            text: 'blabla\nabcde',
+            rawtext: 'blabla\nabcde',
+            html: '<p>blabla</p><p>abcde</p>'
+        },
+        [ Identity.fromObject({'email':'to@runbox.com'})],
+        true, false);
+
+        expect(draft.subject).toBe('Re: Test subject');
+        expect(draft.from).toBe('to@runbox.com');
+        expect(draft.to[0].nameAndAddress).toBe('"From" <from@runbox.com>');
+        expect(draft.cc.length).toBe(1);
+        expect(draft.cc[0].nameAndAddress).toBe('"CC" <cc@runbox.com>');
+        expect(draft.msg_body).toBe(`\n\nOn ${formatDate(mailDate)}, "From" <from@runbox.com> wrote:\n> blabla\n> abcde`);
+        expect(draft.isUnsaved()).toBe(true);
+        done();
+    });
     it('Reply: Address with MAI', (done) => {
         console.log('Reply test: Address with MAI');
         const draft = DraftFormModel.reply({

--- a/src/app/compose/draftdesk.service.ts
+++ b/src/app/compose/draftdesk.service.ts
@@ -107,10 +107,12 @@ export class DraftFormModel {
             ret.to = sender;
         }
 
+        const originalTo = DraftFormModel.addressList(mailObj.to);
+        const originalCc = DraftFormModel.addressList(mailObj.cc);
+
         // If all, also add all the other To/CC folks:
-        // Guard: sometimes mailObj.to is not an array!?
-        if (all && mailObj.to && Array.isArray(mailObj.to)) {
-            ret.to = ret.to.concat(mailObj.to
+        if (all) {
+            ret.to = ret.to.concat(originalTo
                 .filter((addr) =>
                     froms.find(fromObj => fromObj.email === addr.address) ? false : true
                        )
@@ -118,8 +120,8 @@ export class DraftFormModel {
                     return new MailAddressInfo(addr.name, addr.address);
                 })
                                   );
-            if (mailObj.cc) {
-                ret.cc = mailObj.cc
+            if (originalCc.length) {
+                ret.cc = originalCc
                     .filter((addr) => froms.find(fromObj => fromObj.email === addr.address) ? false : true)
                     .map((addr) => {
                         return new MailAddressInfo(addr.name, addr.address);
@@ -156,6 +158,12 @@ export class DraftFormModel {
             ret.useHTML = true;
         }
         return ret;
+    }
+
+    private static addressList(addresses: any): Array<{ name: string; address: string }> {
+        return Array.isArray(addresses)
+            ? addresses.filter(addr => addr && typeof addr.address === 'string')
+            : [];
     }
 
     public static trimmedPreview(preview: string): string {
@@ -219,9 +227,10 @@ ${mailObj.sanitized_html}`;
     private setFromForResponse(mailObj, froms: Identity[]): void {
         if (froms.length > 0) {
             this.from = (
-                [].concat(mailObj.to || []).concat(mailObj.cc || []).find(
-                    addr => froms.find(fromObj => fromObj.email === addr.address.toLowerCase())
-                ) || { address: froms[0].email }
+                DraftFormModel.addressList(mailObj.to)
+                    .concat(DraftFormModel.addressList(mailObj.cc))
+                    .find(addr => froms.find(fromObj => fromObj.email === addr.address.toLowerCase()))
+                || { address: froms[0].email }
             ).address.toLowerCase();
         } else {
             console.error('DraftDesk: No froms passed to setFromForResponse');


### PR DESCRIPTION
## Summary

- Normalize message `to`/`cc` address fields before Reply All uses them.
- Allow Reply All to keep CC recipients when a message has no parsed `To` header.
- Avoid reading `.address` from the empty-string placeholder produced by the message viewer for missing headers.

Fixes #1092.

## Validation

- `npx ng test runbox7 --watch=false --include=src/app/compose/draftdesk.service.spec.ts`
- `npx eslint src/app/compose/draftdesk.service.ts src/app/compose/draftdesk.service.spec.ts --quiet`
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npm run lint -- --quiet`
- `npm run policy` (exits 0; still prints existing historical upstream commit-message warnings)
- `npx ng test runbox7 --watch=false` (`246 SUCCESS`, `2 skipped` on retry; first full run hit an unrelated `RBWebMail should cache message contents` timeout, and that focused spec passed with `3 SUCCESS`)
- `npx ng build --configuration production --base-href=/app/ runbox7`
- `node src/build/post-build.js`
- `git diff --check`
- `git show --check --stat HEAD`
