### PR TITLE
Decode encoded calendar event descriptions

### DIFF
--- a/src/app/calendar-app/calendar-description.ts
+++ b/src/app/calendar-app/calendar-description.ts
@@ -1,0 +1,94 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+const htmlEntities: { [entity: string]: string } = {
+    amp: '&',
+    apos: '\'',
+    gt: '>',
+    lt: '<',
+    nbsp: ' ',
+    quot: '"',
+};
+
+const knownHtmlTag =
+    '(?:a|article|b|blockquote|body|br|center|code|div|em|font|footer|h[1-6]|head|header|html|i|li|meta|ol|p|pre|section|small|span|strong|style|table|tbody|td|tfoot|th|thead|title|tr|u|ul)';
+const knownHtmlTagPattern = new RegExp(`<\\s*/?\\s*${knownHtmlTag}(?:\\s|>|/)`, 'i');
+const knownHtmlTagRemovalPattern = new RegExp(`<\\s*/?\\s*${knownHtmlTag}(?:\\s+[^>]*)?\\s*/?>`, 'gi');
+
+export function formatCalendarDescriptionForDisplay(description?: string): string {
+    if (!description) {
+        return '';
+    }
+
+    const decoded = decodeHtmlEntities(description);
+    if (!knownHtmlTagPattern.test(decoded)) {
+        return decoded;
+    }
+
+    return htmlToPlainText(decoded);
+}
+
+function htmlToPlainText(value: string): string {
+    return decodeHtmlEntities(value)
+        .replace(/<\s*(script|style)\b[^>]*>[\s\S]*?<\s*\/\s*\1\s*>/gi, '')
+        .replace(/<\s*br\s*\/?>/gi, '\n')
+        .replace(
+            /<\s*\/\s*(?:article|blockquote|div|footer|h[1-6]|header|li|p|pre|section|table|tr)\s*>/gi,
+            '\n'
+        )
+        .replace(knownHtmlTagRemovalPattern, '')
+        .replace(/\r\n?/g, '\n')
+        .replace(/[ \t]+\n/g, '\n')
+        .replace(/\n[ \t]+/g, '\n')
+        .replace(/\n{2,}/g, '\n')
+        .trim();
+}
+
+function decodeHtmlEntities(value: string): string {
+    let decoded = value;
+    for (let i = 0; i < 3; i++) {
+        const next = decoded.replace(/&(#x[0-9a-f]+|#[0-9]+|[a-z][a-z0-9]+);/gi, (_match, entity: string) => {
+            return decodeHtmlEntity(entity);
+        });
+        if (next === decoded) {
+            break;
+        }
+        decoded = next;
+    }
+    return decoded;
+}
+
+function decodeHtmlEntity(entity: string): string {
+    const normalized = entity.toLowerCase();
+    if (normalized.startsWith('#x')) {
+        return decodeNumericEntity(normalized.slice(2), 16, entity);
+    }
+    if (normalized.startsWith('#')) {
+        return decodeNumericEntity(normalized.slice(1), 10, entity);
+    }
+    return htmlEntities[normalized] || `&${entity};`;
+}
+
+function decodeNumericEntity(value: string, radix: number, original: string): string {
+    const codePoint = Number.parseInt(value, radix);
+    if (Number.isNaN(codePoint) || codePoint < 0 || codePoint > 0x10ffff) {
+        return `&${original};`;
+    }
+    return String.fromCodePoint(codePoint);
+}

--- a/src/app/calendar-app/calendar-event-card.component.html
+++ b/src/app/calendar-app/calendar-event-card.component.html
@@ -23,7 +23,7 @@
     </mat-card-header>
     <mat-card-content>
         <p>
-            {{ event.description }}
+            {{ event.displayDescription }}
         </p>
     </mat-card-content>
     <mat-card-actions>

--- a/src/app/calendar-app/event-editor-dialog.component.ts
+++ b/src/app/calendar-app/event-editor-dialog.component.ts
@@ -110,7 +110,7 @@ export class EventEditorDialogComponent {
             this.export_url = '/rest/v1/calendar/ics/' + this.event.id;
             this.event_title = this.event.title;
             this.event_location = this.event.location;
-            this.event_description = this.event.description;
+            this.event_description = this.event.displayDescription;
             this.event_allDay = this.event.allDay;
 
             this.event_start = this.event.start;

--- a/src/app/calendar-app/event-overview.ts
+++ b/src/app/calendar-app/event-overview.ts
@@ -19,6 +19,8 @@
 
 import moment from 'moment';
 
+import { formatCalendarDescriptionForDisplay } from './calendar-description';
+
 export class EventOverview {
     ongoing: boolean;
 
@@ -40,5 +42,9 @@ export class EventOverview {
             this.recurringFrequency = freq.charAt(0).toUpperCase()
                                     + freq.slice(1).toLowerCase();
         }
+    }
+
+    get displayDescription(): string {
+        return formatCalendarDescriptionForDisplay(this.description);
     }
 }

--- a/src/app/calendar-app/runbox-calendar-event.spec.ts
+++ b/src/app/calendar-app/runbox-calendar-event.spec.ts
@@ -67,6 +67,26 @@ describe('RunboxCalendarEvent', () => {
         // test things addEvent calls:
         expect(newEvent.toIcal()).toMatch(/BEGIN:VEVENT/);
     });
+    it('should expose readable text for entity-encoded HTML descriptions', () => {
+        const ical = new ICAL.Component(['vcalendar', [], [
+            [ 'vevent', [
+                [ 'dtstart', {}, 'date', '2021-05-15' ],
+                [ 'dtend',   {}, 'date', '2021-05-16' ],
+                [ 'summary', {}, 'text', 'Meeting invitation' ],
+                [
+                    'description', {}, 'text',
+                    '&lt;p&gt;Agenda &amp;amp; notes&lt;/p&gt;&lt;br&gt;Room&nbsp;4'
+                ],
+            ] ]
+        ]]);
+        const sut = new RunboxCalendarEvent(
+          'testcal/testev', new ICAL.Event(ical.getFirstSubcomponent('vevent')),
+          ICAL.Time.fromDateString('2021-05-15'), ICAL.Time.fromDateString('2021-05-16')
+        );
+
+        expect(sut.description).toBe('&lt;p&gt;Agenda &amp;amp; notes&lt;/p&gt;&lt;br&gt;Room&nbsp;4');
+        expect(sut.displayDescription).toBe('Agenda & notes\nRoom 4');
+    });
     it('should be possible to create a new event, without times', () => {
         const newEvent = RunboxCalendarEvent.newEmpty();
         newEvent.updateEvent(

--- a/src/app/calendar-app/runbox-calendar-event.ts
+++ b/src/app/calendar-app/runbox-calendar-event.ts
@@ -24,6 +24,7 @@ import moment from 'moment';
 import 'moment-timezone';
 import ICAL from 'ical.js';
 
+import { formatCalendarDescriptionForDisplay } from './calendar-description';
 import { EventOverview } from './event-overview';
 
 export enum RecurSaveType {
@@ -100,6 +101,10 @@ export class RunboxCalendarEvent implements CalendarEvent {
 
     set description(value: string) {
         this.event.description = value;
+    }
+
+    get displayDescription(): string {
+        return formatCalendarDescriptionForDisplay(this.description);
     }
 
     // This is the start time of an event instance (if recurring)


### PR DESCRIPTION
Closes #897.

## Summary
- add a shared calendar description display formatter that decodes common/numeric HTML entities and flattens encoded HTML markup to readable plain text
- show decoded/plain-text descriptions on calendar event cards, import previews, and the edit dialog's initial textarea value
- preserve the raw iCalendar description value on the event model unless the user explicitly saves an edited description
- add a regression spec for an entity-encoded HTML description that keeps the raw value intact while exposing readable display text

## Validation
- pre-fix focused regression run failed because `displayDescription` did not exist yet
- `npx ng test runbox7 --watch=false --progress=false --browsers FirefoxHeadless --include src/app/calendar-app/runbox-calendar-event.spec.ts` (`17 SUCCESS`)
- `npx ng test runbox7 --watch=false --progress=false --browsers FirefoxHeadless --include src/app/calendar-app/runbox-calendar-event.spec.ts --include src/app/calendar-app/calendar.service.spec.ts` (`26 SUCCESS`)
- `npx tsc --noEmit`
- `npx eslint src/app/calendar-app/calendar-description.ts src/app/calendar-app/runbox-calendar-event.ts src/app/calendar-app/event-overview.ts src/app/calendar-app/event-editor-dialog.component.ts src/app/calendar-app/runbox-calendar-event.spec.ts` (0 errors; existing warning in `event-editor-dialog.component.ts`)
- `git diff --check`
- `npm run lint` (0 errors; existing `770` warnings)
- `npm run policy` (new commit OK; existing historical commit-message warnings still reported)
- production build with `SKIP_CHANGELOG=1`, `node src/build/pre-build.js`, `npx ng build --configuration production --base-href=/app/ runbox7`, `node src/build/post-build.js` (hash `0340235750cf099b`; existing Angular/CommonJS/Sass/unused TS warnings)

I used AI assistance to inspect the code, draft the patch, and run validation; I reviewed the changes and command outputs.
