### PR TITLE
Close preview after reporting spam

### DIFF
--- a/src/app/mailviewer/rmm7messageactions.spec.ts
+++ b/src/app/mailviewer/rmm7messageactions.spec.ts
@@ -1,0 +1,110 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2018 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { Subject } from 'rxjs';
+import { RMM7MessageActions } from './rmm7messageactions';
+
+interface SpamTrainingResponse {
+    status: string;
+    result: {
+        changed_time: number;
+        feedback: string;
+    };
+}
+
+describe('RMM7MessageActions', () => {
+    let actions: RMM7MessageActions;
+    let remoteResponse: Subject<SpamTrainingResponse>;
+    let mailViewerComponent: {
+        close: jasmine.Spy;
+        messageId: number;
+    };
+    let messageListService: {
+        moveMessages: jasmine.Spy;
+        spamFolderName: string;
+    };
+    let rmmapi: {
+        showBackendErrors: jasmine.Spy;
+        trainSpam: jasmine.Spy;
+    };
+    let searchService: {
+        deleteMessages: jasmine.Spy;
+        indexWorker: {
+            postMessage: jasmine.Spy;
+        };
+        localSearchActivated: boolean;
+    };
+    let snackBar: {
+        open: jasmine.Spy;
+    };
+
+    beforeEach(() => {
+        remoteResponse = new Subject<SpamTrainingResponse>();
+        mailViewerComponent = {
+            close: jasmine.createSpy('close'),
+            messageId: 1234
+        };
+        messageListService = {
+            moveMessages: jasmine.createSpy('moveMessages'),
+            spamFolderName: 'Spam'
+        };
+        rmmapi = {
+            showBackendErrors: jasmine.createSpy('showBackendErrors'),
+            trainSpam: jasmine.createSpy('trainSpam').and.returnValue(remoteResponse.asObservable())
+        };
+        searchService = {
+            deleteMessages: jasmine.createSpy('deleteMessages'),
+            indexWorker: {
+                postMessage: jasmine.createSpy('postMessage')
+            },
+            localSearchActivated: false
+        };
+        snackBar = {
+            open: jasmine.createSpy('open')
+        };
+
+        actions = new RMM7MessageActions();
+        actions.mailViewerComponent = mailViewerComponent as unknown as RMM7MessageActions['mailViewerComponent'];
+        actions.messageListService = messageListService as unknown as RMM7MessageActions['messageListService'];
+        actions.rmmapi = rmmapi as unknown as RMM7MessageActions['rmmapi'];
+        actions.searchService = searchService as unknown as RMM7MessageActions['searchService'];
+        actions.snackBar = snackBar as unknown as RMM7MessageActions['snackBar'];
+    });
+
+    it('closes the message preview immediately when reporting spam', () => {
+        actions.trainSpam({is_spam: 1});
+
+        expect(searchService.deleteMessages).toHaveBeenCalledWith([1234]);
+        expect(messageListService.moveMessages).toHaveBeenCalledWith([1234], 'Spam', true);
+        expect(mailViewerComponent.close).toHaveBeenCalledTimes(1);
+        expect(rmmapi.trainSpam).toHaveBeenCalledWith({is_spam: 1, messages: [1234]});
+
+        remoteResponse.next({
+            status: 'success',
+            result: {
+                changed_time: 0,
+                feedback: 'Reported spam'
+            }
+        });
+        remoteResponse.complete();
+
+        expect(mailViewerComponent.close).toHaveBeenCalledTimes(1);
+        expect(snackBar.open).toHaveBeenCalledWith('Reported spam', 'Dismiss', {duration: 3000});
+    });
+});

--- a/src/app/mailviewer/rmm7messageactions.ts
+++ b/src/app/mailviewer/rmm7messageactions.ts
@@ -177,6 +177,7 @@ export class RMM7MessageActions implements MessageActions {
                         });
                     }
                 }
+                this.mailViewerComponent.close();
             },
             updateRemote: (msgIds: number[]) => {
                 const res = this.rmmapi.trainSpam({is_spam: params.is_spam, messages: msgIds});
@@ -191,7 +192,6 @@ export class RMM7MessageActions implements MessageActions {
                 return res;
             },
             afterwards: (result) => {
-                this.mailViewerComponent.close();
                 this.snackBar.open(
                     result['result']['feedback'], 'Dismiss', {
                         duration: 3000


### PR DESCRIPTION
Fixes #401.

## Summary
- Close the single-message preview during the local spam/not-spam update, so moving the open message out of the current folder immediately clears the preview pane.
- Keep the backend feedback snackbar after the remote spam-training call succeeds.
- Add a regression test that keeps the remote response pending and verifies the preview closes before the server responds.

## Testing
- `npx ng test runbox7 --watch=false --progress=false --browsers FirefoxHeadless --include src/app/mailviewer/rmm7messageactions.spec.ts`
- `npx eslint src/app/mailviewer/rmm7messageactions.ts src/app/mailviewer/rmm7messageactions.spec.ts` (passes with 2 existing warnings in `rmm7messageactions.ts`)
- `npx tsc --noEmit`
- `npx ng test runbox7 --watch=false --progress=false --browsers FirefoxHeadless --include src/app/mailviewer/*.spec.ts` (9 success; existing Angular template warnings in `singlemailviewer.component.spec.ts`)
- `git diff --check`
- `git diff --cached --check`
- `npm run policy` (passes; historical commit-message warnings only)
- `git show --check --stat --oneline HEAD`
- `npm run lint` (0 errors, existing 770 warnings)
- `npx ng test runbox7 --watch=false --progress=false --browsers FirefoxHeadless` (246 success, 2 skipped; existing noisy Angular/WebSocket logs)
- `$env:SKIP_CHANGELOG='1'; node src/build/pre-build.js; npx ng build --configuration production --base-href=/app/ runbox7; node src/build/post-build.js` (build hash `87782cc008130b33`, existing Angular/CommonJS warnings)

No live Runbox account, mailbox, spam-training, or production API action was used for this patch.
