### PR TITLE
Label deleted contact group members

### DIFF
--- a/src/app/contacts-app/contact-details/contact-details.component.html
+++ b/src/app/contacts-app/contact-details/contact-details.component.html
@@ -126,7 +126,9 @@
                             </button>
                         </span>
                         <ng-template #not_contact>
-                            {{ member.value }}
+                            <span [matTooltip]="member.uuid ? 'Missing contact ID: ' + member.value : ''">
+                                {{ member.display_name() }}
+                            </span>
                         </ng-template>
 
                         <button mat-icon-button *ngIf="mobileQuery.matches" (click)="removeGroupMember(idx)">

--- a/src/app/contacts-app/contact.spec.ts
+++ b/src/app/contacts-app/contact.spec.ts
@@ -17,7 +17,7 @@
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------
 
-import { Contact, ContactKind, Address, AddressDetails } from './contact';
+import { Contact, ContactKind, Address, AddressDetails, GroupMember } from './contact';
 
 describe('Contact', () => {
     it('can create contact with no name', () => {
@@ -208,6 +208,19 @@ END:VCARD`);
         expect(sut.members[1].uuid).toBe('f00d');
         expect(sut.members[1].name).toBe('Sybilla');
         expect(sut.members[1].email).toBe('sybil@syb.il');
+    });
+
+    it('can display unresolved group members readably', () => {
+        const deletedMember = GroupMember.fromUUID('03a0e51f-d1aa-4385-8a53-e29025acd8ae');
+        expect(deletedMember.display_name()).toBe('Deleted contact');
+
+        const emailMember = Contact.fromVcard(null, `BEGIN:VCARD
+VERSION:4.0
+KIND:group
+MEMBER;X-CN=Jamie:mailto:jamie@me.me
+END:VCARD`).members[0];
+
+        expect(emailMember.display_name()).toBe('Jamie <jamie@me.me>');
     });
 
     it('can parse org and department correctly', () => {

--- a/src/app/contacts-app/contact.ts
+++ b/src/app/contacts-app/contact.ts
@@ -44,6 +44,22 @@ export class GroupMember {
         return this.scheme === 'mailto' ? this.value : this.prop.getParameter('x-email');
     }
 
+    display_name(): string {
+        if (this.name && this.email) {
+            return `${this.name} <${this.email}>`;
+        }
+        if (this.name) {
+            return this.name;
+        }
+        if (this.email) {
+            return this.email;
+        }
+        if (this.uuid) {
+            return 'Deleted contact';
+        }
+        return this.value;
+    }
+
     constructor(public prop: ICAL.Property) {
         const value = prop.getFirstValue();
         const splitter = value.lastIndexOf(':');


### PR DESCRIPTION
Fixes #682.

## Summary
- Labels unresolved UUID group members as `Deleted contact` instead of rendering the raw member value in group details.
- Keeps non-contact group members readable by using display names and email addresses when available.
- Adds a tooltip with the missing contact UUID for unresolved deleted-contact references.

## Validation
- `npx ng test runbox7 --watch=false --progress=false --browsers FirefoxHeadless --include src/app/contacts-app/contact.spec.ts` (`24 SUCCESS`)
- `npx ng test runbox7 --watch=false --progress=false --browsers FirefoxHeadless --include src/app/contacts-app/*.spec.ts` (`37 SUCCESS`)
- `npx eslint src/app/contacts-app/contact.ts src/app/contacts-app/contact.spec.ts src/app/contacts-app/contact-details/contact-details.component.html` (0 errors; existing contact/template warnings remain)
- `npx tsc --noEmit`
- `git diff --check`
- `npm run lint` (0 errors, existing `770 warnings`)
- `npx ng test runbox7 --watch=false --progress=false --browsers FirefoxHeadless` (`246 SUCCESS`, `2 skipped`)
- Manual production build with `SKIP_CHANGELOG=1` using the repository pre-build/build/post-build steps (build hash `404bf4e4cca2d526`; existing Angular/CommonJS warnings)
- `npm run policy` before and after commit (passes; historical upstream commit-message warnings are still printed)
- `git diff --cached --check`
- `git show --check --stat --oneline HEAD`

No live Runbox account, Contacts data, backend API, or production service action was used for validation.
