### PR TITLE
Apply HTML display setting immediately

### DIFF
--- a/src/app/mailviewer/singlemailviewer.component.spec.ts
+++ b/src/app/mailviewer/singlemailviewer.component.spec.ts
@@ -231,6 +231,24 @@ describe('SingleMailViewerComponent', () => {
       expect(component.mailObj.attachments[1].downloadURL.indexOf('blob:')).toBe(0);
     }));
 
+  it('shows the current HTML message when always show HTML is saved', () => {
+    const preferencesService = TestBed.inject(PreferencesService);
+    spyOn(preferencesService, 'set');
+
+    component.mailContentHTML = '<p>HTML body</p>';
+    component.showHTML = false;
+    component.savedAlways = false;
+    component.savedForThisSender = true;
+    component.showHTMLDecision = 'alwaysshowhtml';
+
+    component.saveShowHTMLDecision();
+
+    expect(preferencesService.set).toHaveBeenCalled();
+    expect(component.showHTML).toBeTrue();
+    expect(component.savedAlways).toBeTrue();
+    expect(component.savedForThisSender).toBeFalse();
+  });
+
   describe('mailto: link interceptor', () => {
     let messageContentsElement: HTMLElement;
     let mailtoLink: HTMLAnchorElement;

--- a/src/app/mailviewer/singlemailviewer.component.ts
+++ b/src/app/mailviewer/singlemailviewer.component.ts
@@ -670,6 +670,13 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
     } else {
       this.preferenceService.remove(this.preferenceService.prefGroup, showHtmlDecisionKey);
     }
+    if (this.showHTMLDecision === 'alwaysshowhtml' && this.mailContentHTML) {
+      this.showHTML = true;
+      this.savedAlways = true;
+      this.savedForThisSender = false;
+    } else {
+      this.savedAlways = false;
+    }
   }
 
   saveShowImagesDecision() {


### PR DESCRIPTION
Fixes #438.

## Summary
- apply the global "Always show HTML" setting to the currently open message as soon as it is saved
- keep the saved-state indicators aligned by marking the setting as global and clearing the per-sender marker
- add focused coverage for saving the setting while an HTML-capable message is currently shown in plain-text mode

## Validation
- `npx ng test runbox7 --watch=false --progress=false --browsers FirefoxHeadless --include src/app/mailviewer/singlemailviewer.component.spec.ts`
- `git diff --check`
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npx eslint src/app/mailviewer/singlemailviewer.component.ts src/app/mailviewer/singlemailviewer.component.spec.ts`
- `npm run lint`
- `npm run policy`
- `npx ng test runbox7 --watch=false --progress=false --browsers FirefoxHeadless`
- `node src/build/pre-build.js; npx ng build --configuration production --base-href=/app/ runbox7; node src/build/post-build.js`
- `git diff --cached --check`
- `git show --check --stat --oneline HEAD`

Notes:
- Focused mailviewer spec passes with `9 SUCCESS`.
- Full FirefoxHeadless suite passes with `246 SUCCESS` and `2 skipped`; Firefox prints known post-success disconnect noise while the command exits 0.
- `npm run lint` exits 0 with the repository's existing warning set: `770` warnings, `0` errors.
- `npm run policy` exits 0 after `All commits look OK`, then prints historical commit-message warnings already present in branch history.
- Production build passed with existing Angular/CommonJS/Sass warnings and hash `988b683fbf1586e7`.
- The focused mailviewer spec still prints existing missing Material list-module template warnings in this harness; the command exits 0.

AI disclosure: I used OpenAI Codex to prepare this change.
