### PR TITLE
Open message viewer on double click

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -165,7 +165,7 @@
               && (singlemailviewer.messageId
                   || (!mobileQuery.matches && keepMessagePaneOpen)
             )"
-    [style.width]="mailViewerRightSideWidth"
+    [style.width]="messageViewerFullscreen ? '100%' : mailViewerRightSideWidth"
     id="rightPane"
     appResizable>
       <single-mail-viewer #singlemailviewer
@@ -173,6 +173,7 @@
       [adjustableHeight]="false"
       (afterLoadMessage)="updateMessageListHeight()"
       (orientationChangeRequest)="mailViewerOrientationChangeRequest($event)"
+      (restorePreviewRequest)="restoreMessageListPreview()"
       (onClose)="singleMailViewerClosed($event)"></single-mail-viewer>
       <div *ngIf="mailViewerOnRightSide && !singlemailviewer.messageId"
 	   class="noMessageSelectedNotification">
@@ -421,6 +422,7 @@
           [messageActionsHandler]="messageActionsHandler"
           (afterLoadMessage)="updateMessageListHeight()"
           (orientationChangeRequest)="mailViewerOrientationChangeRequest($event)"
+          (restorePreviewRequest)="restoreMessageListPreview()"
           (onClose)="singleMailViewerClosed($event)"></single-mail-viewer>
     </div>
   </div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -125,6 +125,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
 
   mailViewerOnRightSide = true;
   mailViewerRightSideWidth = '40%';
+  messageViewerFullscreen = false;
   allowMailViewerOrientationChange = true;
   messageSubjectDragTipShown = false;
   showPopularRecipients = true;
@@ -970,6 +971,32 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     }
   }
 
+  public rowDoubleClicked(_rowIndex: number, columnIndex: number) {
+    const isSelect = columnIndex === 0;
+
+    if (isSelect || this.selectedFolder === this.messagelistservice.templateFolderName) {
+      return;
+    }
+
+    this.expandMessageViewer();
+  }
+
+  private expandMessageViewer(): void {
+    if (this.singlemailviewer?.adjustableHeight && this.singlemailviewer.resizer) {
+      this.singlemailviewer.resizer.resizePercentage(100);
+    } else if (this.mailViewerOnRightSide && this.singlemailviewer?.messageId) {
+      this.messageViewerFullscreen = true;
+    }
+  }
+
+  public restoreMessageListPreview(): void {
+    this.messageViewerFullscreen = false;
+
+    if (this.singlemailviewer?.adjustableHeight && this.singlemailviewer.resizer?.isFullHeight) {
+      this.singlemailviewer.resizer.resizePercentage(50);
+    }
+  }
+
   // CanvasTableSelectListener, columnWidths changed:
   saveColumnWidthsPreference(widths: any) {
     this.preferenceService.set(this.preferenceService.prefGroup, 'canvasNamedColumnWidthsBySet', widths);
@@ -1063,6 +1090,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
   }
 
   singleMailViewerClosed(action: string): void {
+    this.messageViewerFullscreen = false;
     this.canvastable.rows.clearOpenedRow();
     this.updateUrlFragment();
   }
@@ -1375,6 +1403,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
 
   mailViewerOrientationChangeRequest(orientation: string) {
     const currentMessageId = this.singlemailviewer.messageId;
+    this.messageViewerFullscreen = false;
     if (orientation === 'vertical') {
       this.mailViewerOnRightSide = true;
     } else {

--- a/src/app/canvastable/canvastable.spec.ts
+++ b/src/app/canvastable/canvastable.spec.ts
@@ -73,4 +73,45 @@ describe('canvastable', () => {
         expect(fixture.componentInstance.canvastable.floatingTooltip).toBeTruthy();
         expect(fixture.componentInstance.canvastable.columnOverlay).toBeTruthy();
     });
+
+    it('should notify listener when a row is double clicked', () => {
+        const fixture = TestBed.createComponent(CanvasTableContainerComponent);
+        const rowDoubleClicked = jasmine.createSpy('rowDoubleClicked');
+        fixture.componentInstance.canvastableselectlistener = {
+            rowSelected: jasmine.createSpy('rowSelected'),
+            rowDoubleClicked,
+            saveColumnWidthsPreference: jasmine.createSpy('saveColumnWidthsPreference')
+        };
+        fixture.componentInstance.canvastable.columns = [
+            {
+                name: '',
+                cacheKey: 'selected',
+                sortColumn: null,
+                checkbox: true,
+                getValue: () => '',
+                width: 40
+            },
+            {
+                name: 'Subject',
+                cacheKey: 'subject',
+                sortColumn: null,
+                getValue: (row) => row.subject,
+                width: 200
+            },
+        ];
+        fixture.componentInstance.canvastable.rows = new MessageList([
+            { id: 1, subject: 'subject1' },
+            { id: 2, subject: 'subject2' }
+        ]);
+        fixture.componentInstance.canvastable.rowWrapMode = false;
+        fixture.detectChanges();
+
+        const canvasRect = fixture.componentInstance.canvastable.canvRef.nativeElement.getBoundingClientRect();
+        fixture.componentInstance.canvastable.canvRef.nativeElement.dispatchEvent(new MouseEvent('dblclick', {
+            clientX: canvasRect.left + 60,
+            clientY: canvasRect.top + 10
+        }));
+
+        expect(rowDoubleClicked).toHaveBeenCalledWith(0, 1);
+    });
 });

--- a/src/app/canvastable/canvastable.ts
+++ b/src/app/canvastable/canvastable.ts
@@ -57,6 +57,7 @@ const getCSSClassProperty = (className, propertyName) => {
 
 export interface CanvasTableSelectListener {
   rowSelected(rowIndex: number, colIndex: number, multiSelect?: boolean): void;
+  rowDoubleClicked?(rowIndex: number, colIndex: number): void;
   saveColumnWidthsPreference(widths);
 }
 
@@ -541,6 +542,16 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
       this.dragSelectionDirectionIsDown = null;
     };
 
+    this.canv.ondblclick = (event: MouseEvent) => {
+      event.preventDefault();
+
+      if (this.visibleColumnSeparatorIndex > 0 || this.scrollbarArea || this.scrollbarDragInProgress) {
+        return;
+      }
+
+      this.doubleClickRow(event.clientX, event.clientY);
+    };
+
 
     this.renderer.listen('window', 'resize', () => true);
 
@@ -771,6 +782,27 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
     this.selectListener.rowSelected(selectedRowIndex,
       this.getColIndexByClientX(clientX),
       multiSelect);
+
+    this.hasChanges = true;
+  }
+
+  public doubleClickRow(clientX: number, clientY: number) {
+    const selectedRowIndex = this.getRowIndexByClientY(clientY);
+    this.doubleClickRowByIndex(clientX, selectedRowIndex);
+  }
+
+  public doubleClickRowByIndex(clientX: number, selectedRowIndex: number) {
+    if (!this.rows?.rowExists(selectedRowIndex) || !this.selectListener?.rowDoubleClicked) {
+      return;
+    }
+
+    const canvrect = this.canv.getBoundingClientRect();
+    clientX -= canvrect.left;
+
+    this.selectListener.rowDoubleClicked(
+      selectedRowIndex,
+      this.getColIndexByClientX(clientX)
+    );
 
     this.hasChanges = true;
   }

--- a/src/app/mailviewer/singlemailviewer.component.html
+++ b/src/app/mailviewer/singlemailviewer.component.html
@@ -4,7 +4,7 @@
     sandbox="allow-same-origin allow-modals"
     style="width: 0px; height: 0px; border: none; position: absolute"
   ></iframe>
-  <mat-toolbar *ngIf="mailObj" style="display: flex; overflow-x: auto;">
+  <mat-toolbar *ngIf="mailObj" style="display: flex; overflow-x: auto;" (dblclick)="restorePreviewOnToolbarDoubleClick($event)">
     
     <!-- Message preview toolbar -->
     <!-- NOTE: These items need to be replicated in the overflow toolbar further down. The number of items shown is controlled by morebuttonindex and TOOLBAR_BUTTON_WIDTH in the .ts file. -->

--- a/src/app/mailviewer/singlemailviewer.component.spec.ts
+++ b/src/app/mailviewer/singlemailviewer.component.spec.ts
@@ -215,6 +215,33 @@ describe('SingleMailViewerComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  it('emits preview restore requests from empty toolbar double clicks', () => {
+    const emitSpy = spyOn(component.restorePreviewRequest, 'emit');
+    const event = {
+      target: null,
+      preventDefault: jasmine.createSpy('preventDefault')
+    } as unknown as MouseEvent;
+
+    component.restorePreviewOnToolbarDoubleClick(event);
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(emitSpy).toHaveBeenCalled();
+  });
+
+  it('ignores toolbar double clicks on action controls', () => {
+    const emitSpy = spyOn(component.restorePreviewRequest, 'emit');
+    const button = document.createElement('button');
+    const event = {
+      target: button,
+      preventDefault: jasmine.createSpy('preventDefault')
+    } as unknown as MouseEvent;
+
+    component.restorePreviewOnToolbarDoubleClick(event);
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(emitSpy).not.toHaveBeenCalled();
+  });
+
   it('show mail', fakeAsync(() => {
       expect(component).toBeTruthy();
 

--- a/src/app/mailviewer/singlemailviewer.component.ts
+++ b/src/app/mailviewer/singlemailviewer.component.ts
@@ -80,6 +80,7 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
   @Output() onClose: EventEmitter<string> = new EventEmitter();
   @Output() afterViewInit: EventEmitter<any> = new EventEmitter();
   @Output() orientationChangeRequest: EventEmitter<string> = new EventEmitter();
+  @Output() restorePreviewRequest: EventEmitter<void> = new EventEmitter();
   @Output() afterLoadMessage: EventEmitter<boolean> = new EventEmitter();
 
   @Input() messageActionsHandler: MessageActions;
@@ -333,6 +334,16 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
   }
   public changeOrientation(orientation: string) {
     this.orientationChangeRequest.emit(orientation);
+  }
+
+  public restorePreviewOnToolbarDoubleClick(event: MouseEvent): void {
+    const target = event.target;
+    if (target instanceof Element && target.closest('button,a,mat-menu,mat-icon')) {
+      return;
+    }
+
+    event.preventDefault();
+    this.restorePreviewRequest.emit();
   }
 
   attachmentIconFromContentType(contentType: string) {


### PR DESCRIPTION
Closes #690.

What changed:
- dispatch canvas row double-clicks to the message-list listener
- expand the horizontal preview to full height on row double-click, or temporarily widen the right-side preview to 100%
- restore list + preview from empty message-toolbar double-clicks while ignoring action buttons and links
- cover the new canvas and toolbar double-click paths in unit tests

Validation:
- git diff --check
- npx tsc -p src/tsconfig.app.json --noEmit
- npx tsc -p src/tsconfig.spec.json --noEmit
- npx ng test runbox7 --watch=false --include src/app/canvastable/canvastable.spec.ts --include src/app/mailviewer/singlemailviewer.component.spec.ts --browsers FirefoxHeadless
- npm run lint
- npm run policy
- npx ng test runbox7 --watch=false --progress=false --browsers FirefoxHeadless
- node src/build/pre-build.js && npx ng build --configuration production --base-href=/app/ runbox7 && node src/build/post-build.js

Notes:
- `npm run lint` exits 0 with the repository's existing warnings only: 770 warnings, 0 errors.
- `npm run policy` exits 0 after `All commits look OK`, then prints historical commit-message warnings already present in the branch history.
- Karma logs existing testbed/icon warnings, but the focused and full test runs complete successfully.

AI disclosure: I used OpenAI Codex to prepare this change.