### PR TITLE
Show empty subject messages in lists

### DIFF
--- a/src/app/common/messagelist.spec.ts
+++ b/src/app/common/messagelist.spec.ts
@@ -1,0 +1,115 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { CanvasTableColumn } from '../canvastable/canvastablecolumn';
+import { MessageList } from './messagelist';
+import { SearchMessageDisplay } from '../xapian/searchmessagedisplay';
+import { WebSocketSearchMailList } from '../websocketsearch/websocketsearchmaillist';
+
+describe('MessageList subject display', () => {
+  const subjectColumn = (columns: CanvasTableColumn[]) =>
+    columns.find(column => column.cacheKey === 'subject');
+
+  it('shows a placeholder for unread regular messages with an empty subject', () => {
+    const messageList = new MessageList([{
+      id: 1,
+      seenFlag: false,
+      subject: '',
+      from: [],
+      to: [],
+      messageDate: new Date(),
+      plaintext: '',
+      size: 0,
+      attachment: false,
+      answeredFlag: false,
+      flaggedFlag: false
+    }]);
+
+    const column = subjectColumn(messageList.getCanvasTableColumns({ selectedFolder: 'Inbox' }));
+
+    expect(column.getValue(0)).toBe('(No subject)');
+    expect(messageList.isBoldRow(0)).toBe(true);
+  });
+
+  it('shows a placeholder for unread indexed messages with a whitespace-only subject', () => {
+    const display = new SearchMessageDisplay({
+      getDocData: () => ({
+        seen: false,
+        subject: '   ',
+        recipients: [],
+        from: '',
+        textcontent: '',
+        attachment: false,
+        answered: false,
+        flagged: false
+      }),
+      getMessageIdFromDocId: (docId: number) => docId,
+      api: {
+        getStringValue: () => '202401011200',
+        getNumericValue: () => 0
+      }
+    }, [[2]]);
+
+    const column = subjectColumn(display.getCanvasTableColumns({
+      selectedFolder: 'Inbox',
+      displayFolderColumn: false,
+      viewmode: 'messages'
+    }));
+
+    expect(column.getValue(0)).toBe('(No subject)');
+    expect(display.isBoldRow(0)).toBe(true);
+  });
+
+  it('shows a placeholder for unread websocket search messages with an empty subject', () => {
+    const messageList = new WebSocketSearchMailList([{
+      id: 3,
+      seen: false,
+      subject: '',
+      dateTime: '2024-01-01 12:00:00',
+      fromName: 'Sender',
+      size: 0
+    }]);
+
+    const column = subjectColumn(messageList.getCanvasTableColumns({}));
+
+    expect(column.getValue(0)).toBe('(No subject)');
+    expect(messageList.isBoldRow(0)).toBe(true);
+  });
+
+  it('keeps non-empty subject text unchanged', () => {
+    const messageList = new MessageList([{
+      id: 4,
+      seenFlag: true,
+      subject: 'Actual subject',
+      from: [],
+      to: [],
+      messageDate: new Date(),
+      plaintext: '',
+      size: 0,
+      attachment: false,
+      answeredFlag: false,
+      flaggedFlag: false
+    }]);
+
+    const column = subjectColumn(messageList.getCanvasTableColumns({ selectedFolder: 'Inbox' }));
+
+    expect(column.getValue(0)).toBe('Actual subject');
+    expect(messageList.isBoldRow(0)).toBe(false);
+  });
+});

--- a/src/app/common/messagelist.ts
+++ b/src/app/common/messagelist.ts
@@ -103,7 +103,7 @@ export class MessageList extends MessageDisplay {
         name: 'Subject',
         cacheKey: 'subject',
         sortColumn: null,
-        getValue: (rowIndex: number): string => this.getRow(rowIndex).subject,
+        getValue: (rowIndex: number): string => MessageTableRowTool.formatSubject(this.getRow(rowIndex).subject),
         draggable: true,
         getContentPreviewText: (rowIndex): string => {
           const ret = this.getRow(rowIndex).plaintext;

--- a/src/app/messagetable/messagetablerow.ts
+++ b/src/app/messagetable/messagetablerow.ts
@@ -20,6 +20,9 @@
 const datelen: number = 'yyyy-MM-dd'.length;
 
 export class MessageTableRowTool {
+    public static formatSubject(subject: string): string {
+        return subject && subject.trim().length > 0 ? subject : '(No subject)';
+    }
 
     public static formatTimestampFromDate(mailTime: Date): string {
         // Adjust for users timezone

--- a/src/app/websocketsearch/websocketsearchmaillist.ts
+++ b/src/app/websocketsearch/websocketsearchmaillist.ts
@@ -80,7 +80,7 @@ export class WebSocketSearchMailList extends MessageDisplay {
                 name: 'Subject',
                 cacheKey: 'subject',
                 sortColumn: null,
-                getValue: (rowIndex: number): string => this.getRow(rowIndex).subject,
+                getValue: (rowIndex: number): string => MessageTableRowTool.formatSubject(this.getRow(rowIndex).subject),
                 draggable: true
                 // tooltipText: "Tip: Drag subject to a folder to move message(s)"
             },

--- a/src/app/xapian/searchmessagedisplay.ts
+++ b/src/app/xapian/searchmessagedisplay.ts
@@ -96,7 +96,7 @@ export class SearchMessageDisplay extends MessageDisplay {
           cacheKey: 'subject',
           sortColumn: 1,
           getValue: (rowIndex): string => {
-            return this.searchService.getDocData(this.getRowId(rowIndex)).subject;
+            return MessageTableRowTool.formatSubject(this.searchService.getDocData(this.getRowId(rowIndex)).subject);
           },
           draggable: true,
           getContentPreviewText: (rowIndex): string => {


### PR DESCRIPTION
Fixes #449.

## Summary
- show `(No subject)` in message-list subject cells when the message subject is empty or whitespace-only
- apply the same subject fallback to regular message lists, indexed search results, and websocket search result rows
- keep existing unread/read styling intact so the placeholder is bold for unread rows and normal weight for read rows
- add focused coverage for regular, indexed, and websocket message-list sources

## Validation
- `npx ng test runbox7 --watch=false --progress=false --browsers FirefoxHeadless --include src/app/common/messagelist.spec.ts`
- `git diff --check`
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npx eslint src/app/messagetable/messagetablerow.ts src/app/common/messagelist.ts src/app/common/messagelist.spec.ts src/app/xapian/searchmessagedisplay.ts src/app/websocketsearch/websocketsearchmaillist.ts`
- `npm run lint`
- `npm run policy`
- `npx ng test runbox7 --watch=false --progress=false --browsers FirefoxHeadless`
- `node src/build/pre-build.js; npx ng build --configuration production --base-href=/app/ runbox7; node src/build/post-build.js`
- `git diff --cached --check`
- `git show --check --stat --oneline HEAD`

Notes:
- Focused subject-display spec passes with `4 SUCCESS`.
- Full FirefoxHeadless suite passes with `249 SUCCESS` and `2 skipped`; it prints existing noisy websocket/template logs while the command exits 0.
- `npm run lint` exits 0 with the repository's existing warning set: `770` warnings, `0` errors.
- `npm run policy` exits 0 after `All commits look OK`, then prints historical commit-message warnings already present in branch history.
- Production build passed with existing Angular/CommonJS/Sass warnings and hash `bb62dbabc9abf203`.

AI disclosure: I used OpenAI Codex to prepare this change.
