### PR TITLE
fix(account): accept broader password symbols

### DIFF
--- a/src/app/account-security/account-password.component.spec.ts
+++ b/src/app/account-security/account-password.component.spec.ts
@@ -1,0 +1,52 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { fakeAsync, tick } from '@angular/core/testing';
+import { AccountPasswordComponent } from './account-password.component';
+
+describe('AccountPasswordComponent', () => {
+    let component: AccountPasswordComponent;
+
+    beforeEach(() => {
+        component = new AccountPasswordComponent(
+            { open: jasmine.createSpy('open') } as any,
+            {
+                me: { load: jasmine.createSpy('load') },
+                ua: { http: { put: jasmine.createSpy('put') } },
+            } as any
+        );
+        component.time_out_duration = 0;
+    });
+
+    it('accepts special characters outside the old hard-coded symbol list', fakeAsync(() => {
+        component.check_password('currentPassword1!', 'new_Password1', 'new_Password1');
+
+        tick();
+
+        expect(component.error).toBeUndefined();
+    }));
+
+    it('still requires a non-alphanumeric character', fakeAsync(() => {
+        component.check_password('currentPassword1!', 'newPassword1', 'newPassword1');
+
+        tick();
+
+        expect(component.error).toBe('Your new password must contain at least 1 special character');
+    }));
+});

--- a/src/app/account-security/account-password.component.ts
+++ b/src/app/account-security/account-password.component.ts
@@ -21,6 +21,8 @@ import { MatLegacySnackBar as MatSnackBar } from '@angular/material/legacy-snack
 import { RMM } from '../rmm';
 import { share, timeout } from 'rxjs/operators';
 
+const PASSWORD_SPECIAL_CHARACTER = /[^A-Za-z0-9]/;
+
 @Component({
     selector: 'app-account-password',
     styleUrls: ['account.security.component.scss'],
@@ -73,8 +75,8 @@ export class AccountPasswordComponent {
                 return;
             }
 
-            if (!/[#?!@$%^&*-]/i.test(new_password)) {
-                this.error = 'Your new password must contain at least 1 special character. Allowed special characters include: # ? ! @ $ % ^ & *';
+            if (!PASSWORD_SPECIAL_CHARACTER.test(new_password)) {
+                this.error = 'Your new password must contain at least 1 special character';
                 return;
             }
 


### PR DESCRIPTION
Fixes #1307.

## Summary

- replace the hard-coded account password special-character whitelist with a non-alphanumeric check so symbols such as `_` are not rejected by the frontend before submit
- keep the existing length, alphabetic, numeric, and password-match validation behavior
- add focused `AccountPasswordComponent` coverage for an underscore password and for the no-symbol rejection path

## Validation

- `npx ng test runbox7 --watch=false --browsers FirefoxHeadless --include=src/app/account-security/account-password.component.spec.ts --progress=false` (`TOTAL: 2 SUCCESS`)
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npx eslint src/app/account-security/account-password.component.ts src/app/account-security/account-password.component.spec.ts --quiet`
- `git diff --check`
- `npm run lint -- --quiet`
- `npx ng test runbox7 --watch=false --browsers FirefoxHeadless --reporters dots --progress=false` (`247` executed, `2` skipped; existing noisy template/WebSocket logs)
- `npx ng build --configuration production --base-href=/app/ runbox7` (existing xapian loader, Angular Material theme, unused TS entry, and CommonJS warnings)
- `node src/build/post-build.js`
- `npm run policy` (exits `0`; historical upstream commit-message warnings only)
- `git show --check --pretty=short HEAD`
