### PR TITLE
fix(calendar): refresh only changed calendars

### DIFF
--- a/src/app/calendar-app/calendar.service.spec.ts
+++ b/src/app/calendar-app/calendar.service.spec.ts
@@ -20,9 +20,10 @@
 import { StorageService } from '../storage.service';
 import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
 import { CalendarService } from './calendar.service';
+import { RunboxCalendar } from './runbox-calendar';
 import { RunboxCalendarEvent } from './runbox-calendar-event';
 import { of } from 'rxjs';
-import { take } from 'rxjs/operators';
+import { skip, take } from 'rxjs/operators';
 import moment from 'moment';
 import ICAL from 'ical.js';
 
@@ -224,6 +225,37 @@ END:VCALENDAR
             expect(calls.deleteCalendarEvent).toBe(1, '1 event was deleted');
             r(null);
         }));
+    });
+
+    it('should keep events from unchanged calendars when one calendar changes', async () => {
+        const initialEvents = await new Promise<RunboxCalendarEvent[]>(r => {
+            sut.eventSubject.pipe(take(1)).subscribe(events => r(events));
+        });
+        const preservedEvent = initialEvents.find(e => e.calendar === 'test') as RunboxCalendarEvent;
+
+        expect(sut.icalevents.length).toBe(2, '2 initial ical events found');
+        expect(initialEvents.length).toBe(6, '6 initial events loaded');
+        expect(preservedEvent).toBeDefined('an unchanged calendar event was loaded');
+
+        dav_events['test2/bar'] = {
+            calendar: 'test2',
+            id:       'test2/bar',
+            ical:     'BEGIN:VCALENDAR\nBEGIN:VEVENT\nDTSTART:20190907T100000\nDTEND:20190907T110000\nSUMMARY:Second calendar\nEND:VEVENT\nEND:VCALENDAR\n'
+        };
+
+        const changedEvents = new Promise<RunboxCalendarEvent[]>(r => {
+            sut.eventSubject.pipe(skip(1), take(1)).subscribe(events => r(events));
+        });
+        sut.calendarSubject.next([
+            new RunboxCalendar({ id: 'test',  displayname: 'Test',  syncToken: 'asdf' }),
+            new RunboxCalendar({ id: 'test2', displayname: 'Test2', syncToken: 'changed' })
+        ]);
+
+        const events = await changedEvents;
+        expect(events.length).toBe(7, 'one event was added from the changed calendar');
+        expect(events).toContain(preservedEvent, 'unchanged calendar event object was retained');
+        expect(events.some(e => e.calendar === 'test2' && e.title === 'Second calendar'))
+            .toBe(true, 'changed calendar event was loaded');
     });
 
     it('should be possible to  import an .ics file', () => {

--- a/src/app/calendar-app/calendar.service.ts
+++ b/src/app/calendar-app/calendar.service.ts
@@ -44,6 +44,12 @@ enum Activity {
     GeneratingEvents    = 'Generating Events',
 }
 
+interface RawCalendarEvent {
+    calendar?: string;
+    id:        string;
+    ical:      string;
+}
+
 @Injectable()
 export class CalendarService implements OnDestroy {
     calendars:    RunboxCalendar[]      = [];
@@ -112,17 +118,24 @@ export class CalendarService implements OnDestroy {
         });
 
         this.calendarSubject.subscribe(cals => {
-            const updatedCals = [];
+            const updatedCals: string[] = [];
+            const currentCals = cals.map(cal => cal.id);
             for (const cal of cals) {
                 if (cal.syncToken !== this.syncTokens[cal.id]) {
                     updatedCals.push(cal.id);
                     this.syncTokens[cal.id] = cal.syncToken;
                 }
             }
+            for (const calId of Object.keys(this.syncTokens)) {
+                if (!currentCals.includes(calId)) {
+                    updatedCals.push(calId);
+                    delete this.syncTokens[calId];
+                }
+            }
 
             if (updatedCals.length > 0) {
                 console.log('Changes detected in calendars', updatedCals);
-                this.reloadEvents();
+                this.reloadEvents(updatedCals);
             } else {
                 console.log('Nothing new in calendars');
                 this.lastUpdate = moment();
@@ -497,21 +510,56 @@ export class CalendarService implements OnDestroy {
         });
     }
 
-    reloadEvents() {
+    private calendarIdFromEventId(id: string): string {
+        return id ? id.split('/')[0] : '';
+    }
+
+    private calendarIdFromRawEvent(event: RawCalendarEvent): string {
+        return event['calendar'] || this.calendarIdFromEventId(event['id']);
+    }
+
+    reloadEvents(calendarIds?: string[]) {
+        const changedCalendarIds = calendarIds && calendarIds.length > 0
+            ? new Set(calendarIds)
+            : undefined;
+
         console.log('Fetching events');
         this.activities.begin(Activity.RefreshingEvents);
         this.rmmapi.getCalendarEvents().subscribe(events => {
-            this.events = [];
-            this.icalevents = [];
-            events.forEach((e: any) => {
-                // store events into this.icalevents
-                this.importFromIcal(e.id, e.ical);
+            const importedEvents: { id: string, event: ICAL.Event}[] = [];
+            const rawEvents = events as RawCalendarEvent[];
+
+            if (changedCalendarIds) {
+                this.events = this.events.filter(
+                    e => !changedCalendarIds.has(e.calendar)
+                );
+                this.icalevents = this.icalevents.filter(
+                    e => !changedCalendarIds.has(this.calendarIdFromEventId(e.id))
+                );
+            } else {
+                this.events = [];
+                this.icalevents = [];
+            }
+
+            rawEvents.forEach((e: RawCalendarEvent) => {
+                if (changedCalendarIds && !changedCalendarIds.has(this.calendarIdFromRawEvent(e))) {
+                    return;
+                }
+
+                const importedEvent = this.importFromIcal(e.id, e.ical);
+                if (importedEvent) {
+                    importedEvents.push(importedEvent);
+                }
             });
 
             // generate RBE events for just this set, for current month+1:
             // TODO: what if user runs import while not looking at "today"?
             // Returns an array of RunboxCalendarEvent objects
-            const runboxevents = this.generateEvents();
+            const runboxevents = this.generateEvents(
+                undefined,
+                undefined,
+                changedCalendarIds ? importedEvents : undefined
+            );
             this.events = this.events.concat(runboxevents);
             this.eventSubject.next(this.events);
             this.activities.end(Activity.RefreshingEvents);


### PR DESCRIPTION
## Summary

- pass changed calendar IDs from the sync-token watcher into `reloadEvents`
- replace only events/ICAL entries that belong to changed calendars, while retaining existing events for unchanged calendars
- evict cached events for calendars missing from the latest calendar list
- add a regression spec that verifies an unchanged calendar event object is retained when another calendar changes

Closes #311.

## Testing

- `npx ng test runbox7 --watch=false --progress=false --browsers FirefoxHeadless --include src/app/calendar-app/calendar.service.spec.ts`
- `npx ng test runbox7 --watch=false --progress=false --browsers FirefoxHeadless --include src/app/calendar-app/calendar.service.spec.ts --include src/app/calendar-app/calendar-app.component.spec.ts --include src/app/calendar-app/runbox-calendar-event.spec.ts`
- `npx tsc --noEmit`
- `npx eslint src/app/calendar-app/calendar.service.ts src/app/calendar-app/calendar.service.spec.ts`
- `npm run lint`
- `npm run policy`
- `npx ng test runbox7 --watch=false --progress=false --browsers FirefoxHeadless`
- `SKIP_CHANGELOG=1 node src/build/pre-build.js && npx ng build --configuration production --base-href=/app/ runbox7 && node src/build/post-build.js`
