### PR TITLE
Highlight active saved search

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -99,7 +99,10 @@
 
     <mat-divider></mat-divider>
 
-    <app-saved-searches (searchClicked)="searchFor($event)"></app-saved-searches>
+    <app-saved-searches
+        [selectedSearch]="selectedSavedSearch"
+        (searchClicked)="savedSearchSelected($event)"
+    ></app-saved-searches>
 
     <mat-divider></mat-divider>
 

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,0 +1,74 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2020 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { fakeAsync, tick } from '@angular/core/testing';
+
+import { AppComponent } from './app.component';
+import { SavedSearch } from './saved-searches/saved-searches.service';
+import { WebSocketSearchService } from './websocketsearch/websocketsearch.service';
+
+describe('AppComponent saved search selection', () => {
+  let component: AppComponent;
+
+  const savedSearch: SavedSearch = {
+    name: 'Invoices',
+    query: 'from:billing@example.com',
+  };
+
+  beforeEach(() => {
+    component = Object.create(AppComponent.prototype);
+    component.searchText = '';
+    component.selectedFolder = 'Inbox';
+    component.selectedSavedSearch = null;
+    component.usewebsocketsearch = false;
+    component.websocketsearchservice = {
+      search: jasmine.createSpy('search'),
+    } as unknown as WebSocketSearchService;
+    component.updateSearch = jasmine.createSpy('updateSearch') as typeof component.updateSearch;
+  });
+
+  it('should clear folder selection and keep saved search highlighted when selected', fakeAsync(() => {
+    component.savedSearchSelected(savedSearch);
+    tick(1);
+
+    expect(component.selectedFolder).toBeNull();
+    expect(component.selectedSavedSearch).toEqual(savedSearch);
+    expect(component.searchText).toBe(savedSearch.query);
+    expect(component.updateSearch).toHaveBeenCalledWith(false);
+  }));
+
+  it('should rerun a saved search even when the query text is unchanged', fakeAsync(() => {
+    component.searchText = savedSearch.query;
+
+    component.savedSearchSelected(savedSearch);
+    tick(1);
+
+    expect(component.selectedFolder).toBeNull();
+    expect(component.selectedSavedSearch).toEqual(savedSearch);
+    expect(component.updateSearch).toHaveBeenCalledWith(true);
+  }));
+
+  it('should clear saved search selection for manual searches', () => {
+    component.selectedSavedSearch = savedSearch;
+
+    component.searchFor('manual query');
+
+    expect(component.selectedSavedSearch).toBeNull();
+  });
+});

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -58,7 +58,7 @@ import { environment } from '../environments/environment';
 import { LogoutService } from './login/logout.service';
 import { ExtendedKeyboardEvent, Hotkey, HotkeysService } from 'angular2-hotkeys';
 import { AppSettings } from './app-settings';
-import { SavedSearchesService } from './saved-searches/saved-searches.service';
+import { SavedSearch, SavedSearchesService } from './saved-searches/saved-searches.service';
 import { DefaultPrefGroups, PreferencesService } from './common/preferences.service';
 import { StorageService } from './storage.service';
 import { SearchMessageDisplay } from './xapian/searchmessagedisplay';
@@ -109,6 +109,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
 
   displayedFolders = new Observable<FolderListEntry[]>();
   selectedFolder = '';
+  selectedSavedSearch: SavedSearch = null;
   composeSelected: boolean;
   draftsSelected: boolean;
   overviewSelected: boolean;
@@ -991,17 +992,28 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     setTimeout(() => this.updateTime(), 1000);
   }
 
-  searchFor(text) {
-    if (text !== this.searchText) {
+  searchFor(text: string, keepSavedSearchSelected = false) {
+    if (!keepSavedSearchSelected) {
+      this.selectedSavedSearch = null;
+    }
+
+    const forceSearch = keepSavedSearchSelected && text === this.searchText;
+    if (text !== this.searchText || forceSearch) {
       this.searchText = text;
       if (this.usewebsocketsearch) {
         this.websocketsearchservice.search(text);
       } else {
         setTimeout(() =>
-          this.updateSearch()
+          this.updateSearch(forceSearch)
           , 1);
       }
     }
+  }
+
+  savedSearchSelected(search: SavedSearch): void {
+    this.selectedSavedSearch = search;
+    this.selectedFolder = null;
+    this.searchFor(search.query, true);
   }
 
   public afterUpdateIndex() {
@@ -1023,6 +1035,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     if (yes) {
       // Don't highlight a folder if we're not viewing one
       this.selectedFolder = null;
+      this.selectedSavedSearch = null;
     }
   }
 
@@ -1183,6 +1196,8 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
   }
 
   private switchToFolder(folder: string): void {
+    this.selectedSavedSearch = null;
+
     if (folder === this.selectedFolder) {
         return;
     }
@@ -1318,7 +1333,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
             break;
           case 'conversations':
           default:
-            if (this.searchText.length < 3) {
+            if (this.searchText.length < 3 && this.selectedFolder) {
               // Expand to all folders if search text length is longer than 3 characters
               const restrictToUnread = this.unreadMessagesOnlyCheckbox
                 && !this.messagelistservice.ignoreUnreadInFolders.includes(this.selectedFolder)

--- a/src/app/saved-searches/saved-searches.component.html
+++ b/src/app/saved-searches/saved-searches.component.html
@@ -8,11 +8,13 @@
         <ng-content></ng-content>
 
         <button mat-list-item *ngFor="let search of searches; let idx = index"
-            (click)="searchClicked.emit(search.query)"
+            [ngClass]="{'selectedFolder': isSelected(search)}"
+            [attr.aria-current]="isSelected(search) ? 'page' : null"
+            (click)="searchClicked.emit(search)"
         >
             {{ search.name }}
             <span style="flex-grow: 1"></span>
-            <button mat-icon-button (click)="remove(idx)">
+            <button mat-icon-button (click)="$event.stopPropagation(); remove(idx)">
                 <mat-icon svgIcon="delete"></mat-icon>
             </button>
         </button>

--- a/src/app/saved-searches/saved-searches.component.spec.ts
+++ b/src/app/saved-searches/saved-searches.component.spec.ts
@@ -1,0 +1,104 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2020 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatExpansionModule } from '@angular/material/expansion';
+import { MatLegacyButtonModule as MatButtonModule } from '@angular/material/legacy-button';
+import { MatIcon, MatIconModule } from '@angular/material/icon';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { MatLegacyListModule as MatListModule } from '@angular/material/legacy-list';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { ReplaySubject } from 'rxjs';
+
+import { SavedSearchesComponent } from './saved-searches.component';
+import { SavedSearch, SavedSearchesService } from './saved-searches.service';
+
+class MockSavedSearchesService {
+    searches = new ReplaySubject<SavedSearch[]>(1);
+    remove = jasmine.createSpy('remove');
+}
+
+describe('SavedSearchesComponent', () => {
+    let component: SavedSearchesComponent;
+    let fixture: ComponentFixture<SavedSearchesComponent>;
+    let service: MockSavedSearchesService;
+
+    const searches: SavedSearch[] = [
+        { name: 'Invoices', query: 'from:billing@example.com' },
+        { name: 'Travel', query: 'subject:itinerary' },
+    ];
+
+    beforeEach(() => {
+        service = new MockSavedSearchesService();
+        TestBed.configureTestingModule({
+            declarations: [ SavedSearchesComponent, MatIcon ],
+            imports: [
+                MatButtonModule,
+                MatExpansionModule,
+                MatIconModule,
+                MatIconTestingModule,
+                MatListModule,
+                NoopAnimationsModule,
+            ],
+            providers: [
+                { provide: SavedSearchesService, useValue: service },
+            ],
+        }).compileComponents();
+    });
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(SavedSearchesComponent);
+        component = fixture.componentInstance;
+        component.expanded = true;
+        service.searches.next(searches);
+        fixture.detectChanges();
+    });
+
+    it('should emit the clicked saved search', () => {
+        let emitted: SavedSearch;
+        component.searchClicked.subscribe((search: SavedSearch) => emitted = search);
+
+        const rows = fixture.nativeElement.querySelectorAll('button[mat-list-item]');
+        rows[1].click();
+
+        expect(emitted).toEqual(searches[1]);
+    });
+
+    it('should highlight the selected saved search', () => {
+        component.selectedSearch = searches[1];
+        fixture.detectChanges();
+
+        const rows = fixture.nativeElement.querySelectorAll('button[mat-list-item]');
+
+        expect(rows[0].classList).not.toContain('selectedFolder');
+        expect(rows[1].classList).toContain('selectedFolder');
+        expect(rows[1].getAttribute('aria-current')).toBe('page');
+    });
+
+    it('should not run a saved search when deleting it', () => {
+        let emitted: SavedSearch;
+        component.searchClicked.subscribe((search: SavedSearch) => emitted = search);
+
+        const rows = fixture.nativeElement.querySelectorAll('button[mat-list-item]');
+        rows[0].querySelector('button[mat-icon-button]').click();
+
+        expect(service.remove).toHaveBeenCalledOnceWith(0);
+        expect(emitted).toBeUndefined();
+    });
+});

--- a/src/app/saved-searches/saved-searches.component.ts
+++ b/src/app/saved-searches/saved-searches.component.ts
@@ -27,7 +27,8 @@ import { SavedSearch, SavedSearchesService } from './saved-searches.service';
 })
 export class SavedSearchesComponent implements OnInit {
     @Input() expanded = false;
-    @Output() searchClicked: EventEmitter<string> = new EventEmitter();
+    @Input() selectedSearch: SavedSearch = null;
+    @Output() searchClicked: EventEmitter<SavedSearch> = new EventEmitter();
 
     searches: SavedSearch[] = [];
 
@@ -41,5 +42,11 @@ export class SavedSearchesComponent implements OnInit {
 
     remove(index: number): void {
         this.service.remove(index);
+    }
+
+    isSelected(search: SavedSearch): boolean {
+        return !!this.selectedSearch
+            && this.selectedSearch.name === search.name
+            && this.selectedSearch.query === search.query;
     }
 }


### PR DESCRIPTION
Closes #918.

## Summary

- emit the selected saved-search entry instead of only the query text
- track the active saved search in the app shell and pass it back to the sidebar for highlighting
- clear the folder highlight immediately when a saved search is selected, and clear the saved-search highlight again when changing folders or typing a manual search
- stop delete-button clicks from also running the saved search

## Validation

- `git diff --check`
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npx ng test runbox7 --watch=false --include src/app/app.component.spec.ts --include src/app/saved-searches/saved-searches.component.spec.ts --include src/app/saved-searches/saved-searches.service.spec.ts --browsers FirefoxHeadless`
- `npx eslint src/app/app.component.ts src/app/app.component.html src/app/app.component.spec.ts src/app/saved-searches/saved-searches.component.ts src/app/saved-searches/saved-searches.component.html src/app/saved-searches/saved-searches.component.spec.ts`
- `npm run lint`
- `npm run policy`
- `npx ng test runbox7 --watch=false --progress=false --browsers FirefoxHeadless`
- `node src/build/pre-build.js; npx ng build --configuration production --base-href=/app/ runbox7; node src/build/post-build.js`
- `git diff --cached --check`
- `git show --check --stat --oneline HEAD`

Notes:
- `npm run lint` exits 0 with the repository's existing warnings only: 770 warnings, 0 errors.
- `npm run policy` exits 0 after `All commits look OK`, then prints historical commit-message warnings already present in the branch history.
- Full FirefoxHeadless tests pass with `251 SUCCESS` and `2 skipped`.
- Production build passed with existing Angular/CommonJS/Sass warnings and hash `dea620dd89e659d9`.

AI disclosure: I used OpenAI Codex to prepare this change.
