### PR TITLE
feat(folder): sort user folders alphabetically

### DIFF
--- a/src/app/folder/folderlist.component.html
+++ b/src/app/folder/folderlist.component.html
@@ -1,5 +1,9 @@
 <div id="folderListHeader" style="display: flex">
   <span mat-subheader style="flex-grow: 1">Folders</span>
+  <button mat-icon-button id="sortFoldersAlphabeticallyButton"
+    matTooltip="Sort folders alphabetically" (click)="sortFoldersAlphabetically()">
+    <mat-icon svgIcon="sort-alphabetical-ascending"></mat-icon>
+  </button>
   <button mat-icon-button id="createFolderButton" matTooltip="Create folder..." (click)="addFolder()">
     <mat-icon svgIcon="plus"></mat-icon>
   </button>

--- a/src/app/folder/folderlist.component.spec.ts
+++ b/src/app/folder/folderlist.component.spec.ts
@@ -32,9 +32,12 @@ import { DialogModule } from '../dialog/dialog.module';
 import { HotkeysService } from 'angular2-hotkeys';
 
 class MatDialogMock {
+    public closedValue = 'testtest';
+
     open() {
       return {
-        afterClosed: () => of('testtest')
+        componentInstance: {},
+        afterClosed: () => of(this.closedValue)
       };
     }
   }
@@ -228,6 +231,67 @@ describe('FolderListComponent', () => {
         expect(rearrangedFolders.map(f => f.folderId)).toEqual([1, 7, 6, 5, 3, 2, 4]);
         expect(rearrangedFolders.map(f => f.folderLevel)).toEqual([0, 0, 0, 0, 1, 2, 1]);
         expect(moveEvent.order).toEqual([1, 7, 6, 5, 3, 2, 4]);
+    });
+
+    it('should sort user folders alphabetically without changing parents', async () => {
+        (dialog as any).closedValue = true;
+
+        const comp = new FolderListComponent(dialog, hotkeyMock);
+        comp.selectedFolder = 'Inbox';
+        comp.folders = new BehaviorSubject([
+            new FolderListEntry(1, 50, 40, 'inbox', 'Inbox', 'Inbox', 0),
+            new FolderListEntry(2, 50, 40, 'user', 'Zebra', 'Zebra', 0),
+            new FolderListEntry(3, 50, 40, 'user', 'Gamma', 'Zebra.Gamma', 1),
+            new FolderListEntry(4, 50, 40, 'user', 'Alpha', 'Zebra.Alpha', 1),
+            new FolderListEntry(5, 50, 40, 'sent', 'Sent', 'Sent', 0),
+            new FolderListEntry(6, 50, 40, 'user', 'Apple', 'Apple', 0),
+            new FolderListEntry(7, 50, 40, 'user', 'Delta', 'Apple.Delta', 1),
+            new FolderListEntry(8, 50, 40, 'user', 'Charlie', 'Apple.Charlie', 1),
+            new FolderListEntry(9, 50, 40, 'user', 'Mango', 'Mango', 0),
+        ]);
+
+        let moveEvent: MoveFolderEvent;
+        comp.moveFolder.subscribe((e: MoveFolderEvent) => moveEvent = e);
+
+        comp.sortFoldersAlphabetically();
+        const reorderedFolders = await firstValueFrom(comp.folders);
+
+        expect(reorderedFolders.map(folder => folder.folderId)).toEqual([1, 6, 8, 7, 5, 9, 2, 4, 3]);
+        expect(reorderedFolders.map(folder => folder.folderLevel)).toEqual([0, 0, 1, 1, 0, 0, 0, 1, 1]);
+        expect(reorderedFolders.map(folder => folder.folderPath)).toEqual([
+            'Inbox',
+            'Apple',
+            'Apple.Charlie',
+            'Apple.Delta',
+            'Sent',
+            'Mango',
+            'Zebra',
+            'Zebra.Alpha',
+            'Zebra.Gamma',
+        ]);
+        expect(moveEvent.sourceId).toEqual(6);
+        expect(moveEvent.destinationId).toEqual(0);
+        expect(moveEvent.order).toEqual([1, 6, 8, 7, 5, 9, 2, 4, 3]);
+    });
+
+    it('should not reorder folders that are already alphabetically sorted', async () => {
+        (dialog as any).closedValue = true;
+
+        const comp = new FolderListComponent(dialog, hotkeyMock);
+        comp.folders = new BehaviorSubject([
+            new FolderListEntry(1, 50, 40, 'inbox', 'Inbox', 'Inbox', 0),
+            new FolderListEntry(2, 50, 40, 'user', 'Apple', 'Apple', 0),
+            new FolderListEntry(3, 50, 40, 'user', 'Beta', 'Beta', 0),
+        ]);
+
+        let moveEvent: MoveFolderEvent;
+        comp.moveFolder.subscribe((e: MoveFolderEvent) => moveEvent = e);
+
+        comp.sortFoldersAlphabetically();
+        const reorderedFolders = await firstValueFrom(comp.folders);
+
+        expect(reorderedFolders.map(folder => folder.folderId)).toEqual([1, 2, 3]);
+        expect(moveEvent).toBeUndefined();
     });
 
     it('should create new folder in root', async () => {

--- a/src/app/folder/folderlist.component.ts
+++ b/src/app/folder/folderlist.component.ts
@@ -360,6 +360,112 @@ export class FolderListComponent implements OnChanges {
         );
     }
 
+    sortFoldersAlphabetically(): void {
+        const confirmDialog = this.dialog.open(ConfirmDialog);
+        confirmDialog.componentInstance.title = 'Sort folders alphabetically?';
+        confirmDialog.componentInstance.question =
+            'This will reorder your user folders alphabetically, including subfolders.';
+        confirmDialog.componentInstance.noOptionTitle = 'cancel';
+        confirmDialog.componentInstance.yesOptionTitle = 'sort';
+        confirmDialog.afterClosed().pipe(
+            filter(res => res === true),
+        ).subscribe(() => this.folders.pipe(take(1)).subscribe(folders => {
+            const sortedFolders = this.alphabeticalFolderOrder(folders);
+            const movedFolder = sortedFolders.find((folder, index) =>
+                folder.folderType === 'user' && folder.folderId !== folders[index]?.folderId
+            );
+            if (!movedFolder) {
+                return;
+            }
+
+            const parentFolderId = this.parentFolderId(folders, movedFolder);
+            folders.splice(0, folders.length, ...sortedFolders);
+
+            let priority = 1;
+            for (const folder of folders) {
+                folder.priority = priority++;
+            }
+            this.updateFolderTree(folders);
+
+            this.moveFolder.emit({
+                sourceId:      movedFolder.folderId,
+                destinationId: parentFolderId,
+                order:         folders.map(folder => folder.folderId),
+            });
+        }));
+    }
+
+    private alphabeticalFolderOrder(folders: FolderListEntry[]): FolderListEntry[] {
+        return this.flattenFolderNodes(
+            this.sortUserFolderNodesAlphabetically(
+                this.folderNodesFromFlatList(folders)
+            )
+        );
+    }
+
+    private folderNodesFromFlatList(folders: FolderListEntry[]): FolderNode[] {
+        const rootNodes: FolderNode[] = [];
+        const parentStack: FolderNode[] = [];
+
+        for (const folder of folders) {
+            const folderNode: FolderNode = { children: [], data: folder };
+
+            while (parentStack.length > folder.folderLevel) {
+                parentStack.pop();
+            }
+
+            if (parentStack.length > 0) {
+                parentStack[parentStack.length - 1].children.push(folderNode);
+            } else {
+                rootNodes.push(folderNode);
+            }
+            parentStack.push(folderNode);
+        }
+
+        return rootNodes;
+    }
+
+    private sortUserFolderNodesAlphabetically(nodes: FolderNode[]): FolderNode[] {
+        const nodesWithSortedChildren = nodes.map((node): FolderNode => ({
+            children: this.sortUserFolderNodesAlphabetically(node.children),
+            data:     node.data,
+        }));
+        const sortedUserNodes = nodesWithSortedChildren
+            .map((node, index) => ({ node, index }))
+            .filter(entry => entry.node.data.folderType === 'user')
+            .sort((left, right) =>
+                this.compareFolderNames(left.node.data, right.node.data) || left.index - right.index
+            )
+            .map(entry => entry.node);
+
+        let sortedUserNodeIndex = 0;
+        return nodesWithSortedChildren.map(node =>
+            node.data.folderType === 'user' ? sortedUserNodes[sortedUserNodeIndex++] : node
+        );
+    }
+
+    private compareFolderNames(left: FolderListEntry, right: FolderListEntry): number {
+        return left.folderName.localeCompare(right.folderName, undefined, { numeric: true, sensitivity: 'base' }) ||
+            left.folderPath.localeCompare(right.folderPath) ||
+            left.folderId - right.folderId;
+    }
+
+    private flattenFolderNodes(nodes: FolderNode[]): FolderListEntry[] {
+        const folders: FolderListEntry[] = [];
+        for (const node of nodes) {
+            folders.push(node.data, ...this.flattenFolderNodes(node.children));
+        }
+        return folders;
+    }
+
+    private parentFolderId(folders: FolderListEntry[], folder: FolderListEntry): number {
+        const parentFolderPath = folder.folderPath.split('.').slice(0, -1).join('.');
+        const parentFolder = parentFolderPath ?
+            folders.find(folderEntry => folderEntry.folderPath === parentFolderPath) :
+            null;
+        return parentFolder ? parentFolder.folderId : 0;
+    }
+
     async folderReorderingDrop(sourceFolderId: number, destinationFolderId: number, aboveOrBelowOrInside: number) {
         if (sourceFolderId === destinationFolderId) {
             // can't move a folder above, below or inside itself


### PR DESCRIPTION
## Summary

- Add a folder-list header button that asks for confirmation before sorting.
- Sort user folders alphabetically within each sibling group, recursively including subfolders.
- Reuse the existing folder move event/API path with the full ordered folder ID list, without changing folder parents.

Closes #1534

## Tests

- `npx ng test runbox7 --watch=false --include src/app/folder/folderlist.component.spec.ts`
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npx eslint src/app/folder/folderlist.component.ts src/app/folder/folderlist.component.html src/app/folder/folderlist.component.spec.ts --quiet`
- `git diff --check`
- `npm run lint -- --quiet`
- `npm run policy`
- `npx ng test runbox7 --watch=false --browsers FirefoxHeadless --reporters dots --progress=false`
- `npx ng build --configuration production --base-href=/app/ runbox7`
- `node src/build/post-build.js`
