### PR TITLE
Keep sidenav behind TinyMCE fullscreen

### DIFF
--- a/src/app/rmm/plugin/tinymce.plugin.ts
+++ b/src/app/rmm/plugin/tinymce.plugin.ts
@@ -45,7 +45,7 @@ export class TinyMCEPlugin {
                     'strikethrough forecolor backcolor codesample | ' +
                     'link image paste pastetext | alignleft aligncenter ' +
                     'alignright alignjustify  | ' +
-                    'numlist bullist outdent indent | removeformat | addcomment | code'),
+                    'numlist bullist outdent indent | removeformat | addcomment | fullscreen code'),
                 codesample_languages: (options.codesample_languages || [
                             {text: 'HTML/XML', value: 'markup'},
                             {text: 'JavaScript', value: 'javascript'},

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -755,6 +755,10 @@ mat-sidenav-container {
     }
 }
 
+body.tox-fullscreen #sideMenu {
+    z-index: 1;
+}
+
 #toggleFolderPaneIcon {
     overflow: visible;
     margin-right: 10px;


### PR DESCRIPTION
Closes #621.

## Summary

- Add TinyMCE's existing `fullscreen` control to the default rich-text toolbar so users can enter fullscreen mode from the editor UI.
- Lower the Runbox sidenav behind the editor only while TinyMCE has `body.tox-fullscreen` active, preventing the folder pane from covering the fullscreen editor.

## Testing

- `npx eslint src/app/rmm/plugin/tinymce.plugin.ts` exited 0 with existing warnings in that file (`no-explicit-any`, empty constructor).
- `npx tsc --noEmit`
- `npm run lint` exited 0 with existing warnings only: `770 problems (0 errors, 770 warnings)`.
- `npm run policy` exited 0 before and after commit; it still reports historical upstream commit-message warnings, while the current commit is OK.
- `git diff --check`, `git diff --check --cached`, `git show --stat --oneline HEAD`, and `git show --check --format=short HEAD`.
- `npx ng test runbox7 --watch=false --progress=false --browsers FirefoxHeadless --include src/app/compose/draftdesk.service.spec.ts --include src/app/compose/emailvalidator.spec.ts --include src/app/compose/recipients.service.spec.ts --include src/app/profiles/profile.service.spec.ts` passed with `TOTAL: 37 SUCCESS`.
- `npx ng test runbox7 --watch=false --progress=false --browsers FirefoxHeadless --include src/app/help/help.component.spec.ts --include src/app/profiles/profile.service.spec.ts` passed with `TOTAL: 9 SUCCESS` while logging existing HelpComponent unknown-element warnings.
- `npx ng test runbox7 --watch=false --progress=false --browsers FirefoxHeadless --include src/app/common/preferences.service.spec.ts` passed with `TOTAL: 15 SUCCESS` while logging existing `PreferencesService.loadOldStyle()` unhandled-rejection warnings.
- Manual production build passed with `SKIP_CHANGELOG=1`, `node src/build/pre-build.js`, `npx ng build --configuration production --base-href=/app/ runbox7`, and `node src/build/post-build.js`; production build hash `c5337f90b16fe456`.

Known current-suite issue:

- `npx ng test runbox7 --watch=false --progress=false --browsers FirefoxHeadless` currently exits non-zero with `TOTAL: 2 FAILED, 243 SUCCESS, 2 skipped`. The failure output is from `PreferencesService.loadOldStyle()` unhandled promise rejections (`can't access property "subscribe", source is undefined`) and is unrelated to the TinyMCE toolbar/CSS change.
