### PR TITLE
Sort Draft Desk by updated time

### DIFF
--- a/src/app/compose/draftdesk.component.ts
+++ b/src/app/compose/draftdesk.component.ts
@@ -102,7 +102,7 @@ export class DraftDeskComponent implements OnInit {
                 }
             });
             this.draftModelsInView.splice(0, 0, ...newEntries);
-            this.draftModelsInView.sort((a,b) => a.mid < 0 ? -1 : b.mid < 0 ? 1 : a.mid > b.mid ? -1 : 1);
+            this.draftModelsInView.sort(DraftFormModel.compareByUpdatedDesc);
             this.draftModelsInView = this.draftModelsInView.slice(0, this.currentMaxDraftsInView);
             deletedEntries.forEach(
                 (dMsgId) => this.draftModelsInView.splice(this.draftModelsInView.findIndex((dMsg) => dMsg.mid === dMsgId), 1));

--- a/src/app/compose/draftdesk.service.spec.ts
+++ b/src/app/compose/draftdesk.service.spec.ts
@@ -410,6 +410,34 @@ Subject: Test subject <br />
         expect(draft.isUnsaved()).toBe(false);
         done();
     });
+
+    it('sorts saved drafts by updated date descending and keeps unsaved drafts first', () => {
+        const olderDraft = DraftFormModel.create(
+            200,
+            Identity.fromObject({'email':'to@runbox.com'}),
+            '"Older" <older@runbox.com>',
+            'Older',
+            null,
+            new Date('2024-01-01T00:00:00Z'));
+        const newerDraft = DraftFormModel.create(
+            100,
+            Identity.fromObject({'email':'to@runbox.com'}),
+            '"Newer" <newer@runbox.com>',
+            'Newer',
+            null,
+            new Date('2024-02-01T00:00:00Z'));
+        const unsavedDraft = DraftFormModel.create(
+            -1,
+            Identity.fromObject({'email':'to@runbox.com'}),
+            null,
+            'Unsaved');
+
+        const sortedDraftIds = [olderDraft, newerDraft, unsavedDraft]
+            .sort(DraftFormModel.compareByUpdatedDesc)
+            .map((draft) => draft.mid);
+
+        expect(sortedDraftIds).toEqual([-1, 100, 200]);
+    });
 });
 
 describe('DraftDeskService', () => {
@@ -494,6 +522,33 @@ describe('DraftDeskService', () => {
 
             // The drafts array should have been updated
             expect(drafts.length).toBeGreaterThan(0);
+        });
+
+        it('should sort refreshed drafts by changed date descending', async () => {
+            const olderChangedDate = new Date('2024-01-01T00:00:00Z');
+            const newerChangedDate = new Date('2024-02-01T00:00:00Z');
+
+            mockRmmapi.listAllMessages.and.returnValue(of([
+                {
+                    id: 200,
+                    changedDate: olderChangedDate,
+                    to: [{ name: null, address: 'older@runbox.com' }],
+                    subject: 'Older draft'
+                },
+                {
+                    id: 100,
+                    changedDate: newerChangedDate,
+                    to: [{ name: null, address: 'newer@runbox.com' }],
+                    subject: 'Newer draft'
+                }
+            ]));
+
+            draftDeskService['refreshDrafts']();
+
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            expect(draftDeskService.draftModels.value.map((draft) => draft.mid)).toEqual([100, 200]);
+            expect(draftDeskService.draftModels.value[0].message_date).toEqual(newerChangedDate);
         });
     });
 

--- a/src/app/compose/draftdesk.service.ts
+++ b/src/app/compose/draftdesk.service.ts
@@ -77,6 +77,7 @@ export class DraftFormModel {
         ret.mid = draftId;
         ret.to = to ? MailAddressInfo.parse(to) : [];
         ret.subject = subject;
+        ret.message_date = message_date;
         if (preview) {
             // We create an element here because we want the plain text
             const previewElm = document.createElement('div');
@@ -85,6 +86,27 @@ export class DraftFormModel {
             ret.preview = DraftFormModel.trimmedPreview(previewElm.innerText.trim().replace(/\s+/g, ' '));
         }
         return ret;
+    }
+
+    public static compareByUpdatedDesc(a: DraftFormModel, b: DraftFormModel): number {
+        if (a.isUnsaved() && b.isUnsaved()) {
+            return a.mid - b.mid;
+        }
+        if (a.isUnsaved()) {
+            return -1;
+        }
+        if (b.isUnsaved()) {
+            return 1;
+        }
+
+        const aTime = a.message_date instanceof Date ? a.message_date.getTime() : 0;
+        const bTime = b.message_date instanceof Date ? b.message_date.getTime() : 0;
+
+        if (aTime !== bTime) {
+            return bTime - aTime;
+        }
+
+        return b.mid - a.mid;
     }
 
     public static reply(mailObj, froms: Identity[], all: boolean, useHTML: boolean): DraftFormModel {
@@ -295,12 +317,13 @@ export class DraftDeskService {
                                 this.mainIdentity(),
                                 msgInfo.to.map((addr) => addr.name === null || addr.address.indexOf(addr.name + '@') === 0 ?
                                     addr.address : addr.name + '<' + addr.address + '>').join(','),
-                                msgInfo.subject, null, msgInfo.messageDate)
+                                msgInfo.subject, null, msgInfo.changedDate)
                         )
                                 );
                     if (this.composingNewDraft) {
                         newDrafts.splice(0, 0, this.composingNewDraft);
                     }
+                    newDrafts.sort(DraftFormModel.compareByUpdatedDesc);
                     this.draftModels.next(newDrafts);
                 });
         }


### PR DESCRIPTION
Fixes #688

## Summary
- preserve the draft message `changedDate` timestamp on `DraftFormModel`
- sort Draft Desk saved drafts by that updated timestamp descending instead of by message id
- reuse the same ordering when the Draft Desk view updates in place, while keeping unsaved drafts above saved drafts

## Validation
- `git diff --check`
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npx ng test runbox7 --watch=false --include src/app/compose/draftdesk.service.spec.ts --browsers FirefoxHeadless`
- `npx eslint src/app/compose/draftdesk.service.ts src/app/compose/draftdesk.component.ts src/app/compose/draftdesk.service.spec.ts`
- `npm run lint`
- `npm run policy`
- `npx ng test runbox7 --watch=false --progress=false --browsers FirefoxHeadless`
- `node src/build/pre-build.js; npx ng build --configuration production --base-href=/app/ runbox7; node src/build/post-build.js`
