### PR TITLE
fix(canvastable): add non-latin font fallbacks

### DIFF
--- a/src/app/canvastable/canvastable.spec.ts
+++ b/src/app/canvastable/canvastable.spec.ts
@@ -18,7 +18,12 @@
 // ---------- END RUNBOX LICENSE ----------
 
 import { TestBed } from '@angular/core/testing';
-import { CanvasTableModule, CanvasTableContainerComponent } from './canvastable';
+import {
+    CANVAS_TABLE_FONT_FAMILY,
+    CANVAS_TABLE_FONT_FAMILY_BOLD,
+    CanvasTableModule,
+    CanvasTableContainerComponent
+} from './canvastable';
 import { MessageList } from '../common/messagelist';
 
 describe('canvastable', () => {
@@ -72,5 +77,19 @@ describe('canvastable', () => {
         fixture.detectChanges();
         expect(fixture.componentInstance.canvastable.floatingTooltip).toBeTruthy();
         expect(fixture.componentInstance.canvastable.columnOverlay).toBeTruthy();
+    });
+
+    it('should include non-Latin fallbacks in the message-list canvas font stack', () => {
+        const fixture = TestBed.createComponent(CanvasTableContainerComponent);
+        const canvastable = fixture.componentInstance.canvastable;
+
+        expect(canvastable.fontFamily).toBe(CANVAS_TABLE_FONT_FAMILY);
+        expect(canvastable.fontFamily).toContain('"Noto Sans"');
+        expect(canvastable.fontFamily).toContain('"Noto Sans CJK JP"');
+        expect(canvastable.fontFamily).toContain('"Microsoft YaHei"');
+        expect(canvastable.fontFamily).toContain('Meiryo');
+        expect(canvastable.fontFamilyBold).toBe(CANVAS_TABLE_FONT_FAMILY_BOLD);
+        expect(canvastable.fontFamilyBold).toContain('"Segoe UI Semibold"');
+        expect(canvastable.fontFamilyBold).toContain('"Noto Sans CJK KR"');
     });
 });

--- a/src/app/canvastable/canvastable.ts
+++ b/src/app/canvastable/canvastable.ts
@@ -42,6 +42,39 @@ import { PreferencesService } from '../common/preferences.service';
 
 const MIN_COLUMN_WIDTH = 40;
 
+export const CANVAS_TABLE_FONT_FAMILY = [
+  '"Avenir Next Pro Regular"',
+  '"Helvetica Neue"',
+  '"Segoe UI"',
+  '"Noto Sans"',
+  '"Noto Sans CJK SC"',
+  '"Noto Sans CJK JP"',
+  '"Noto Sans CJK KR"',
+  '"PingFang SC"',
+  '"Hiragino Sans"',
+  '"Microsoft YaHei"',
+  'Meiryo',
+  'Arial',
+  'sans-serif'
+].join(', ');
+
+export const CANVAS_TABLE_FONT_FAMILY_BOLD = [
+  '"Avenir Next Pro Medium"',
+  '"Helvetica Neue"',
+  '"Segoe UI Semibold"',
+  '"Segoe UI"',
+  '"Noto Sans"',
+  '"Noto Sans CJK SC"',
+  '"Noto Sans CJK JP"',
+  '"Noto Sans CJK KR"',
+  '"PingFang SC"',
+  '"Hiragino Sans"',
+  '"Microsoft YaHei"',
+  'Meiryo',
+  'Arial',
+  'sans-serif'
+].join(', ');
+
 const getCSSClassProperty = (className, propertyName) => {
   const elementId = '_classPropertyLookup_' + className;
   let element: HTMLSpanElement = document.getElementById(elementId);
@@ -120,8 +153,8 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
 
   private scrollbarwidth = 12;
 
-  public fontFamily = '"Avenir Next Pro Regular", "Helvetica Neue", sans-serif';
-  public fontFamilyBold = '"Avenir Next Pro Medium", "Helvetica Neue", sans-serif';
+  public fontFamily = CANVAS_TABLE_FONT_FAMILY;
+  public fontFamilyBold = CANVAS_TABLE_FONT_FAMILY_BOLD;
 
   private maxVisibleRows: number;
 


### PR DESCRIPTION
## Summary

- Add common system and Noto CJK fallbacks to the canvas message-list font stacks.
- Keep the existing Avenir/Helvetica preference first while allowing non-Latin row text to fall through to fonts with broader glyph coverage.
- Leave icon-specific Material Icons column fonts untouched.
- Add focused CanvasTable coverage so the message-list font stack keeps non-Latin fallbacks.

Closes #1442.

## Validation

- `npx ng test runbox7 --watch=false --browsers FirefoxHeadless --include=src/app/canvastable/canvastable.spec.ts --progress=false` (`TOTAL: 2 SUCCESS`; existing CanvasTable console noise, and Karma printed a post-success Firefox disconnect while exiting 0)
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npx eslint src/app/canvastable/canvastable.ts src/app/canvastable/canvastable.spec.ts --quiet`
- `git diff --check`
- `npm run lint -- --quiet`
- `npx ng test runbox7 --watch=false --browsers FirefoxHeadless --reporters dots --progress=false` (`246 SUCCESS`, `2 skipped`; existing Angular template warnings)
- `npx ng build --configuration production --base-href=/app/ runbox7`
- `node src/build/post-build.js`
- `npm run policy` (exits 0; historical upstream commit-message warnings remain, current commit OK)
- `git show --check --stat HEAD`
