### PR TITLE
Add PWA share target for compose

### DIFF
--- a/src/app/compose/draftdesk.component.spec.ts
+++ b/src/app/compose/draftdesk.component.spec.ts
@@ -1,0 +1,61 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2022 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { BehaviorSubject, of } from 'rxjs';
+import { ActivatedRoute, Router } from '@angular/router';
+
+import { DraftDeskComponent } from './draftdesk.component';
+import { DraftDeskService, DraftFormModel } from './draftdesk.service';
+import { Identity } from '../profiles/profile.service';
+import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
+
+describe('DraftDeskComponent', () => {
+    it('creates a compose draft from Web Share Target query parameters', async () => {
+        const draftDeskService = {
+            draftModels: new BehaviorSubject<DraftFormModel[]>([]),
+            fromsSubject: new BehaviorSubject([
+                Identity.fromObject({ email: 'sender@runbox.com' })
+            ]),
+            newSharedDraft: jasmine.createSpy('newSharedDraft').and.returnValue(Promise.resolve())
+        };
+        const route = {
+            queryParams: of({
+                'share-title': 'Shared page',
+                'share-text': 'Shared text',
+                'share-url': 'https://example.com/page'
+            })
+        };
+
+        const component = new DraftDeskComponent(
+            {} as RunboxWebmailAPI,
+            {} as Router,
+            route as unknown as ActivatedRoute,
+            draftDeskService as unknown as DraftDeskService
+        );
+        component.ngOnInit();
+
+        await Promise.resolve();
+
+        expect(draftDeskService.newSharedDraft).toHaveBeenCalledWith(
+            'Shared page',
+            'Shared text',
+            'https://example.com/page'
+        );
+    });
+});

--- a/src/app/compose/draftdesk.component.ts
+++ b/src/app/compose/draftdesk.component.ts
@@ -22,8 +22,12 @@ import { Router, ActivatedRoute } from '@angular/router';
 import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
 import { DraftDeskService, DraftFormModel } from './draftdesk.service';
 import { RecipientsService } from './recipients.service';
+import { filter, take } from 'rxjs/operators';
 
 const MAX_DRAFTS_IN_VIEW = 10;
+const SHARE_TARGET_TITLE_PARAM = 'share-title';
+const SHARE_TARGET_TEXT_PARAM = 'share-text';
+const SHARE_TARGET_URL_PARAM = 'share-url';
 
 @Component({
     templateUrl: 'draftdesk.component.html',
@@ -43,7 +47,7 @@ export class DraftDeskComponent implements OnInit {
         public draftDeskservice: DraftDeskService) {
 
         this.draftDeskservice.draftModels.subscribe(
-            drafts => this.updateDraftsInView(),
+            _drafts => this.updateDraftsInView(),
             err => console.log(err)
         );
     }
@@ -51,21 +55,35 @@ export class DraftDeskComponent implements OnInit {
     ngOnInit() {
         this.route.queryParams
             .subscribe(params => {
+                const sharedTitle = params[SHARE_TARGET_TITLE_PARAM];
+                const sharedText = params[SHARE_TARGET_TEXT_PARAM];
+                const sharedUrl = params[SHARE_TARGET_URL_PARAM];
                 if (params['to']) {
-                    this.draftDeskservice.newDraft(
-                        DraftFormModel.create(-1, this.draftDeskservice.fromsSubject.value[0], params['to'], '')
-                    ).then(() => this.updateDraftsInView());
+                    this.withLoadedFroms(() => {
+                        this.draftDeskservice.newDraft(
+                            DraftFormModel.create(-1, this.draftDeskservice.fromsSubject.value[0], params['to'], '')
+                        ).then(() => this.updateDraftsInView());
+                    });
+                } else if (sharedTitle || sharedText || sharedUrl) {
+                    this.withLoadedFroms(() => {
+                        this.draftDeskservice.newSharedDraft(sharedTitle, sharedText, sharedUrl)
+                            .then(() => this.updateDraftsInView());
+                    });
                 } else if (params['new']) {
-                    // Can't create a new draft until froms has been loaded
-                    // FIXME: This needs to only happen once (after froms loaded)
-                    this.draftDeskservice.fromsSubject.subscribe((froms) => {
-                        if (froms.length > 0 && !this.hasInitialized) {
+                    this.withLoadedFroms(() => {
+                        if (!this.hasInitialized) {
                             this.newDraft();
                             this.hasInitialized = true;
                         }
                     });
                 }
             });
+    }
+
+    private withLoadedFroms(action: () => void): void {
+        this.draftDeskservice.fromsSubject
+            .pipe(filter((froms) => froms.length > 0), take(1))
+            .subscribe(() => action());
     }
 
     updateDraftsInView() {

--- a/src/app/compose/draftdesk.service.spec.ts
+++ b/src/app/compose/draftdesk.service.spec.ts
@@ -565,6 +565,28 @@ describe('DraftDeskService', () => {
         });
     });
 
+    describe('newSharedDraft', () => {
+        it('should create shared draft from Web Share Target fields', async () => {
+            await draftDeskService.newSharedDraft('Shared page', 'Shared text', 'https://example.com/page');
+
+            const drafts = draftDeskService.draftModels.value;
+            expect(drafts.length).toBeGreaterThan(0);
+
+            const sharedDraft = drafts[0];
+            expect(sharedDraft.subject).toBe('Shared page');
+            expect(sharedDraft.msg_body).toBe('Shared text\n\nhttps://example.com/page');
+            expect(sharedDraft.to).toEqual([]);
+        });
+
+        it('should not duplicate identical shared text and URL values', async () => {
+            await draftDeskService.newSharedDraft('', 'https://example.com/page', 'https://example.com/page');
+
+            const drafts = draftDeskService.draftModels.value;
+            expect(drafts[0].subject).toBe('');
+            expect(drafts[0].msg_body).toBe('https://example.com/page');
+        });
+    });
+
     describe('mainIdentity', () => {
         it('should return compose profile from ProfileService', () => {
             const identity = draftDeskService.mainIdentity();

--- a/src/app/compose/draftdesk.service.ts
+++ b/src/app/compose/draftdesk.service.ts
@@ -396,6 +396,26 @@ export class DraftDeskService {
         await this.newDraft(draftObj);
     }
 
+    public async newSharedDraft(title: string, text: string, url: string) {
+        const draftObj = DraftFormModel.create(
+            -1,
+            this.mainIdentity(),
+            null,
+            (title || '').trim()
+        );
+        draftObj.msg_body = DraftDeskService.joinSharedContent(text, url);
+
+        await this.newDraft(draftObj);
+    }
+
+    private static joinSharedContent(text?: string, url?: string): string {
+        const sharedParts = [text, url]
+            .map(part => (part || '').trim())
+            .filter(part => part.length > 0);
+
+        return [...new Set(sharedParts)].join('\n\n');
+    }
+
     public newDraft(model: DraftFormModel): Promise<void> {
         return new Promise((resolve, _) => {
             const afterPrepare = () => {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -6,6 +6,16 @@
   "display": "standalone",
   "scope": "/app/",
   "start_url": "/app/",
+  "share_target": {
+    "action": "/app/compose",
+    "method": "GET",
+    "enctype": "application/x-www-form-urlencoded",
+    "params": {
+      "title": "share-title",
+      "text": "share-text",
+      "url": "share-url"
+    }
+  },
   "icons": [
     {
       "src": "assets/icons/icon-72x72.png",


### PR DESCRIPTION
Fixes #1497.

## Summary
- Registers Runbox 7 as a PWA Web Share Target for shared title, text, and URL payloads.
- Opens the compose route from share-target launches and waits for identities before creating the draft, matching the existing `?new=true` flow's loading requirement.
- Creates a new compose draft with the shared title as the subject and shared text/URL in the body, avoiding duplicate body text when Android supplies the same URL twice.

## Validation
- `node -e "JSON.parse(require('fs').readFileSync('src/manifest.json','utf8')); console.log('manifest ok')"`
- `npx ng test runbox7 --watch=false --progress=false --browsers FirefoxHeadless --include src/app/compose/draftdesk*.spec.ts` (`25 SUCCESS`)
- `npx eslint src/app/compose/draftdesk.component.ts src/app/compose/draftdesk.component.spec.ts src/app/compose/draftdesk.service.ts src/app/compose/draftdesk.service.spec.ts` (0 errors; existing compose warnings remain)
- `npx tsc --noEmit`
- `npm run policy` (passes; historical upstream commit-message warnings are still printed)
- `npm run lint` (0 errors, existing `769 warnings`)
- `npx ng test runbox7 --watch=false --progress=false --browsers FirefoxHeadless` (`248 SUCCESS`, `2 skipped`)
- Manual production build with `SKIP_CHANGELOG=1` using the repository pre-build/build/post-build steps (build hash `cf3fef5cdfe1f597`; existing Angular/CommonJS warnings)
