### PR TITLE
Prevent duplicate contact saves

### DIFF
--- a/src/app/contacts-app/contact-details/contact-details.component.html
+++ b/src/app/contacts-app/contact-details/contact-details.component.html
@@ -232,7 +232,7 @@
         </app-contact-details-fa-viewer>
 
         <mat-toolbar style="position: fixed; bottom: 0;">
-            <a mat-button (click)="save()">Save changes</a>
+            <button mat-button type="button" (click)="save()" [disabled]="isSaving">Save changes</button>
             <a mat-button (click)="rollback()" *ngIf="contact.id && !mobileQuery.matches">Discard changes</a>
             <a mat-button (click)="delete()" *ngIf="contact.id">Delete this contact</a>
         </mat-toolbar>

--- a/src/app/contacts-app/contact-details/contact-details.component.spec.ts
+++ b/src/app/contacts-app/contact-details/contact-details.component.spec.ts
@@ -1,0 +1,111 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { Location } from '@angular/common';
+import { MatLegacyDialog as MatDialog } from '@angular/material/legacy-dialog';
+import { MatLegacySnackBar as MatSnackBar } from '@angular/material/legacy-snack-bar';
+import { UntypedFormBuilder } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { of, ReplaySubject } from 'rxjs';
+
+import { PreferencesService } from '../../common/preferences.service';
+import { DraftDeskService } from '../../compose/draftdesk.service';
+import { MobileQueryService } from '../../mobile-query.service';
+import { RunboxWebmailAPI } from '../../rmmapi/rbwebmail';
+import { ContactDetailsComponent } from './contact-details.component';
+import { ContactsService } from '../contacts.service';
+
+describe('ContactDetailsComponent', () => {
+    let component: ContactDetailsComponent;
+    let contactsService: jasmine.SpyObj<ContactsService>;
+    let router: jasmine.SpyObj<Router>;
+    let snackBar: jasmine.SpyObj<MatSnackBar>;
+
+    beforeEach(() => {
+        spyOn(console, 'log');
+        contactsService = {
+            contactCategories: of([]),
+            contactsSubject: of([]),
+            lookupAvatar: jasmine.createSpy('lookupAvatar').and.returnValue(Promise.resolve(null)),
+            saveContact: jasmine.createSpy('saveContact'),
+        } as unknown as jasmine.SpyObj<ContactsService>;
+        router = jasmine.createSpyObj<Router>('Router', ['navigate', 'navigateByUrl']);
+        router.navigateByUrl.and.returnValue(Promise.resolve(true));
+        snackBar = jasmine.createSpyObj<MatSnackBar>('MatSnackBar', ['open']);
+
+        const preferences = new ReplaySubject<Map<string, unknown>>(1);
+        preferences.next(new Map());
+
+        component = new ContactDetailsComponent(
+            null as unknown as MatDialog,
+            { matches: false } as unknown as MobileQueryService,
+            { preferences, prefGroup: 'Desktop' } as unknown as PreferencesService,
+            new UntypedFormBuilder(),
+            {} as unknown as RunboxWebmailAPI,
+            router,
+            { params: of({}), queryParams: of({}) } as unknown as ActivatedRoute,
+            snackBar,
+            contactsService,
+            {} as unknown as DraftDeskService,
+            {} as unknown as Location,
+        );
+    });
+
+    it('ignores duplicate save clicks while a new contact is still saving', async () => {
+        let resolveSave: (id: string) => void;
+        const savePromise = new Promise<string>(resolve => {
+            resolveSave = resolve;
+        });
+        contactsService.saveContact.and.returnValue(savePromise);
+
+        component.loadNewContact({});
+        component.contactForm.get('first_name').setValue('Ada');
+        component.contactForm.get('first_name').markAsDirty();
+
+        const pendingSave = component.save();
+        component.save();
+
+        expect(contactsService.saveContact).toHaveBeenCalledTimes(1);
+        expect(component.isSaving).toBeTrue();
+
+        resolveSave('new-contact-id');
+        await pendingSave;
+
+        expect(router.navigateByUrl).toHaveBeenCalledWith('/contacts/new-contact-id');
+        expect(component.isSaving).toBeFalse();
+    });
+
+    it('allows another save after the previous save fails', async () => {
+        spyOn(console, 'error');
+        contactsService.saveContact.and.returnValue(Promise.reject(new Error('Save failed')));
+
+        component.loadNewContact({});
+        component.contactForm.get('first_name').setValue('Ada');
+        component.contactForm.get('first_name').markAsDirty();
+
+        await component.save();
+
+        expect(snackBar.open).toHaveBeenCalledWith('Save failed', 'Ok');
+        expect(component.isSaving).toBeFalse();
+
+        contactsService.saveContact.and.returnValue(Promise.resolve('new-contact-id'));
+        component.save();
+        expect(contactsService.saveContact).toHaveBeenCalledTimes(2);
+    });
+});

--- a/src/app/contacts-app/contact-details/contact-details.component.ts
+++ b/src/app/contacts-app/contact-details/contact-details.component.ts
@@ -66,6 +66,7 @@ export class ContactDetailsComponent {
 
     contactIcon: string;
     avatarSource: string;
+    isSaving = false;
 
     contactIsDragged = false;
     memberIsDragged  = false;
@@ -276,7 +277,12 @@ export class ContactDetailsComponent {
     newUrl():      void { this.addFGtoFA(this.createEmailFG([]), 'urls');      }
     newRelative(): void { this.addFGtoFA(this.createEmailFG([]), 'related');   }
 
-    save(): void {
+    save(): Promise<void> {
+        if (this.isSaving) {
+            return Promise.resolve();
+        }
+
+        this.isSaving = true;
         for (const name of Object.keys(this.contactForm.controls)) {
             const ctl = this.contactForm.get(name);
             if (ctl.dirty) {
@@ -293,11 +299,13 @@ export class ContactDetailsComponent {
             this.contact.members = this.groupMembers;
         }
         console.log('Saving contact:', this.contact);
-        this.contactsservice.saveContact(this.contact).then(
-            id => this.router.navigateByUrl('/contacts/' + id)
-        ).catch(err => {
+        return this.contactsservice.saveContact(this.contact).then(async id => {
+            await this.router.navigateByUrl('/contacts/' + id);
+        }).catch(err => {
             console.error(err);
-            return this.snackBar.open(err.message, 'Ok');
+            this.snackBar.open(err.message, 'Ok');
+        }).finally(() => {
+            this.isSaving = false;
         });
     }
 


### PR DESCRIPTION
## Summary

- prevent rapid repeated Save clicks from starting multiple contact creation requests while the first save is still in flight
- disable the Save changes button during an active save and reset it after either success or failure
- add focused component coverage for duplicate save clicks and retrying after a failed save

Closes #601.

## Validation

- `npx ng test runbox7 --watch=false --include src/app/contacts-app/contact-details/contact-details.component.spec.ts` passed with `2 SUCCESS`
- `npx eslint src/app/contacts-app/contact-details/contact-details.component.ts src/app/contacts-app/contact-details/contact-details.component.spec.ts` exited 0; existing warnings remain in `contact-details.component.ts`
- `npx tsc -p src/tsconfig.spec.json --noEmit` passed
- `npx tsc -p src/tsconfig.app.json --noEmit` passed
- `git diff --check` passed with line-ending normalization warnings only
- `npm run lint -- --quiet` passed
- `npx ng test runbox7 --watch=false` passed with `247 SUCCESS`, `2 skipped`, and existing unrelated console noise
- `npx ng build --configuration production --base-href=/app/ runbox7` passed with existing build warnings; build hash `061108808a5352ec`
- `node src/build/post-build.js` passed
- `git diff --cached --check` passed with line-ending normalization warnings only
- `git show --check --stat HEAD` passed
- `npm run policy` exited 0 before and after commit; it printed existing historical upstream commit-message warnings while the current commit was OK

`npm run build` itself is Bash-shaped in this PowerShell shell, so I validated the production build by running the Angular build and post-build steps directly.

AI assistance was used for source review, implementation, and validation planning.
