### PR TITLE
Reopen legacy HTML drafts as rich text

### DIFF
--- a/src/app/compose/compose.component.spec.ts
+++ b/src/app/compose/compose.component.spec.ts
@@ -1,0 +1,65 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { getDraftHtmlBody } from './compose.component';
+
+describe('getDraftHtmlBody', () => {
+    it('uses the explicit parsed HTML body when available', () => {
+        expect(getDraftHtmlBody({
+            text: {
+                html: '<p>Rich draft</p>',
+                text: 'Rich draft',
+            }
+        })).toBe('<p>Rich draft</p>');
+    });
+
+    it('uses the text body for legacy HTML drafts with a content-type header', () => {
+        expect(getDraftHtmlBody({
+            headers: {
+                'content-type': {
+                    value: 'text/html',
+                    params: {
+                        charset: 'utf-8',
+                    },
+                },
+            },
+            text: {
+                text: '<p>Legacy rich draft</p>',
+            },
+        })).toBe('<p>Legacy rich draft</p>');
+    });
+
+    it('uses the text body when the text part reports an HTML type', () => {
+        expect(getDraftHtmlBody({
+            text: {
+                type: 'html',
+                text: '<div>Legacy rich draft</div>',
+            },
+        })).toBe('<div>Legacy rich draft</div>');
+    });
+
+    it('does not infer HTML mode for ordinary plaintext without metadata', () => {
+        expect(getDraftHtmlBody({
+            headers: {},
+            text: {
+                text: 'Use <b> tags literally in this draft.',
+            },
+        })).toBeNull();
+    });
+});

--- a/src/app/compose/compose.component.ts
+++ b/src/app/compose/compose.component.ts
@@ -48,6 +48,74 @@ const LOCAL_STORAGE_SHOW_POPULAR_RECIPIENTS = 'showPopularRecipients';
 const LOCAL_STORAGE_DEFAULT_HTML_COMPOSE = 'composeInHTMLByDefault';
 const DOWNLOAD_DRAFT_URL = '/ajax/download_draft_attachment?filename=';
 
+function asRecord(value: unknown): Record<string, unknown> | null {
+    return value && typeof value === 'object' ? value as Record<string, unknown> : null;
+}
+
+function getContentTypeCandidates(value: unknown): string[] {
+    if (!value) {
+        return [];
+    }
+
+    if (typeof value === 'string') {
+        return [value];
+    }
+
+    if (Array.isArray(value)) {
+        return value.flatMap((entry) => getContentTypeCandidates(entry));
+    }
+
+    const record = asRecord(value);
+
+    if (record) {
+        return [
+            ...getContentTypeCandidates(record.type),
+            ...getContentTypeCandidates(record.value),
+            ...getContentTypeCandidates(record.text),
+            ...getContentTypeCandidates(record.contentType),
+            ...getContentTypeCandidates(record.mimeType),
+        ];
+    }
+
+    return [];
+}
+
+function isHtmlContentType(value: unknown): boolean {
+    return getContentTypeCandidates(value).some((candidate) => {
+        const normalized = candidate.trim().toLowerCase();
+        return normalized === 'html' || /\btext\/html\b/.test(normalized);
+    });
+}
+
+export function getDraftHtmlBody(message: unknown): string | null {
+    const messageRecord = asRecord(message);
+    const text = asRecord(messageRecord?.text);
+
+    if (!text) {
+        return null;
+    }
+
+    if (typeof text.html === 'string' && text.html.length > 0) {
+        return text.html;
+    }
+
+    if (typeof text.text !== 'string' || text.text.length === 0) {
+        return null;
+    }
+
+    const headers = asRecord(messageRecord?.headers) || {};
+    const hasHtmlContentType = isHtmlContentType(text.type)
+        || isHtmlContentType(text.contentType)
+        || isHtmlContentType(messageRecord?.contentType)
+        || isHtmlContentType(messageRecord?.ctype)
+        || isHtmlContentType(headers['content-type'])
+        || isHtmlContentType(headers['Content-Type'])
+        || isHtmlContentType(headers.contentType)
+        || isHtmlContentType(headers.ctype);
+
+    return hasHtmlContentType ? text.text : null;
+}
+
 @Component({
     // eslint-disable-next-line @angular-eslint/component-selector
     selector: 'compose',
@@ -506,8 +574,9 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
 
         model.subject = msgObj.headers.subject;
         if (msgObj.text) {
-            if (msgObj.text.html) {
-                model.html = msgObj.text.html;
+            const draftHtmlBody = getDraftHtmlBody(msgObj);
+            if (draftHtmlBody) {
+                model.html = draftHtmlBody;
                 model.msg_body = msgObj.text.text;
                 model.useHTML = true;
             } else {


### PR DESCRIPTION
Closes #409.

## Summary
- recognize legacy draft responses as HTML when the parsed `text.html` body is missing but message/text metadata still marks the draft as `text/html`
- open those legacy Runbox 6 HTML drafts in the rich-text editor instead of the plaintext compose area
- keep plaintext drafts unchanged unless an HTML content-type marker is present, and add focused helper coverage for explicit HTML, legacy HTML, and literal plaintext tag cases

## Testing
- `npx ng test runbox7 --watch=false --progress=false --browsers FirefoxHeadless --include src/app/compose/compose.component.spec.ts`
- `npx ng test runbox7 --watch=false --progress=false --browsers FirefoxHeadless --include src/app/compose/draftdesk.service.spec.ts --include src/app/compose/emailvalidator.spec.ts --include src/app/compose/recipients.service.spec.ts --include src/app/compose/compose.component.spec.ts`
- `npx tsc --noEmit`
- `npx eslint src/app/compose/compose.component.ts src/app/compose/compose.component.spec.ts`
- `git diff --check`
- `npm run lint`
- `npx ng test runbox7 --watch=false --progress=false --browsers FirefoxHeadless`
- `$env:SKIP_CHANGELOG='1'; node src/build/pre-build.js; npx ng build --configuration production --base-href=/app/ runbox7; node src/build/post-build.js`
- `npm run policy`
