### PR TITLE
fix(dialog): show determinate progress bar

### DIFF
--- a/src/app/dialog/dialog.module.ts
+++ b/src/app/dialog/dialog.module.ts
@@ -23,6 +23,7 @@ import { MatLegacyButtonModule as MatButtonModule } from '@angular/material/lega
 import { MatLegacyDialogModule as MatDialogModule } from '@angular/material/legacy-dialog';
 import { MatIconModule } from '@angular/material/icon';
 import { MatLegacyInputModule as MatInputModule } from '@angular/material/legacy-input';
+import { MatLegacyProgressBarModule as MatProgressBarModule } from '@angular/material/legacy-progress-bar';
 import { MatLegacyProgressSpinnerModule as MatProgressSpinnerModule } from '@angular/material/legacy-progress-spinner';
 import { MatLegacySnackBarModule as MatSnackBarModule } from '@angular/material/legacy-snack-bar';
 import { MatLegacyTooltipModule as MatTooltipModule } from '@angular/material/legacy-tooltip';
@@ -53,6 +54,7 @@ export { ProgressDialog } from './progress.dialog';
         MatButtonModule,
         MatTooltipModule,
         MatIconModule,
+        MatProgressBarModule,
         MatProgressSpinnerModule
     ],
     exports: [],

--- a/src/app/dialog/progress.dialog.spec.ts
+++ b/src/app/dialog/progress.dialog.spec.ts
@@ -1,0 +1,70 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+import { DialogModule } from './dialog.module';
+import { ProgressDialog } from './progress.dialog';
+
+describe('ProgressDialog', () => {
+    let fixture: ComponentFixture<ProgressDialog>;
+
+    beforeEach(waitForAsync(() => {
+        TestBed.configureTestingModule({
+            imports: [
+                NoopAnimationsModule,
+                DialogModule
+            ]
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(ProgressDialog);
+    }));
+
+    it('shows an indeterminate spinner before progress is available', () => {
+        fixture.detectChanges();
+
+        expect(fixture.debugElement.query(By.css('mat-spinner'))).not.toBeNull();
+        expect(fixture.debugElement.query(By.css('mat-progress-bar'))).toBeNull();
+    });
+
+    it('shows a determinate progress bar for numeric progress', () => {
+        fixture.componentInstance.value = 37;
+
+        fixture.detectChanges();
+
+        const progressBar = fixture.debugElement.query(By.css('mat-progress-bar'));
+        expect(progressBar).not.toBeNull();
+        expect(progressBar.componentInstance.mode).toBe('determinate');
+        expect(progressBar.componentInstance.value).toBe(37);
+        expect(fixture.debugElement.query(By.css('mat-spinner'))).toBeNull();
+    });
+
+    it('treats zero as a valid progress value', () => {
+        fixture.componentInstance.value = 0;
+
+        fixture.detectChanges();
+
+        const progressBar = fixture.debugElement.query(By.css('mat-progress-bar'));
+        expect(progressBar).not.toBeNull();
+        expect(progressBar.componentInstance.value).toBe(0);
+        expect(fixture.debugElement.query(By.css('mat-spinner'))).toBeNull();
+    });
+});

--- a/src/app/dialog/progress.dialog.ts
+++ b/src/app/dialog/progress.dialog.ts
@@ -25,20 +25,24 @@ import { Component } from '@angular/core';
 import { MatLegacyDialog as MatDialog, MatLegacyDialogRef as MatDialogRef } from '@angular/material/legacy-dialog';
 
 @Component({
-    template: `<mat-spinner *ngIf="!value"></mat-spinner>
-                <mat-progress-spinner *ngIf="value" [value]="value"></mat-progress-spinner>`
+    template: `<mat-spinner *ngIf="!hasProgressValue"></mat-spinner>
+                <mat-progress-bar *ngIf="hasProgressValue" mode="determinate" [value]="value"></mat-progress-bar>`,
+    styles: [`
+        mat-progress-bar {
+            min-width: 240px;
+        }
+    `]
 })
 // eslint-disable-next-line @angular-eslint/component-class-suffix
 export class ProgressDialog {
     static progressDialogRef: MatDialogRef<ProgressDialog>;
-    value: number;
+    value: number | null = null;
 
-    constructor() {
-
+    get hasProgressValue(): boolean {
+        return this.value !== null && typeof this.value !== 'undefined';
     }
 
-
-    static setValue(value: number) {
+    static setValue(value: number | null) {
         ProgressDialog.progressDialogRef.componentInstance.value = value;
     }
 


### PR DESCRIPTION
## Summary
- render `ProgressDialog` numeric progress with a determinate linear `mat-progress-bar`
- keep the indeterminate spinner when no progress value is available
- treat `0` as valid progress and add focused dialog coverage

Fixes #307

## Testing
- `npm test -- --watch=false --browsers=FirefoxHeadless --include src/app/dialog/progress.dialog.spec.ts` (`TOTAL: 3 SUCCESS`)
- `npx tsc --noEmit`
- `npm run lint -- --lint-file-patterns src/app/dialog/progress.dialog.ts --lint-file-patterns src/app/dialog/dialog.module.ts --lint-file-patterns src/app/dialog/progress.dialog.spec.ts`
- `npm test -- --watch=false --browsers=FirefoxHeadless --include src/app/dialog/progress.dialog.spec.ts --include src/app/dialog/progresssnackbarcomponent.spec.ts` (`TOTAL: 4 SUCCESS`)
- `npm run policy` (passes; reports existing historical commit-message warnings)
- `git diff --check` (passes; CRLF notices only)
- `npm run lint` (0 errors, existing warnings only)
- `git show --check --format=short HEAD`

## AI disclosure
This contribution was implemented with assistance from OpenAI Codex in `src/app/dialog/progress.dialog.ts`, `src/app/dialog/dialog.module.ts`, and `src/app/dialog/progress.dialog.spec.ts`.
