### PR TITLE
fix(identities): show identity descriptions

### DIFF
--- a/src/app/profiles/profiles.lister.html
+++ b/src/app/profiles/profiles.lister.html
@@ -14,8 +14,14 @@
                 <mat-grid-tile colspan="4" rowspan="2">
                     <span class="float-left">{{item.email}}</span>
                 </mat-grid-tile>
-                <mat-grid-tile colspan="1" rowspan="8" *ngIf="!mobile">
+                <mat-grid-tile colspan="1" rowspan="10" *ngIf="!mobile">
                     <button mat-raised-button (click)="edit(item)" color="primary">Edit</button>
+                </mat-grid-tile>
+                <mat-grid-tile colspan="2" rowspan="2">
+                    <span class="float-right">Description:</span>
+                </mat-grid-tile>
+                <mat-grid-tile colspan="4" rowspan="2">
+                    <span class="float-left">{{item.name}}</span>
                 </mat-grid-tile>
                 <mat-grid-tile colspan="2" rowspan="2">
                     <span class="float-right">From Name:</span>

--- a/src/app/profiles/profiles.lister.spec.ts
+++ b/src/app/profiles/profiles.lister.spec.ts
@@ -1,0 +1,89 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { CommonModule } from '@angular/common';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { MatLegacyDialog as MatDialog } from '@angular/material/legacy-dialog';
+import { MatLegacySnackBar as MatSnackBar } from '@angular/material/legacy-snack-bar';
+import { Subject } from 'rxjs';
+import { MobileQueryService, ScreenSize } from '../mobile-query.service';
+import { ProfilesListerComponent } from './profiles.lister';
+
+class MobileQueryServiceStub {
+    screenSize = ScreenSize.Desktop;
+    screenSizeChanged = new Subject<ScreenSize>();
+}
+
+describe('ProfilesListerComponent', () => {
+    let component: ProfilesListerComponent;
+    let fixture: ComponentFixture<ProfilesListerComponent>;
+
+    beforeEach(waitForAsync(() => {
+        TestBed.configureTestingModule({
+            declarations: [
+                ProfilesListerComponent,
+            ],
+            imports: [
+                CommonModule,
+            ],
+            providers: [
+                { provide: MatDialog, useValue: { open: jasmine.createSpy('open') } },
+                { provide: MatSnackBar, useValue: { open: jasmine.createSpy('open') } },
+                { provide: MobileQueryService, useClass: MobileQueryServiceStub },
+            ],
+            schemas: [
+                NO_ERRORS_SCHEMA,
+            ],
+        }).compileComponents();
+    }));
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(ProfilesListerComponent);
+        component = fixture.componentInstance;
+        component.profiles = [{
+            email: 'support@example.com',
+            from_name: 'Support Team',
+            name: 'Customer-facing support identity',
+            reference: {},
+            reference_type: 'preference',
+            reply_to: 'reply@example.com',
+            signature: 'Best regards',
+            type: 'external_email',
+        }];
+    });
+
+    it('shows the identity description in desktop overview cards', () => {
+        component.mobile = false;
+        fixture.detectChanges();
+
+        const text = fixture.nativeElement.textContent;
+        expect(text).toContain('Description:');
+        expect(text).toContain('Customer-facing support identity');
+    });
+
+    it('shows the identity description in mobile overview cards', () => {
+        component.mobile = true;
+        fixture.detectChanges();
+
+        const text = fixture.nativeElement.textContent;
+        expect(text).toContain('Description:');
+        expect(text).toContain('Customer-facing support identity');
+    });
+});


### PR DESCRIPTION
Fixes #908.

## Summary

- show each identity's existing Description (`name`) value in the identity overview card
- keep the row visible in both desktop and mobile lister layouts
- add focused `ProfilesListerComponent` coverage for desktop and mobile rendering

## Validation

- `npx ng test runbox7 --watch=false --browsers FirefoxHeadless --include=src/app/profiles/profiles.lister.spec.ts --progress=false`
- `npx eslint src/app/profiles/profiles.lister.ts src/app/profiles/profiles.lister.spec.ts --quiet`
- `git diff --check`
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npm run lint -- --quiet`
- `npx ng test runbox7 --watch=false --browsers FirefoxHeadless --reporters dots --progress=false`
- `npx ng build --configuration production --base-href=/app/ runbox7`
- `node src/build/post-build.js`
- `npm run policy`
- `git show --check --stat HEAD`

No live Runbox account, identity, mailbox, or production API action was performed.
