### PR TITLE
Parse pasted full address lists

### DIFF
--- a/src/app/common/mailaddressinfo.spec.ts
+++ b/src/app/common/mailaddressinfo.spec.ts
@@ -70,6 +70,22 @@ describe('MailAddressInfo', () => {
         expect(ma_list[1].address).toBe('test2@runbox.com');
         expect(ma_list[1].nameAndAddress).toBe('"Test2" <test2@runbox.com>');
     });
+    it('Parse space-separated full address list', () => {
+        const ma_list = MailAddressInfo.parse('Test1 <test1@runbox.com> Test2 <test2@runbox.com>');
+        expect(ma_list.length).toBe(2);
+        expect(ma_list[0].name).toBe('Test1');
+        expect(ma_list[0].address).toBe('test1@runbox.com');
+        expect(ma_list[0].nameAndAddress).toBe('"Test1" <test1@runbox.com>');
+        expect(ma_list[1].name).toBe('Test2');
+        expect(ma_list[1].address).toBe('test2@runbox.com');
+        expect(ma_list[1].nameAndAddress).toBe('"Test2" <test2@runbox.com>');
+    });
+    it('Parse space-separated quoted full address list', () => {
+        const ma_list = MailAddressInfo.parse('"Test One" <test1@runbox.com> "Test Two" <test2@runbox.com>');
+        expect(ma_list.length).toBe(2);
+        expect(ma_list[0].nameAndAddress).toBe('"Test One" <test1@runbox.com>');
+        expect(ma_list[1].nameAndAddress).toBe('"Test Two" <test2@runbox.com>');
+    });
     it('Parse multi-level domain', () => {
         const ma_list = MailAddressInfo.parse('"Fred B" <fred@foo.bar.baz.tld>');
         expect(ma_list[0].name).toBe('Fred B');

--- a/src/app/common/mailaddressinfo.ts
+++ b/src/app/common/mailaddressinfo.ts
@@ -32,11 +32,20 @@ export class MailAddressInfo {
         let lastStart = 0;
         let name: string = null;
         let addr: string = null;
+        const pushCurrent = () => {
+            ret.push(new MailAddressInfo(name, addr));
+            addr = null;
+            name = null;
+        };
         for (let n = 0; n < mailaddr.length; n++) {
             const ch = mailaddr.charAt(n);
 
             switch (ch) {
                 case '"':
+                    if (!namePart && addr) {
+                        pushCurrent();
+                    }
+
                     namePart = !namePart;
 
                     if (namePart) {
@@ -50,14 +59,15 @@ export class MailAddressInfo {
                         if (!addr) {
                             addr = mailaddr.substring(lastStart, n).trim();
                         }
-                        ret.push(new MailAddressInfo(name, addr));
-                        addr = null;
-                        name = null;
+                        pushCurrent();
                         lastStart = n + 1;
                     }
                     break;
                 case '<':
                     if (!namePart) {
+                        if (addr) {
+                            pushCurrent();
+                        }
                         if (name == null) {
                             name = mailaddr.substring(lastStart, n).trim();
                         }
@@ -67,6 +77,7 @@ export class MailAddressInfo {
                 case '>':
                     if (!namePart) {
                         addr = mailaddr.substring(lastStart, n).trim();
+                        lastStart = n + 1;
                     }
                     break;
             }


### PR DESCRIPTION
## Summary

- Treat a completed `<address>` block as a recipient when another display-name/address block starts without a comma.
- Preserve existing comma-separated parsing behavior.
- Add coverage for pasted unquoted and quoted full-address lists such as `Name <name@example.com> Other <other@example.com>`.

## Validation

- Pre-fix `npx ng test runbox7 --watch=false --include src/app/common/mailaddressinfo.spec.ts` failed on the new space-separated address-list regression.
- `npx ng test runbox7 --watch=false --include src/app/common/mailaddressinfo.spec.ts`
- `npx eslint src/app/common/mailaddressinfo.ts src/app/common/mailaddressinfo.spec.ts`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `git diff --check`
- `npm run lint -- --quiet`
- `npx ng test runbox7 --watch=false`
- `npx ng build --configuration production --base-href=/app/ runbox7`
- `node src/build/post-build.js`
- `npm run policy`
- `git diff --cached --check`
- `git show --check --stat HEAD`

Closes #1034.

AI assistance disclosure: I used OpenAI Codex to inspect the parser path, make the patch, and run the validation commands above.
