### PR TITLE
Widen calendar event editor dialog

### DIFF
--- a/src/app/calendar-app/calendar-app.component.spec.ts
+++ b/src/app/calendar-app/calendar-app.component.spec.ts
@@ -33,9 +33,11 @@ import { PreferencesService } from '../common/preferences.service';
 import { RouterTestingModule } from '@angular/router/testing';
 import { take } from 'rxjs/operators';
 import { of, Observable, ReplaySubject } from 'rxjs';
+import { MatLegacyDialogRef as MatDialogRef } from '@angular/material/legacy-dialog';
 import { MatLegacySnackBar as MatSnackBar } from '@angular/material/legacy-snack-bar';
 import { RunboxCalendar } from './runbox-calendar';
 import { RunboxCalendarEvent } from './runbox-calendar-event';
+import { EventEditorDialogComponent } from './event-editor-dialog.component';
 import { MatIcon } from '@angular/material/icon';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import moment from 'moment';
@@ -308,5 +310,40 @@ END:VCALENDAR
         expect(first_occurence.getDate()).toBe(1, 'day matches');
         expect(first_occurence.getHours()).toBe(12, 'hour matches');
         expect(first_occurence.getMinutes()).toBe(34, 'minute matches');
+    });
+
+    it('opens event editor dialogs with responsive dimensions', () => {
+        component.calendars = mockData.calendars;
+
+        const dialogRef = {
+            afterClosed: () => of(null),
+        } as unknown as MatDialogRef<EventEditorDialogComponent, null>;
+        const openSpy = spyOn(component['dialog'], 'open').and.returnValue(dialogRef);
+
+        component.addEvent();
+
+        expect(openSpy).toHaveBeenCalledWith(
+            EventEditorDialogComponent,
+            jasmine.objectContaining({
+                width: '90vw',
+                maxWidth: '920px',
+                maxHeight: '90vh',
+                data: jasmine.objectContaining({ is_new: true }),
+            }),
+        );
+
+        openSpy.calls.reset();
+
+        component.openEvent(RunboxCalendarEvent.newEmpty('Europe/London'));
+
+        expect(openSpy).toHaveBeenCalledWith(
+            EventEditorDialogComponent,
+            jasmine.objectContaining({
+                width: '90vw',
+                maxWidth: '920px',
+                maxHeight: '90vh',
+                data: jasmine.objectContaining({ is_new: false }),
+            }),
+        );
     });
 });

--- a/src/app/calendar-app/calendar-app.component.ts
+++ b/src/app/calendar-app/calendar-app.component.ts
@@ -65,6 +65,12 @@ import { DefaultPrefGroups, PreferencesService } from '../common/preferences.ser
 
 import '../sentry';
 
+const EVENT_EDITOR_DIALOG_CONFIG = {
+    width: '90vw',
+    maxWidth: '920px',
+    maxHeight: '90vh',
+};
+
 @Component({
     selector: 'app-calendar-app-component',
     templateUrl: './calendar-app.component.html',
@@ -171,8 +177,9 @@ export class CalendarAppComponent implements OnDestroy {
         const new_event = RunboxCalendarEvent.newEmpty(this.calendarservice.me.timezone);
         new_event.timezone = this.calendarservice.me.timezone;
         const dialogRef = this.dialog.open(EventEditorDialogComponent, {
-            data: { event: new_event, calendars: this.calendars, settings: this.settings, start: on, is_new: true } }
-        );
+            ...EVENT_EDITOR_DIALOG_CONFIG,
+            data: { event: new_event, calendars: this.calendars, settings: this.settings, start: on, is_new: true }
+        });
         dialogRef.afterClosed().subscribe(event => {
             if (event) {
                 this.calendarservice.addEvent(event);
@@ -277,6 +284,7 @@ export class CalendarAppComponent implements OnDestroy {
     openEvent(event: CalendarEvent): void {
         const target = event as RunboxCalendarEvent;
         const dialogRef = this.dialog.open(EventEditorDialogComponent, {
+            ...EVENT_EDITOR_DIALOG_CONFIG,
             data: { event: target, calendars: this.calendars, settings: this.settings, is_new: false }
         });
         dialogRef.afterClosed().subscribe(result => {

--- a/src/app/calendar-app/event-editor-dialog.component.html
+++ b/src/app/calendar-app/event-editor-dialog.component.html
@@ -1,5 +1,5 @@
 <h1 mat-dialog-title>{{ event_title || "New event" }}</h1>
-<section mat-dialog-content style="max-width: 500px; box-sizing: border-box;">
+<section mat-dialog-content style="box-sizing: border-box; width: 100%;">
   <mat-tab-group>
     <mat-tab label="Details">
     <style>
@@ -17,7 +17,7 @@
         </mat-form-field>
     </p><p>
         <mat-form-field>
-            <textarea matInput placeholder="Description" [(ngModel)]="event_description"></textarea>
+            <textarea matInput placeholder="Description" rows="5" [(ngModel)]="event_description"></textarea>
         </mat-form-field>
     </p><p>
         <mat-form-field>


### PR DESCRIPTION
Closes #1400.

What changed:
- open the calendar event editor dialog at a responsive width (`90vw`, capped at `920px`) and max height (`90vh`)
- remove the dialog content's previous `500px` cap so details fields can use the wider dialog
- make the Description textarea visibly multiline by default
- add focused coverage that both create-event and edit-event paths keep the responsive dialog sizing

Validation:
- git diff --check
- npx tsc -p src/tsconfig.app.json --noEmit
- npx tsc -p src/tsconfig.spec.json --noEmit
- npx ng test runbox7 --watch=false --include src/app/calendar-app/calendar-app.component.spec.ts --browsers FirefoxHeadless
- npx eslint src/app/calendar-app/calendar-app.component.ts src/app/calendar-app/calendar-app.component.spec.ts src/app/calendar-app/event-editor-dialog.component.html
- npm run lint
- npm run policy
- npx ng test runbox7 --watch=false --progress=false --browsers FirefoxHeadless
- node src/build/pre-build.js && npx ng build --configuration production --base-href=/app/ runbox7 && node src/build/post-build.js
- git diff --cached --check
- git show --check --stat --oneline HEAD

Notes:
- `npm run lint` exits 0 with the repository's existing warnings only: 770 warnings, 0 errors.
- `npm run policy` exits 0 after `All commits look OK`, then prints historical commit-message warnings already present in the branch history.
- Karma logs existing unrelated Angular template noise, but the focused and full test runs complete successfully.
- Production build passed with existing Angular/CommonJS/Sass warnings and hash `e743a7c1458858ac`.

AI disclosure: I used OpenAI Codex to prepare this change.
