### PR TITLE
Auto-dismiss message-list flag notifications

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,0 +1,67 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { AppComponent } from './app.component';
+
+describe('AppComponent message action notifications', () => {
+  function createComponent() {
+    const component = Object.create(AppComponent.prototype) as AppComponent;
+    const snackBarOpen = jasmine.createSpy('open');
+    const updateMessages = jasmine.createSpy('updateMessages');
+    component.snackBar = {
+      open: snackBarOpen,
+    } as unknown as AppComponent['snackBar'];
+    component.canvastable = {
+      rows: {
+        selectedMessageIds: () => [42],
+      },
+    } as unknown as AppComponent['canvastable'];
+    component.messageActionsHandler = {
+      updateMessages,
+    } as unknown as AppComponent['messageActionsHandler'];
+
+    return { component, snackBarOpen, updateMessages };
+  }
+
+  it('auto-dismisses the flag toggle notification', () => {
+    const { component, snackBarOpen, updateMessages } = createComponent();
+
+    component.setFlaggedStatus(true);
+
+    expect(snackBarOpen).toHaveBeenCalledWith(
+      'Toggling flags...',
+      undefined,
+      { duration: 3000 },
+    );
+    expect(updateMessages).toHaveBeenCalled();
+  });
+
+  it('auto-dismisses the read status toggle notification', () => {
+    const { component, snackBarOpen, updateMessages } = createComponent();
+
+    component.setReadStatus(true);
+
+    expect(snackBarOpen).toHaveBeenCalledWith(
+      'Toggling read status...',
+      undefined,
+      { duration: 3000 },
+    );
+    expect(updateMessages).toHaveBeenCalled();
+  });
+});

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -76,6 +76,7 @@ const LOCAL_STORAGE_SHOW_UNREAD_ONLY = 'rmm7mailViewerShowUnreadOnly';
 const LOCAL_STORAGE_SHOW_POPULAR_RECIPIENTS = 'showPopularRecipients';
 const LOCAL_STORAGE_INDEX_PROMPT = 'localSearchPromptDisplayed';
 const TOOLBAR_LIST_BUTTON_WIDTH = 30;
+const MESSAGE_ACTION_SNACKBAR_DURATION = 3000;
 
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
@@ -750,7 +751,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
   }
 
   public setReadStatus(status: boolean) {
-    this.snackBar.open('Toggling read status...');
+    this.snackBar.open('Toggling read status...', undefined, { duration: MESSAGE_ACTION_SNACKBAR_DURATION });
     const messageIds = this.canvastable.rows.selectedMessageIds();
 
     this.messageActionsHandler.updateMessages({
@@ -779,7 +780,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
   }
 
   public setFlaggedStatus(status: boolean) {
-    this.snackBar.open('Toggling flags...');
+    this.snackBar.open('Toggling flags...', undefined, { duration: MESSAGE_ACTION_SNACKBAR_DURATION });
     const messageIds = this.canvastable.rows.selectedMessageIds();
 
     this.messageActionsHandler.updateMessages({


### PR DESCRIPTION
## Summary

- give the transient message-list flag toggle snackbar a 3-second duration so it does not remain stuck over the UI
- apply the same duration to the sibling read-status toggle snackbar, which used the same indefinite notification pattern
- add focused `AppComponent` coverage for both snackbar calls without constructing the full Angular component fixture

Closes #1732.

## Testing

- `npx ng test runbox7 --watch=false --include src/app/app.component.spec.ts` (`2 SUCCESS`)
- `npx eslint src/app/app.component.ts src/app/app.component.spec.ts` (exits 0; existing warnings in `app.component.ts`)
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npm run lint -- --quiet`
- `npx ng test runbox7 --watch=false` (`247 SUCCESS`, `2 skipped`; existing Angular template warnings from unrelated specs)
- `npx ng build --configuration production --base-href=/app/ runbox7` (passes with existing CommonJS/theme/unused-file warnings)
- `node src/build/post-build.js`
- `git diff --check`
- `git diff --cached --check`
- `npm run policy` (exits 0; reports existing historical upstream commit-message warnings)

Note: `npm run build` is Bash-shaped under this PowerShell shell, so I ran the production build and post-build steps directly.
