### PR TITLE
Fix From sorting with special characters

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1355,6 +1355,13 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
               this.canvastablecontainer.sortDescending ? 1 : 0, 0, 50000,
               this.viewmode === 'conversations' ? 1 : -1
             );
+            if (this.canvastablecontainer.sortColumn === 0) {
+              searchResults = SearchMessageDisplay.sortRowsByFrom(
+                searchResults,
+                this.searchService,
+                this.canvastablecontainer.sortDescending
+              );
+            }
           });
           // console.log("Search time: "+(new Date().getTime()-startTime));
           // console.log(searchResults.length);

--- a/src/app/common/messageinfo.spec.ts
+++ b/src/app/common/messageinfo.spec.ts
@@ -19,6 +19,7 @@
 
 import { MessageInfo, IndexingTools } from './messageinfo';
 import { MailAddressInfo } from './mailaddressinfo';
+import { XapianAPI } from '@runboxcom/runbox-searchindex/rmmxapianapi';
 
 describe('MessageInfo', () => {
     it('testGetSubjectWithoutAbbreviation', () => {
@@ -28,6 +29,30 @@ describe('MessageInfo', () => {
         expect(MessageInfo.getSubjectWithoutAbbreviation('SV: Fwd: Test FWD: svar')).toBe('Test FWD: svar');
         expect(MessageInfo.getSubjectWithoutAbbreviation('')).toBe('');
         expect(MessageInfo.getSubjectWithoutAbbreviation(null)).toBe('');
+    });
+
+    it('builds a sortable text key for names with punctuation and diacritics', () => {
+        const sortedNames = [
+            'Alice',
+            '"Bob',
+            '_Carl',
+            'Charlie',
+            'Časlav',
+            'David'
+        ].sort((a, b) => MessageInfo.getSortableText(a) < MessageInfo.getSortableText(b) ? -1 : 1);
+
+        expect(sortedNames).toEqual([
+            'Alice',
+            '"Bob',
+            '_Carl',
+            'Charlie',
+            'Časlav',
+            'David'
+        ]);
+        expect(MessageInfo.getSortableText('"Bob')).toBe('BOB');
+        expect(MessageInfo.getSortableText('_Carl')).toBe('CARL');
+        expect(MessageInfo.getSortableText('Časlav')).toBe('C~ASLAV');
+        expect(MessageInfo.getSortableText('C~ASLAV')).toBe('C~ASLAV');
     });
 
     it('testAddMessageToIndexWithDeleteFolders', () => {
@@ -59,7 +84,7 @@ describe('MessageInfo', () => {
             deleteDocumentByUniqueTerm: () => {
                 removeCalled = true;
             }
-        }  as any);
+        } as unknown as XapianAPI);
 
         indexingtools.addMessageToIndex(msg);
         expect(addCalled).toBeTruthy();
@@ -72,6 +97,35 @@ describe('MessageInfo', () => {
         indexingtools.addMessageToIndex(msg, ['Trash', 'Spam']);
         expect(removeCalled).toBeFalsy();
         expect(addCalled).toBeTruthy();
+    });
+
+    it('passes normalized From sort text to the index', () => {
+        const msg = new MessageInfo(3,
+            new Date(),
+            new Date(),
+            'Inbox',
+            false,
+            false,
+            false,
+            [new MailAddressInfo('_Časlav', 'caslav@example.com')],
+            MailAddressInfo.parse('test2@example.com'),
+            [],
+            [],
+            'Test subject',
+            'The text',
+            50,
+            false
+            );
+
+        let sortableFrom = '';
+        const indexingtools = new IndexingTools({
+            addSortableEmailToXapianIndex: (...args: unknown[]) => {
+                sortableFrom = args[2] as string;
+            },
+        } as unknown as XapianAPI);
+
+        indexingtools.addMessageToIndex(msg);
+        expect(sortableFrom).toBe('C~ASLAV');
     });
 
     it('test AddMessageToIndex with bad dates', () => {
@@ -97,7 +151,7 @@ describe('MessageInfo', () => {
             addSortableEmailToXapianIndex: () => {
                 addCalled = true;
             },
-        }  as any);
+        } as unknown as XapianAPI);
 
         indexingtools.addMessageToIndex(msg);
         expect(addCalled).toBeTruthy();

--- a/src/app/common/messageinfo.ts
+++ b/src/app/common/messageinfo.ts
@@ -21,6 +21,9 @@ import { XapianAPI } from '@runboxcom/runbox-searchindex/rmmxapianapi';
 import { MailAddressInfo } from './mailaddressinfo';
 
 export class MessageInfo {
+    private static ignoredSortCharacterRegex = /[\p{P}\p{S}]/u;
+    private static combiningMarkRegex = /[\u0300-\u036f]/;
+
     deletedFlag: boolean;
 
     constructor(
@@ -58,6 +61,28 @@ export class MessageInfo {
             subjectTextStart ++;
         }
         return subjectparts.slice(subjectTextStart).join(' ');
+    }
+
+    static getSortableText(text: string): string {
+        let sortText = '';
+        const normalizedText = text ? text.trim().normalize('NFD') : '';
+
+        for (const ch of normalizedText) {
+            if (MessageInfo.combiningMarkRegex.test(ch)) {
+                if (sortText.length > 0 && sortText.charAt(sortText.length - 1) !== '~') {
+                    sortText += '~';
+                }
+                continue;
+            }
+
+            if (ch !== '~' && MessageInfo.ignoredSortCharacterRegex.test(ch)) {
+                continue;
+            }
+
+            sortText += ch.toUpperCase();
+        }
+
+        return sortText.replace(/\s+/g, ' ').trim();
     }
 }
 
@@ -126,7 +151,7 @@ export class IndexingTools {
         this.indexAPI.addSortableEmailToXapianIndex(
             'Q' + msginfo.id,
             visibleFrom,
-            visibleFrom.toUpperCase(),
+            MessageInfo.getSortableText(visibleFrom),
             fromAddressInfo.address,
             recipients,
             msginfo.subject,

--- a/src/app/xapian/searchmessagedisplay.spec.ts
+++ b/src/app/xapian/searchmessagedisplay.spec.ts
@@ -1,0 +1,59 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2022 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { SearchMessageDisplay } from './searchmessagedisplay';
+
+describe('SearchMessageDisplay', () => {
+  it('sorts From rows using normalized Xapian sort text', () => {
+    const sortableFromValues: { [key: number]: string } = {
+      1: 'ALICE',
+      2: '"BOB',
+      3: '_CARL',
+      4: 'CHARLIE',
+      5: 'ČASLAV',
+      6: 'DAVID'
+    };
+    const searchService = {
+      api: {
+        getStringValue: (docid: number, slot: number) => {
+          expect(slot).toBe(0);
+          return sortableFromValues[docid];
+        }
+      }
+    };
+    const rows: Array<[number]> = [[1], [2], [3], [4], [5], [6]];
+
+    expect(SearchMessageDisplay.sortRowsByFrom(rows, searchService, false).map((row) => row[0]))
+      .toEqual([1, 2, 3, 4, 5, 6]);
+    expect(SearchMessageDisplay.sortRowsByFrom(rows, searchService, true).map((row) => row[0]))
+      .toEqual([6, 5, 4, 3, 2, 1]);
+  });
+
+  it('keeps equal normalized From rows in their original order', () => {
+    const searchService = {
+      api: {
+        getStringValue: (_docid: number, _slot: number) => '"BOB'
+      }
+    };
+    const rows: Array<[number]> = [[3], [1], [2]];
+
+    expect(SearchMessageDisplay.sortRowsByFrom(rows, searchService, false)).toEqual(rows);
+    expect(SearchMessageDisplay.sortRowsByFrom(rows, searchService, true)).toEqual(rows);
+  });
+});

--- a/src/app/xapian/searchmessagedisplay.ts
+++ b/src/app/xapian/searchmessagedisplay.ts
@@ -21,6 +21,14 @@ import { MessageDisplay } from '../common/messagedisplay';
 import { SearchService } from './searchservice';
 import { MessageTableRowTool} from '../messagetable/messagetablerow';
 import { CanvasTableColumn } from '../canvastable/canvastablecolumn';
+import { MessageInfo } from '../common/messageinfo';
+
+type SearchResultRow = [number, ...unknown[]];
+interface FromSortValueSource {
+  api: {
+    getStringValue(docid: number, slot: number): string;
+  };
+}
 
 export class SearchMessageDisplay extends MessageDisplay {
   private searchService: SearchService;
@@ -29,6 +37,30 @@ export class SearchMessageDisplay extends MessageDisplay {
   constructor(...args: any[]) {
     super(args[1]);
     this.searchService = args[0];
+  }
+
+  public static sortRowsByFrom(
+    rows: SearchResultRow[],
+    searchService: FromSortValueSource,
+    descending: boolean
+  ): SearchResultRow[] {
+    const sortDirection = descending ? -1 : 1;
+    return rows
+      .map((row, index) => ({
+        row,
+        index,
+        sortText: MessageInfo.getSortableText(searchService.api.getStringValue(row[0], 0))
+      }))
+      .sort((a, b) => {
+        if (a.sortText < b.sortText) {
+          return -1 * sortDirection;
+        }
+        if (a.sortText > b.sortText) {
+          return sortDirection;
+        }
+        return a.index - b.index;
+      })
+      .map((sortedRow) => sortedRow.row);
   }
 
   getRowSeen(index: number): boolean {


### PR DESCRIPTION
Closes #446.

## Summary

- normalize sender sort text so punctuation like quotes and underscores is ignored
- place diacritic variants after their base letter in From-name ordering, e.g. `Č` sorts after other `C` names and before `D`
- apply the normalized comparison to From-column search results using Xapian value slot `0`, so existing downloaded/local index rows are displayed in the corrected order
- write the same normalized sort text for newly indexed local messages

## Tests

- `npx ng test runbox7 --watch=false --progress=false --browsers FirefoxHeadless --include src/app/common/messageinfo.spec.ts --include src/app/xapian/searchmessagedisplay.spec.ts`
- `npx tsc --noEmit`
- `npx eslint src/app/app.component.ts src/app/common/messageinfo.ts src/app/common/messageinfo.spec.ts src/app/xapian/searchmessagedisplay.ts src/app/xapian/searchmessagedisplay.spec.ts`
- `npm run lint`
- `npx ng test runbox7 --watch=false --progress=false --browsers FirefoxHeadless`
- `npm run policy`
- `git diff --check`
- `git diff --cached --check`
- `git show --stat --oneline --check HEAD`
- `$env:SKIP_CHANGELOG='1'; node src/build/pre-build.js; npx ng build --configuration production --base-href=/app/ runbox7; node src/build/post-build.js`
