### PR TITLE
Show calendar week numbers

### DIFF
--- a/src/app/calendar-app/calendar-app.component.html
+++ b/src/app/calendar-app/calendar-app.component.html
@@ -1,6 +1,13 @@
 <ng-template #dayViewTemplate let-day="day" let-locale="locale">
     <div class="calendarMonthDayView">
         <div class="cal-cell-top">
+            <span
+                *ngIf="settings.showWeekNumbers && isFirstDayOfCalendarWeek(day.date)"
+                class="calendarWeekNumber"
+                [attr.aria-label]="'Week ' + getCalendarWeekNumber(day.date)"
+            >
+                W{{ getCalendarWeekNumber(day.date) }}
+            </span>
             <span class="cal-day-number">
                 {{ day.date | calendarDate:'monthViewDayNumber':locale }}
             </span>

--- a/src/app/calendar-app/calendar-app.component.scss
+++ b/src/app/calendar-app/calendar-app.component.scss
@@ -18,6 +18,25 @@
     }
 }
 
+.calendarMonthDayView {
+    .cal-cell-top {
+        position: relative;
+    }
+}
+
+.calendarWeekNumber {
+    position: absolute;
+    top: 4px;
+    left: 4px;
+    padding: 1px 4px;
+    border-radius: 2px;
+    background-color: rgba(0, 0, 0, 0.06);
+    color: rgba(0, 0, 0, 0.54);
+    font-size: 11px;
+    font-weight: 600;
+    line-height: 16px;
+}
+
 .updateInfo {
     &:hover {
         background-color: #fff;

--- a/src/app/calendar-app/calendar-app.component.spec.ts
+++ b/src/app/calendar-app/calendar-app.component.spec.ts
@@ -36,6 +36,7 @@ import { of, Observable, ReplaySubject } from 'rxjs';
 import { MatLegacySnackBar as MatSnackBar } from '@angular/material/legacy-snack-bar';
 import { RunboxCalendar } from './runbox-calendar';
 import { RunboxCalendarEvent } from './runbox-calendar-event';
+import { CalendarSettings } from './calendar-settings';
 import { MatIcon } from '@angular/material/icon';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import moment from 'moment';
@@ -244,6 +245,43 @@ END:VCALENDAR
 
         const event = events[0];
         expect(event.innerText).toContain('Test Event #0', 'test event is displayed in the month view');
+    });
+
+    it('should preserve the week number calendar setting', () => {
+        const settings = new CalendarSettings({ showWeekNumbers: true });
+
+        expect(settings.showWeekNumbers).toBeTrue();
+    });
+
+    it('should display week numbers in month view when enabled', () => {
+        component.viewDate = new Date(2026, 0, 15);
+        component.settings.showWeekNumbers = true;
+
+        fixture.detectChanges();
+
+        const weekNumbers = Array.from<HTMLElement>(
+            fixture.debugElement.nativeElement.querySelectorAll('.calendarWeekNumber')
+        ).map(element => element.innerText.trim());
+
+        expect(weekNumbers).toContain('W1');
+        expect(weekNumbers).toContain('W2');
+    });
+
+    it('should use Sunday as the first week-number day when the calendar starts on Sunday', () => {
+        component.settings = new CalendarSettings({ showWeekNumbers: true, weekStartsOnSunday: true });
+
+        expect(component.isFirstDayOfCalendarWeek(new Date(2026, 0, 4))).toBeTrue();
+        expect(component.isFirstDayOfCalendarWeek(new Date(2026, 0, 5))).toBeFalse();
+    });
+
+    it('should hide week numbers in month view by default', () => {
+        component.viewDate = new Date(2026, 0, 15);
+
+        fixture.detectChanges();
+
+        const weekNumbers = fixture.debugElement.nativeElement.querySelectorAll('.calendarWeekNumber');
+
+        expect(weekNumbers.length).toBe(0);
     });
 
     it('should be possible to hide calendars', () => {

--- a/src/app/calendar-app/calendar-app.component.ts
+++ b/src/app/calendar-app/calendar-app.component.ts
@@ -33,7 +33,11 @@ import { MatLegacyDialog as MatDialog } from '@angular/material/legacy-dialog';
 import { MatSidenav } from '@angular/material/sidenav';
 import { MatLegacySnackBar as MatSnackBar } from '@angular/material/legacy-snack-bar';
 
-import { isSameDay, } from 'date-fns';
+import {
+    getISOWeek,
+    getWeek,
+    isSameDay,
+} from 'date-fns';
 
 import { Subject } from 'rxjs';
 
@@ -249,6 +253,18 @@ export class CalendarAppComponent implements OnDestroy {
 
     importEventClicked(): void {
         this.icsUploadInput.nativeElement.click();
+    }
+
+    getCalendarWeekNumber(date: Date): number {
+        if (this.settings.weekStartsOnSunday) {
+            return getWeek(date, { weekStartsOn: 0, firstWeekContainsDate: 1 });
+        }
+
+        return getISOWeek(date);
+    }
+
+    isFirstDayOfCalendarWeek(date: Date): boolean {
+        return date.getDay() === (this.settings.weekStartsOnSunday ? 0 : 1);
     }
 
     importEvents(calendarId: string, ics: string): void {

--- a/src/app/calendar-app/calendar-settings-dialog.component.ts
+++ b/src/app/calendar-app/calendar-settings-dialog.component.ts
@@ -33,6 +33,11 @@ import { CalendarService } from './calendar.service';
             Week starts on sunday
         </mat-checkbox>
     </p>
+    <p>
+        <mat-checkbox [(ngModel)]="settings.showWeekNumbers">
+            Show week numbers
+        </mat-checkbox>
+    </p>
     <mat-divider></mat-divider>
     <p>
         <button mat-raised-button (click)="removeCache()">

--- a/src/app/calendar-app/calendar-settings.ts
+++ b/src/app/calendar-app/calendar-settings.ts
@@ -22,6 +22,7 @@ import { RunboxCalendarView } from './runbox-calendar-view';
 export class CalendarSettings {
     weekStartsOnSunday = false;
     lastUsedView: RunboxCalendarView = RunboxCalendarView.Month;
+    showWeekNumbers = false;
 
     constructor(props: any) {
         if ('weekStartsOnSunday' in props) {
@@ -29,6 +30,9 @@ export class CalendarSettings {
         }
         if ('lastUsedView' in props) {
             this.lastUsedView = props['lastUsedView'];
+        }
+        if ('showWeekNumbers' in props) {
+            this.showWeekNumbers = props['showWeekNumbers'];
         }
     }
 }


### PR DESCRIPTION
Closes #903.

## Summary
- add a persisted calendar setting for showing week numbers
- display week-number badges on the first day cell of each desktop month-view week
- respect the existing Monday/Sunday week-start setting when deciding where week badges appear
- add focused calendar coverage for saved settings, visible/hidden badges, and Sunday-start behavior

## Validation
- `git diff --check`
- `npx ng test runbox7 --watch=false --include src/app/calendar-app/calendar-app.component.spec.ts --browsers FirefoxHeadless`
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npx eslint src/app/calendar-app/calendar-app.component.ts src/app/calendar-app/calendar-app.component.html src/app/calendar-app/calendar-app.component.scss src/app/calendar-app/calendar-app.component.spec.ts src/app/calendar-app/calendar-settings.ts src/app/calendar-app/calendar-settings-dialog.component.ts`
- `npm run lint`
- `npm run policy`
- `npx ng test runbox7 --watch=false --progress=false --browsers FirefoxHeadless`
- `node src/build/pre-build.js; npx ng build --configuration production --base-href=/app/ runbox7; node src/build/post-build.js`
- `git diff --cached --check`
- `git show --check --stat --oneline HEAD`

Notes:
- Focused FirefoxHeadless calendar spec passes with `10 SUCCESS`.
- Full FirefoxHeadless suite passes with `249 SUCCESS` and `2 skipped`.
- `npm run lint` exits 0 with the repository's existing warning set: `770` warnings, `0` errors.
- `npm run policy` exits 0 after `All commits look OK`, then prints historical commit-message warnings already present in the branch history.
- Production build passed with existing Angular/CommonJS/Sass warnings and hash `a307f16d799ec9a0`.

AI disclosure: I used OpenAI Codex to prepare this change.
