### PR TITLE
fix(mail): treat whitespace text as unavailable

### DIFF
--- a/src/app/mailviewer/singlemailviewer.component.spec.ts
+++ b/src/app/mailviewer/singlemailviewer.component.spec.ts
@@ -231,6 +231,32 @@ describe('SingleMailViewerComponent', () => {
       expect(component.mailObj.attachments[1].downloadURL.indexOf('blob:')).toBe(0);
     }));
 
+  it('treats whitespace-only plain text as unavailable when HTML exists', () => {
+    const processed = component['processMessageContents'](Object.assign(new MessageContents(), {
+      headers: {
+        from: {
+          value: [{
+            address: 'test@runbox.com',
+            name: 'Testy'
+          }]
+        },
+        date: new Date(2016, 0, 1).toJSON(),
+        subject: 'HTML only'
+      },
+      text: {
+        text: ' \r\n\t ',
+        html: '<p>HTML body</p>',
+        textAsHtml: ' \r\n\t '
+      },
+      sanitized_html: '<p>HTML body</p>',
+      sanitized_html_without_images: '<p>HTML body</p>',
+      attachments: []
+    }));
+
+    expect(processed.text).toBe('undefined');
+    expect(processed.html).toBeTruthy();
+  });
+
   describe('mailto: link interceptor', () => {
     let messageContentsElement: HTMLElement;
     let mailtoLink: HTMLAnchorElement;

--- a/src/app/mailviewer/singlemailviewer.component.ts
+++ b/src/app/mailviewer/singlemailviewer.component.ts
@@ -61,6 +61,9 @@ const resizerPercentageKey = 'rmm7resizerpercentage';
 
 const TOOLBAR_BUTTON_WIDTH = 30;
 
+function hasVisiblePlainText(text: string): boolean {
+  return typeof text === 'string' && text.trim().length > 0;
+}
 
 type Mail = any;
 
@@ -582,7 +585,7 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
     /**
      * Transform the links so that they are clickable
      */
-    let text = res.text.text;
+    let text = res.text ? res.text.text : '';
     res.rawtext = text;
     text = String(text).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 
@@ -621,7 +624,9 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
     text = html.join('');
 
    //  res.text = text;
-    res.text = this.domSanitizer.bypassSecurityTrustHtml(DOMPurify.sanitize(res.text.textAsHtml)); // res.text.textAsHtml;
+    res.text = hasVisiblePlainText(res.rawtext)
+      ? this.domSanitizer.bypassSecurityTrustHtml(DOMPurify.sanitize(res.text.textAsHtml))
+      : 'undefined'; // res.text.textAsHtml;
     return res;
   }
 


### PR DESCRIPTION
## Summary

- Treat whitespace-only plain text bodies as unavailable, so messages with HTML plus blank text are handled as HTML-only.
- Keep non-empty plain text behavior unchanged.
- Add a regression test for an HTML message whose plain text part contains only whitespace.

Fixes #591

## Testing

- `npx ng test runbox7 --watch=false --browsers FirefoxHeadless --include=src/app/mailviewer/singlemailviewer.component.spec.ts --reporters dots --progress=false`
- `npx eslint src/app/mailviewer/singlemailviewer.component.ts src/app/mailviewer/singlemailviewer.component.spec.ts --quiet`
- `git diff --check`
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npm run lint -- --quiet`
- `npx ng test runbox7 --watch=false --browsers FirefoxHeadless --reporters dots --progress=false`
- `npx ng build --configuration production --base-href=/app/ runbox7`
- `node src/build/post-build.js`
- `npm run policy`
