### PR TITLE
fix(app): explain local index removal

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -122,7 +122,7 @@
     <mat-nav-list *ngIf="searchService.localSearchActivated">
       <button mat-list-item
         (click)="deleteLocalIndex()"
-        matTooltip="Stop synchronization and remove index stored on your device">
+        [matTooltip]="localIndexStopTooltip">
           <mat-icon  svgIcon="sync-off" mat-list-icon></mat-icon>
           Stop index synchronization
       </button>

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,0 +1,28 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { LOCAL_INDEX_STOP_TOOLTIP } from './app.component';
+
+describe('AppComponent local index copy', () => {
+    it('explains what stopping index synchronization removes and why', () => {
+        expect(LOCAL_INDEX_STOP_TOOLTIP).toContain('locally stored search index');
+        expect(LOCAL_INDEX_STOP_TOOLTIP).toContain('makes message search faster');
+        expect(LOCAL_INDEX_STOP_TOOLTIP).toContain('shared or untrusted devices');
+    });
+});

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -76,6 +76,9 @@ const LOCAL_STORAGE_SHOW_UNREAD_ONLY = 'rmm7mailViewerShowUnreadOnly';
 const LOCAL_STORAGE_SHOW_POPULAR_RECIPIENTS = 'showPopularRecipients';
 const LOCAL_STORAGE_INDEX_PROMPT = 'localSearchPromptDisplayed';
 const TOOLBAR_LIST_BUTTON_WIDTH = 30;
+export const LOCAL_INDEX_STOP_TOOLTIP =
+  'Stop synchronization and remove the locally stored search index from this device. ' +
+  'The index makes message search faster; remove it on shared or untrusted devices.';
 
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
@@ -101,6 +104,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
   unreadMessagesOnlyCheckbox = false;
   unreadOnlyToolTip = 'Unread messages only';
   localSearchIndexPrompted = false;
+  localIndexStopTooltip = LOCAL_INDEX_STOP_TOOLTIP;
   offerInitialLocalIndex = false;
 
   indexDocCount = 0;


### PR DESCRIPTION
Fixes #545.

## Summary

- expand the Stop index synchronization tooltip to explain the locally stored search index
- mention that the index makes message search faster and may be removed on shared or untrusted devices
- bind the tooltip text through a named component property and add focused wording coverage

## Validation

- `npx ng test runbox7 --watch=false --browsers FirefoxHeadless --include=src/app/app.component.spec.ts --reporters dots --progress=false`
- `npx eslint src/app/app.component.ts src/app/app.component.spec.ts --quiet`
- `git diff --check`
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npm run lint -- --quiet`
- `npx ng test runbox7 --watch=false --browsers FirefoxHeadless --reporters dots --progress=false`
- `npx ng build --configuration production --base-href=/app/ runbox7`
- `node src/build/post-build.js`
- `npm run policy`
- `git show --check --stat HEAD`

No live Runbox account, mailbox, local index, or production API action was performed.
