### PR TITLE
fix(mail): show fallback folder error messages

### DIFF
--- a/src/app/rmmapi/rbwebmail.spec.ts
+++ b/src/app/rmmapi/rbwebmail.spec.ts
@@ -21,7 +21,7 @@ import { TestBed } from '@angular/core/testing';
 import { RunboxWebmailAPI } from './rbwebmail';
 import { FolderListEntry } from '../common/folderlistentry';
 import { MatLegacyDialogModule as MatDialogModule } from '@angular/material/legacy-dialog';
-import { MatLegacySnackBarModule as MatSnackBarModule } from '@angular/material/legacy-snack-bar';
+import { MatLegacySnackBar as MatSnackBar, MatLegacySnackBarModule as MatSnackBarModule } from '@angular/material/legacy-snack-bar';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { MessageCache } from './messagecache';
 import { firstValueFrom } from 'rxjs';
@@ -648,5 +648,21 @@ describe('RBWebMail', () => {
         expect(folders[12].folderLevel).toBe(2);
         expect(folders[15].folderPath).toBe('HTML.lalala.hohohohahaha.subtest');
         expect(folders[15].folderLevel).toBe(3);
+    });
+
+    it('should show fallback text for blank backend error messages', () => {
+        const rmmapi = TestBed.inject(RunboxWebmailAPI);
+        const snackBar = TestBed.inject(MatSnackBar);
+        const openSpy = spyOn(snackBar, 'open');
+
+        rmmapi.showBackendErrors({
+            status: 'error',
+            errors: ['']
+        });
+
+        expect(openSpy).toHaveBeenCalledWith(
+            'There was an unknown error and this action cannot be completed.',
+            'Dismiss'
+        );
     });
 });

--- a/src/app/rmmapi/rbwebmail.ts
+++ b/src/app/rmmapi/rbwebmail.ts
@@ -428,14 +428,19 @@ export class RunboxWebmailAPI {
             console.log(res);
             if (res.errors && res.errors.length) {
                 const error_msg = res.errors.map((key) => {
-                    let loc = this.rblocale.translate(key).replace('_', ' ');
-                    if (loc.length === 0) {
-                        loc = key;
+                    const errorKey = String(key || '').trim();
+                    let loc = errorKey.length > 0 ? this.rblocale.translate(errorKey) : '';
+                    if (typeof loc !== 'string' || loc.trim().length === 0) {
+                        loc = errorKey;
                     }
-                    return loc;
-                }).join('. ');
-                const error_formatted = error_msg.charAt(0).toUpperCase() + error_msg.slice(1);
-                this.snackBar.open(error_formatted, 'Dismiss');
+                    return loc.replace(/_/g, ' ').trim();
+                }).filter((message) => message.length > 0).join('. ');
+                if (error_msg.length > 0) {
+                    const error_formatted = error_msg.charAt(0).toUpperCase() + error_msg.slice(1);
+                    this.snackBar.open(error_formatted, 'Dismiss');
+                } else {
+                    this.snackBar.open('There was an unknown error and this action cannot be completed.', 'Dismiss');
+                }
             } else {
                 this.snackBar.open('There was an unknown error and this action cannot be completed.', 'Dismiss');
             }


### PR DESCRIPTION
Fixes #505

## Summary

- Treat blank backend error tokens as missing error text instead of opening an empty snackbar.
- Preserve the existing translation/fallback behavior for non-empty backend error keys, including underscore normalization.
- Add coverage for blank backend error responses.

## Validation

- `npx ng test runbox7 --watch=false --progress=false --browsers FirefoxHeadless --include src/app/rmmapi/rbwebmail.spec.ts` (`TOTAL: 4 SUCCESS`)
- `npx tsc --noEmit`
- `npx eslint src/app/rmmapi/rbwebmail.ts src/app/rmmapi/rbwebmail.spec.ts` (0 errors; existing warnings only)
- `npx ng test runbox7 --watch=false --progress=false --browsers FirefoxHeadless --include src/app/rmmapi/rbwebmail.spec.ts --include src/app/folder/folderlist.component.spec.ts` (`TOTAL: 6 SUCCESS`)
- `npm run lint` (0 errors; existing warnings only)
- `npm run policy`
- `git diff --check`
