### PR TITLE
fix(compose): close empty cc and bcc fields

### DIFF
--- a/src/app/compose/compose.component.html
+++ b/src/app/compose/compose.component.html
@@ -89,7 +89,7 @@
                 [recipients]="model.cc"
                 (updateRecipient)="onUpdateRecipient('cc', $event)"
             ></mailrecipient-input>
-            <button mat-icon-button (click)="formGroup.controls.cc.setValue(null)"><mat-icon svgIcon="close"></mat-icon></button>
+            <button mat-icon-button (click)="closeRecipientField('cc')"><mat-icon svgIcon="close"></mat-icon></button>
         </div>
         <div style="display: flex;" *ngIf="editing && hasBCC" class="fieldRecipient" (drop)="recipientDropped($event, 'bcc')">
             <mailrecipient-input *ngIf="editing" style="width: auto; flex-grow: 1"
@@ -97,7 +97,7 @@
                 [recipients]="model.bcc"
                 (updateRecipient)="onUpdateRecipient('bcc', $event)"
             ></mailrecipient-input>
-            <button mat-icon-button (click)="formGroup.controls.bcc.setValue(null)"><mat-icon svgIcon="close"></mat-icon></button>
+            <button mat-icon-button (click)="closeRecipientField('bcc')"><mat-icon svgIcon="close"></mat-icon></button>
         </div>
     </mat-card-subtitle>
     <mat-card-content>

--- a/src/app/compose/compose.component.spec.ts
+++ b/src/app/compose/compose.component.spec.ts
@@ -1,0 +1,80 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { UntypedFormBuilder } from '@angular/forms';
+import { NgZone } from '@angular/core';
+import { BehaviorSubject, of } from 'rxjs';
+
+import { ComposeComponent } from './compose.component';
+import { DraftFormModel } from './draftdesk.service';
+
+describe('ComposeComponent', () => {
+    function createComponent() {
+        const formBuilder = new UntypedFormBuilder();
+        const component = new ComposeComponent(
+            {} as any,
+            {} as any,
+            {} as any,
+            {
+                fromsSubject: new BehaviorSubject([]),
+                isEditing: -1,
+                composingNewDraft: null,
+            } as any,
+            {} as any,
+            {} as any,
+            formBuilder,
+            {} as any,
+            {} as any,
+            { recentlyUsed: of([]) } as any,
+            {
+                prefGroup: 'global',
+                preferences: of(new Map<string, string>()),
+                set: jasmine.createSpy('set'),
+            } as any,
+            new NgZone({ enableLongStackTrace: false }),
+        );
+
+        component.model = new DraftFormModel();
+        component.formGroup = formBuilder.group(component.model);
+
+        return component;
+    }
+
+    it('closes the empty CC recipient field', () => {
+        const component = createComponent();
+        component.hasCC = true;
+
+        component.closeRecipientField('cc');
+
+        expect(component.hasCC).toBeFalse();
+        expect(component.model.cc).toEqual([]);
+        expect(component.formGroup.controls.cc.value).toBe('');
+    });
+
+    it('closes the empty BCC recipient field', () => {
+        const component = createComponent();
+        component.hasBCC = true;
+
+        component.closeRecipientField('bcc');
+
+        expect(component.hasBCC).toBeFalse();
+        expect(component.model.bcc).toEqual([]);
+        expect(component.formGroup.controls.bcc.value).toBe('');
+    });
+});

--- a/src/app/compose/compose.component.ts
+++ b/src/app/compose/compose.component.ts
@@ -328,6 +328,10 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
         this.formGroup.controls[field].setValue(recipientString);
     }
 
+    public closeRecipientField(field: 'cc' | 'bcc') {
+        this.onUpdateRecipient(field, []);
+    }
+
     public hideDropZone() {
       this.draggingOverDropZone = false;
       this.showDropZone = false;


### PR DESCRIPTION
## Summary

- route the CC/BCC close buttons through `ComposeComponent.closeRecipientField()`
- reuse the existing recipient update path so empty CC/BCC fields clear the model/form value and flip `hasCC`/`hasBCC` back to false
- add focused component coverage for closing the empty CC and BCC fields

Closes #1183

## Validation

- `npx ng test runbox7 --watch=false --include src/app/compose/compose.component.spec.ts` passed with `2 SUCCESS`
- `npx eslint src/app/compose/compose.component.ts src/app/compose/compose.component.html src/app/compose/compose.component.spec.ts --quiet` passed
- `npx tsc -p src/tsconfig.app.json --noEmit` passed
- `npx tsc -p src/tsconfig.spec.json --noEmit` passed
- `git diff --check` passed with line-ending normalization warnings only
- `npm run lint -- --quiet` passed
- `npx ng test runbox7 --watch=false` passed with `247 SUCCESS`, `2 skipped`, and existing unrelated console noise
- `npx ng build --configuration production --base-href=/app/ runbox7` passed with existing build warnings; build hash `b7117d1d9ed1da83`
- `node src/build/post-build.js` passed
- `git diff --cached --check` passed with line-ending normalization warnings only
- `git show --check --stat HEAD` passed
- `npm run policy` exited 0 before and after commit; it printed existing historical upstream commit-message warnings while the current commit was OK

`npm run build` itself is Bash-shaped in this PowerShell shell, so I validated the production build by running the Angular build and post-build steps directly.

AI assistance was used for source review, implementation, and validation planning.
