### PR TITLE
Decode quoted-printable calendar imports

### DIFF
--- a/src/app/calendar-app/calendar.service.spec.ts
+++ b/src/app/calendar-app/calendar.service.spec.ts
@@ -273,6 +273,29 @@ END:VCALENDAR
         expect(rbevents[0].recurringFrequency).toEqual('DAILY', 'recurrence is DAILY');
     });
 
+    it('should decode quoted-printable text when importing an .ics file', () => {
+        const imported = sut.importFromIcal(undefined,
+`BEGIN:VCALENDAR
+X-LOTUS-CHARSET:UTF-8
+VERSION:2.0
+BEGIN:VEVENT
+DTSTART:20260610T100000Z
+DTEND:20260610T110000Z
+SUMMARY;CHARSET=UTF-8;ENCODING=QUOTED-PRINTABLE:=C3=98ystein m=C3=B8te
+LOCATION;ENCODING=QUOTED-PRINTABLE;CHARSET=UTF-8:Bl=C3=A5b=C3=A6rveien 1
+DESCRIPTION;ENCODING=QUOTED-PRINTABLE:F=C3=B8rste linje=0AAndre linje
+UID:quoted-printable-import
+END:VEVENT
+END:VCALENDAR
+`, false);
+        const rbevents = sut.generateEvents(undefined, undefined, [imported]);
+        const overview = rbevents[0].get_overview()[0];
+
+        expect(overview.title).toBe('\u00d8ystein m\u00f8te');
+        expect(overview.location).toBe('Bl\u00e5b\u00e6rveien 1');
+        expect(overview.description).toBe('F\u00f8rste linje\nAndre linje');
+    });
+
     it('should be possible to import an .ics file with exceptions', () => {
         sut.loadVTimezone('Europe/Stockholm');
         sut.importFromIcal(undefined,

--- a/src/app/calendar-app/calendar.service.ts
+++ b/src/app/calendar-app/calendar.service.ts
@@ -303,7 +303,7 @@ export class CalendarService implements OnDestroy {
     // an exception ICAL.Event gets both the exception, and the main one!?
     // set an "isException" flag!?
     importFromIcal(id: string, ical: string, keep = true): {id: string, event: any} {
-        let component = new ICAL.Component(ICAL.parse(ical));
+        let component = new ICAL.Component(ICAL.parse(CalendarService.preprocessIcal(ical)));
         // https://github.com/mozilla-comm/ical.js/issues/455
         if (component.getFirstSubcomponent('vtimezone')) {
             for (const tzComponent of component.getAllSubcomponents('vtimezone')) {
@@ -349,6 +349,102 @@ export class CalendarService implements OnDestroy {
         }
 
         return { 'id': id, 'event': vevents[0] };
+    }
+
+    private static preprocessIcal(ical: string): string {
+        const lines = CalendarService.unfoldIcalLines(ical);
+        const calendarCharset = CalendarService.getCalendarCharset(lines);
+        return lines
+            .map((line) => CalendarService.decodeQuotedPrintableLine(line, calendarCharset))
+            .join('\r\n');
+    }
+
+    private static unfoldIcalLines(ical: string): string[] {
+        const lines = ical.split(/\r\n|\n|\r/);
+        const unfolded: string[] = [];
+
+        for (const line of lines) {
+            if (/^[ \t]/.test(line) && unfolded.length > 0) {
+                unfolded[unfolded.length - 1] += line.slice(1);
+            } else {
+                unfolded.push(line);
+            }
+        }
+
+        return unfolded;
+    }
+
+    private static getCalendarCharset(lines: string[]): string | undefined {
+        const charsetLine = lines.find((line) => /^X-LOTUS-CHARSET:/i.test(line));
+        if (!charsetLine) {
+            return undefined;
+        }
+
+        return charsetLine.slice(charsetLine.indexOf(':') + 1).trim();
+    }
+
+    private static decodeQuotedPrintableLine(line: string, calendarCharset: string | undefined): string {
+        const separator = CalendarService.findIcalValueSeparator(line);
+        if (separator < 0) {
+            return line;
+        }
+
+        const property = line.slice(0, separator);
+        if (!/;\s*ENCODING\s*=\s*"?QUOTED-PRINTABLE"?/i.test(property)) {
+            return line;
+        }
+
+        const charset = CalendarService.getIcalParameter(property, 'CHARSET') || calendarCharset || 'UTF-8';
+        const decodedValue = CalendarService.decodeQuotedPrintableValue(line.slice(separator + 1), charset)
+            .replace(/\r\n|\r|\n/g, '\\n');
+        const decodedProperty = property
+            .replace(/;\s*ENCODING\s*=\s*"?QUOTED-PRINTABLE"?/i, '')
+            .replace(/;\s*CHARSET\s*=\s*("[^"]*"|[^;]*)/i, '');
+
+        return `${decodedProperty}:${decodedValue}`;
+    }
+
+    private static findIcalValueSeparator(line: string): number {
+        let quoted = false;
+
+        for (let i = 0; i < line.length; i++) {
+            if (line[i] === '"') {
+                quoted = !quoted;
+            } else if (line[i] === ':' && !quoted) {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private static getIcalParameter(property: string, name: string): string | undefined {
+        const parameter = new RegExp(`;\\s*${name}\\s*=\\s*("[^"]*"|[^;]*)`, 'i').exec(property);
+        if (!parameter) {
+            return undefined;
+        }
+
+        return parameter[1].replace(/^"|"$/g, '');
+    }
+
+    private static decodeQuotedPrintableValue(value: string, charset: string): string {
+        const bytes: number[] = [];
+        const textEncoder = new TextEncoder();
+
+        for (let i = 0; i < value.length; i++) {
+            if (value[i] === '=' && /^[0-9A-Fa-f]{2}$/.test(value.slice(i + 1, i + 3))) {
+                bytes.push(parseInt(value.slice(i + 1, i + 3), 16));
+                i += 2;
+            } else {
+                bytes.push(...textEncoder.encode(value[i]));
+            }
+        }
+
+        try {
+            return new TextDecoder(charset).decode(new Uint8Array(bytes));
+        } catch {
+            return new TextDecoder('UTF-8').decode(new Uint8Array(bytes));
+        }
     }
 
     // generate RBE events from ICAL.Events (inc exceptions)


### PR DESCRIPTION
Fixes #810.

## Summary
- preprocess imported iCalendar data before `ICAL.parse()` so legacy `ENCODING=QUOTED-PRINTABLE` text fields are decoded for the calendar import preview
- support per-property `CHARSET` values, with `X-LOTUS-CHARSET` as the calendar-level fallback used by some older invitations
- add a regression test that verifies decoded summary, location, and description text through the generated event overview path used by the import dialog

## Validation
- `npx ng test runbox7 --watch=false --progress=false --browsers FirefoxHeadless --include src/app/calendar-app/calendar.service.spec.ts` (`10 SUCCESS`)
- `npx eslint src/app/calendar-app/calendar.service.ts src/app/calendar-app/calendar.service.spec.ts` (0 errors; existing warnings only)
- `npx tsc --noEmit`
- `npx ng test runbox7 --watch=false --progress=false --browsers FirefoxHeadless --include src/app/calendar-app/*.spec.ts` (`32 SUCCESS`)
- `git diff --check`
- `npm run policy` (new commit OK; existing historical commit-message warnings still reported)
- `npm run lint` (0 errors; existing `770` warnings)
- `npx ng test runbox7 --watch=false --progress=false --browsers FirefoxHeadless` (`246 SUCCESS`, `2 skipped`)
- manual production build: `SKIP_CHANGELOG=1`, `node src/build/pre-build.js`, `npx ng build --configuration production --base-href=/app/ runbox7`, `node src/build/post-build.js` (hash `183f414ebd43b78b`; existing Angular/CommonJS warnings)
- `git diff --cached --check`
- `git show --check --stat --oneline HEAD`
