### PR TITLE
Fix Drafts route lingering after selecting folders

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,0 +1,68 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { AppComponent } from './app.component';
+
+describe('AppComponent route fragments', () => {
+    const createComponent = (
+        url: string,
+        selectedFolder = 'Inbox',
+        hasChildRouterOutlet = false,
+        fragment = 'Drafts'
+    ): { component: AppComponent, navigate: jasmine.Spy } => {
+        const navigate = jasmine.createSpy('navigate');
+        const component = Object.create(AppComponent.prototype) as AppComponent;
+
+        Object.assign(component, {
+            fragment,
+            hasChildRouterOutlet,
+            router: { url, navigate },
+            selectedFolder,
+        });
+
+        return { component, navigate };
+    };
+
+    it('updates the root mail fragment when leaving a child route for a folder', () => {
+        const { component, navigate } = createComponent('/compose', 'Inbox', true, 'Drafts');
+
+        component['updateUrlFragment']();
+
+        expect(component.fragment).toBe('Inbox');
+        expect(navigate).toHaveBeenCalledOnceWith(['/'], { fragment: 'Inbox' });
+    });
+
+    it('leaves a child route even when the selected folder fragment is already current', () => {
+        const { component, navigate } = createComponent('/compose', 'Inbox', true, 'Inbox');
+
+        component['updateUrlFragment']();
+
+        expect(component.fragment).toBe('Inbox');
+        expect(navigate).toHaveBeenCalledOnceWith(['/'], { fragment: 'Inbox' });
+    });
+
+    it('does not replace an unrelated app route with a mail folder fragment', () => {
+        const { component, navigate } = createComponent('/account');
+
+        component['updateUrlFragment']();
+
+        expect(component.fragment).toBe('Drafts');
+        expect(navigate).not.toHaveBeenCalled();
+    });
+});

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1173,13 +1173,16 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
   }
 
   selectFolder(folder: string): void {
+    const hadChildRouterOutlet = this.hasChildRouterOutlet;
     if (this.mobileQuery.matches && this.sidemenu.opened) {
       this.sidemenu.close();
     }
     this.singlemailviewer.close();
     this.searchFor('');
     this.switchToFolder(folder);
-    this.updateUrlFragment();
+    if (!hadChildRouterOutlet) {
+      this.updateUrlFragment();
+    }
   }
 
   private switchToFolder(folder: string): void {
@@ -1216,7 +1219,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     }
 
     if (this.hasChildRouterOutlet) {
-      this.router.navigate(['/']);
+      this.updateUrlFragment();
     }
 
     setTimeout(() => {
@@ -1423,8 +1426,8 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
   }
 
   private updateUrlFragment(messageId?: number): void {
-    if (this.router.url.match('^/[^#]')) {
-      // we're not actually on mailviewer, so don't try to be smart
+    if (this.router.url.match('^/[^#]') && !this.hasChildRouterOutlet) {
+      // We're outside the message list view, so don't replace the current route.
       return;
     }
     let fragment = this.selectedFolder;
@@ -1434,7 +1437,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     }
 
     // navigating to the same page does not fire off our fragment.subscribe
-    if (fragment !== this.fragment) {
+    if (fragment !== this.fragment || this.hasChildRouterOutlet) {
       this.fragment = fragment;
       this.router.navigate(['/'], { fragment });
     }


### PR DESCRIPTION
Closes #657.

## Summary
- preserve the selected folder in the root mail URL when a folder is selected from a child route such as `/compose`
- route child-view folder selections through the existing fragment updater so leaving Drafts records `/#Inbox` or the selected folder instead of leaving a stale Drafts route behind
- add focused `AppComponent` route-fragment specs for child-route and unrelated-route behavior

## Testing
- `npx ng test runbox7 --watch=false --progress=false --browsers FirefoxHeadless --include src/app/app.component.spec.ts`
- `npx tsc --noEmit`
- `npx eslint src/app/app.component.ts src/app/app.component.spec.ts`
- `npm run lint`
- `npx ng test runbox7 --watch=false --progress=false --browsers FirefoxHeadless`
- `$env:SKIP_CHANGELOG='1'; node src/build/pre-build.js; npx ng build --configuration production --base-href=/app/ runbox7; node src/build/post-build.js`
- `npm run policy`
