### PR TITLE
Remember preview pane width

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -167,7 +167,9 @@
             )"
     [style.width]="mailViewerRightSideWidth"
     id="rightPane"
-    appResizable>
+    appResizable
+    position="end"
+    (resized)="mailViewerRightSideResized($event)">
       <single-mail-viewer #singlemailviewer
       [messageActionsHandler]="messageActionsHandler"
       [adjustableHeight]="false"

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,0 +1,83 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { AppComponent } from './app.component';
+import { ScreenSize } from './mobile-query.service';
+
+interface PreferenceServiceStub {
+    prefGroup: string;
+    set: jasmine.Spy;
+}
+
+describe('AppComponent mail viewer width', () => {
+    let component: AppComponent;
+    let preferenceService: PreferenceServiceStub;
+
+    beforeEach(() => {
+        preferenceService = {
+            prefGroup: 'Desktop',
+            set: jasmine.createSpy('set')
+        };
+        component = Object.create(AppComponent.prototype) as AppComponent;
+        component.mobileQuery = { screenSize: ScreenSize.Desktop } as AppComponent['mobileQuery'];
+        (component as unknown as { preferenceService: PreferenceServiceStub }).preferenceService = preferenceService;
+        component.mailViewerRightSideWidth = '40%';
+    });
+
+    it('loads the saved desktop preview-pane width from preferences', () => {
+        component.applyMailViewerRightSideWidthPreference(new Map([
+            ['Desktop:mailViewerRightSideWidth', '480px']
+        ]));
+
+        expect(component.mailViewerRightSideWidth).toBe('480px');
+    });
+
+    it('uses the default desktop preview-pane width when no preference exists', () => {
+        component.mailViewerRightSideWidth = '240px';
+
+        component.applyMailViewerRightSideWidthPreference(new Map());
+
+        expect(component.mailViewerRightSideWidth).toBe('40%');
+    });
+
+    it('keeps the right preview pane full width outside desktop layout', () => {
+        component.mobileQuery = { screenSize: ScreenSize.Phone } as AppComponent['mobileQuery'];
+
+        component.applyMailViewerRightSideWidthPreference(new Map([
+            ['Desktop:mailViewerRightSideWidth', '480px']
+        ]));
+
+        expect(component.mailViewerRightSideWidth).toBe('100%');
+    });
+
+    it('stores desktop resize width as a preference', () => {
+        component.mailViewerRightSideResized(420);
+
+        expect(component.mailViewerRightSideWidth).toBe('420px');
+        expect(preferenceService.set).toHaveBeenCalledWith('Desktop', 'mailViewerRightSideWidth', '420px');
+    });
+
+    it('does not store resize width outside desktop layout', () => {
+        component.mobileQuery = { screenSize: ScreenSize.Phone } as AppComponent['mobileQuery'];
+
+        component.mailViewerRightSideResized(420);
+
+        expect(preferenceService.set).not.toHaveBeenCalled();
+    });
+});

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -69,6 +69,8 @@ import { UpdateAlertComponent } from './updatealert/updatealert.component';
 
 const LOCAL_STORAGE_SETTING_MAILVIEWER_ON_RIGHT_SIDE_IF_MOBILE = 'mailViewerOnRightSideIfMobile';
 const LOCAL_STORAGE_SETTING_MAILVIEWER_ON_RIGHT_SIDE = 'mailViewerOnRightSide';
+const LOCAL_STORAGE_MAILVIEWER_RIGHT_SIDE_WIDTH = 'mailViewerRightSideWidth';
+const MAILVIEWER_RIGHT_SIDE_DEFAULT_WIDTH = '40%';
 const LOCAL_STORAGE_VIEWMODE = 'rmm7mailViewerViewMode';
 const LOCAL_STORAGE_SHOWCONTENTPREVIEW = 'rmm7mailViewerContentPreview';
 const LOCAL_STORAGE_KEEP_PANE = 'keepMessagePaneOpen';
@@ -124,7 +126,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
   displayFolderColumn = false;
 
   mailViewerOnRightSide = true;
-  mailViewerRightSideWidth = '40%';
+  mailViewerRightSideWidth = MAILVIEWER_RIGHT_SIDE_DEFAULT_WIDTH;
   allowMailViewerOrientationChange = true;
   messageSubjectDragTipShown = false;
   showPopularRecipients = true;
@@ -283,12 +285,12 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
         const storedMailViewerOrientationSetting = this.preferences.get(`${this.preferenceService.prefGroup}:${LOCAL_STORAGE_SETTING_MAILVIEWER_ON_RIGHT_SIDE}`);
         this.mailViewerOnRightSide = !storedMailViewerOrientationSetting || storedMailViewerOrientationSetting === 'true';
         this.allowMailViewerOrientationChange = true;
-        this.mailViewerRightSideWidth = '35%';
+        this.applyMailViewerRightSideWidthPreference(this.preferences);
       }
 
       if (size !== ScreenSize.Desktop) {
         // #935 - Allow vertical preview also on mobile, and use full width
-        this.mailViewerRightSideWidth = '100%';
+        this.applyMailViewerRightSideWidthPreference(this.preferences);
         this.mailViewerOnRightSide = this.preferences.get(`${this.preferenceService.prefGroup}:${LOCAL_STORAGE_SETTING_MAILVIEWER_ON_RIGHT_SIDE_IF_MOBILE}`);
       }
       console.log(this.mailViewerOnRightSide);
@@ -321,6 +323,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
       }
       // after the above
       this.mailViewerOnRightSide = storedMailViewerOrientationSettingMobile === 'true';
+      this.applyMailViewerRightSideWidthPreference(prefs);
 
       // sidebar
       this.showPopularRecipients = prefs.get(`${this.preferenceService.prefGroup}:${LOCAL_STORAGE_SHOW_POPULAR_RECIPIENTS}`) === 'true';
@@ -342,6 +345,27 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     return this.singlemailviewer && this.singlemailviewer.adjustableHeight
       ? this.singlemailviewer.resizerHeight
       : 0;
+  }
+
+  public applyMailViewerRightSideWidthPreference(prefs: Map<string, unknown>): void {
+    if (this.mobileQuery.screenSize !== ScreenSize.Desktop) {
+      this.mailViewerRightSideWidth = '100%';
+      return;
+    }
+
+    const storedWidth = prefs.get(`${this.preferenceService.prefGroup}:${LOCAL_STORAGE_MAILVIEWER_RIGHT_SIDE_WIDTH}`);
+    this.mailViewerRightSideWidth = typeof storedWidth === 'string' && storedWidth
+      ? storedWidth
+      : MAILVIEWER_RIGHT_SIDE_DEFAULT_WIDTH;
+  }
+
+  public mailViewerRightSideResized(width: number): void {
+    if (this.mobileQuery.screenSize !== ScreenSize.Desktop || width <= 0) {
+      return;
+    }
+
+    this.mailViewerRightSideWidth = `${width}px`;
+    this.preferenceService.set(this.preferenceService.prefGroup, LOCAL_STORAGE_MAILVIEWER_RIGHT_SIDE_WIDTH, this.mailViewerRightSideWidth);
   }
 
   ngDoCheck(): void {
@@ -1377,6 +1401,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     const currentMessageId = this.singlemailviewer.messageId;
     if (orientation === 'vertical') {
       this.mailViewerOnRightSide = true;
+      this.applyMailViewerRightSideWidthPreference(this.preferences);
     } else {
       this.mailViewerOnRightSide = false;
     }

--- a/src/app/directives/resizer.directive.spec.ts
+++ b/src/app/directives/resizer.directive.spec.ts
@@ -1,0 +1,109 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { ElementRef, Renderer2 } from '@angular/core';
+
+import { ResizerDirective } from './resizer.directive';
+
+interface ResizerEvent {
+    clientX: number;
+    preventDefault?: () => void;
+}
+
+interface MockNativeElement {
+    offsetLeft: number;
+    offsetWidth: number;
+    style: {
+        width?: string;
+        'border-right'?: string;
+        'border-left'?: string;
+    };
+    addEventListener: (eventName: string, callback: (event: ResizerEvent) => void) => void;
+    getBoundingClientRect: () => {
+        left: number;
+        width: number;
+    };
+}
+
+class MockRenderer {
+    listeners = new Map<string, (event: ResizerEvent) => void>();
+
+    listen(target: string, eventName: string, callback: (event: ResizerEvent) => void): () => void {
+        this.listeners.set(`${target}:${eventName}`, callback);
+        return () => undefined;
+    }
+}
+
+describe('ResizerDirective', () => {
+    function createDirective() {
+        const elementListeners = new Map<string, (event: ResizerEvent) => void>();
+        const nativeElement: MockNativeElement = {
+            offsetLeft: 100,
+            offsetWidth: 200,
+            style: {},
+            addEventListener: (eventName: string, callback: (event: ResizerEvent) => void) => {
+                elementListeners.set(eventName, callback);
+            },
+            getBoundingClientRect: () => ({
+                left: 100,
+                width: 200
+            })
+        };
+        const renderer = new MockRenderer();
+        const directive = new ResizerDirective(
+            new ElementRef(nativeElement),
+            renderer as unknown as Renderer2
+        );
+
+        return { directive, elementListeners, nativeElement, renderer };
+    }
+
+    it('emits resized width while dragging from the start edge', () => {
+        const { directive, elementListeners, nativeElement, renderer } = createDirective();
+        const widths: number[] = [];
+        directive.resized.subscribe(width => widths.push(width));
+        directive.ngOnInit();
+
+        elementListeners.get('mousedown')({
+            clientX: 298,
+            preventDefault: () => undefined
+        });
+        renderer.listeners.get('window:mousemove')({ clientX: 250 });
+
+        expect(nativeElement.style.width).toBe('150px');
+        expect(widths).toEqual([150]);
+    });
+
+    it('uses the left drag edge and emits resized width for end-positioned panes', () => {
+        const { directive, elementListeners, nativeElement, renderer } = createDirective();
+        const widths: number[] = [];
+        directive.position = 'end';
+        directive.resized.subscribe(width => widths.push(width));
+        directive.ngOnInit();
+
+        elementListeners.get('mousedown')({
+            clientX: 102,
+            preventDefault: () => undefined
+        });
+        renderer.listeners.get('window:mousemove')({ clientX: 160 });
+
+        expect(nativeElement.style.width).toBe('140px');
+        expect(widths).toEqual([140]);
+    });
+});

--- a/src/app/directives/resizer.directive.ts
+++ b/src/app/directives/resizer.directive.ts
@@ -17,7 +17,7 @@
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
 
-import { Directive, ElementRef, OnInit, Input, Renderer2 } from '@angular/core';
+import { Directive, ElementRef, OnInit, Input, Renderer2, Output, EventEmitter } from '@angular/core';
 
 @Directive({
     selector: '[appResizable]' // Attribute selector
@@ -26,6 +26,7 @@ export class ResizerDirective implements OnInit {
     @Input() resizableGrabWidth = 8;
     @Input() resizableMinWidth = 10;
     @Input() position = 'start';
+    @Output() resized = new EventEmitter<number>();
 
     dragging = false;
 
@@ -41,9 +42,11 @@ export class ResizerDirective implements OnInit {
                 const newWidth = Math.max(this.resizableMinWidth,
                             ((el.nativeElement.offsetLeft + el.nativeElement.offsetWidth) - evt.clientX)) ;
                 el.nativeElement.style.width = newWidth + 'px';
+                this.resized.emit(newWidth);
             } else {
                 const newWidth = Math.max(this.resizableMinWidth, (evt.clientX - el.nativeElement.offsetLeft)) ;
                 el.nativeElement.style.width = newWidth + 'px';
+                this.resized.emit(newWidth);
             }
         };
 


### PR DESCRIPTION
Closes #946.

## Summary

- remember the right-side preview pane width as a desktop preference
- emit resize widths from the vertical resizer and use the left drag edge for the right-side pane
- restore the saved pane width when preferences load, when returning to desktop layout, and when switching back to vertical preview
- keep the mobile right-side preview full width

## Validation

- `git diff --check`
- `npx ng test runbox7 --watch=false --include src/app/app.component.spec.ts --include src/app/directives/resizer.directive.spec.ts --browsers FirefoxHeadless`
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npx eslint src/app/app.component.ts src/app/app.component.html src/app/app.component.spec.ts src/app/directives/resizer.directive.ts src/app/directives/resizer.directive.spec.ts`
- `npm run lint`
- `npm run policy`
- `npx ng test runbox7 --watch=false --progress=false --browsers FirefoxHeadless`
- `node src/build/pre-build.js; npx ng build --configuration production --base-href=/app/ runbox7; node src/build/post-build.js`
- `git diff --cached --check`
- `git show --check --stat --oneline HEAD`

Notes:
- Focused FirefoxHeadless specs pass with `7 SUCCESS`.
- `npm run lint` exits 0 with the repository's existing warning set: 770 warnings, 0 errors.
- `npm run policy` exits 0 after `All commits look OK`, then prints historical commit-message warnings already present in the branch history.
- Full FirefoxHeadless tests pass with `252 SUCCESS` and `2 skipped`.
- Production build passed with existing Angular/CommonJS/Sass warnings and hash `d38367a59cf6907d`.

AI disclosure: I used OpenAI Codex to prepare this change.
