### PR TITLE
Select reply identity from envelope recipient

### DIFF
--- a/src/app/compose/draftdesk.service.spec.ts
+++ b/src/app/compose/draftdesk.service.spec.ts
@@ -302,6 +302,65 @@ Subject: Test subject <br />
         expect(draft.isUnsaved()).toBe(true);
         done();
     });
+    it('Reply: selects from address from envelope recipient before visible list address', (done) => {
+        const draft = DraftFormModel.reply({
+            headers: {
+                'message-id': 'themessageid12123abcdef',
+                'envelope-to': 'alias@runbox.com',
+            },
+            from: [
+                {address: 'sender@example.com', name: 'Sender'}
+            ],
+            to: [
+                {address: 'list@example.org', name: 'Project List'}
+            ],
+            date: mailDate,
+            subject: 'Test subject',
+            text: 'blabla\nabcde',
+            rawtext: 'blabla\nabcde',
+            html: '<p>blabla</p><p>abcde</p>'
+        },
+        [
+            Identity.fromObject({'email':'primary@runbox.com'}),
+            Identity.fromObject({'email':'alias@runbox.com'})
+        ],
+        false, false);
+
+        expect(draft.subject).toBe('Re: Test subject');
+        expect(draft.from).toBe('alias@runbox.com');
+        expect(draft.to[0].nameAndAddress).toBe('"Sender" <sender@example.com>');
+        expect(draft.msg_body).toBe(`\n\nOn ${formatDate(mailDate)}, "Sender" <sender@example.com> wrote:\n> blabla\n> abcde`);
+        expect(draft.isUnsaved()).toBe(true);
+        done();
+    });
+    it('Reply: keeps visible recipient before delivered-to fallback', (done) => {
+        const draft = DraftFormModel.reply({
+            headers: {
+                'message-id': 'themessageid12123abcdef',
+                'delivered-to': 'primary@runbox.com',
+            },
+            from: [
+                {address: 'sender@example.com', name: 'Sender'}
+            ],
+            to: [
+                {address: 'alias@runbox.com', name: 'Alias'}
+            ],
+            date: mailDate,
+            subject: 'Test subject',
+            text: 'blabla\nabcde',
+            rawtext: 'blabla\nabcde',
+            html: '<p>blabla</p><p>abcde</p>'
+        },
+        [
+            Identity.fromObject({'email':'primary@runbox.com'}),
+            Identity.fromObject({'email':'alias@runbox.com'})
+        ],
+        false, false);
+
+        expect(draft.from).toBe('alias@runbox.com');
+        expect(draft.isUnsaved()).toBe(true);
+        done();
+    });
     it('Reply: Address with MAI', (done) => {
         console.log('Reply test: Address with MAI');
         const draft = DraftFormModel.reply({

--- a/src/app/compose/draftdesk.service.ts
+++ b/src/app/compose/draftdesk.service.ts
@@ -46,6 +46,15 @@ export class ForwardedAttachment {
 export class DraftFormModel {
     static MAX_DRAFT_PREVIEW_LENGTH = 200;
     static newDraftCount = -1;
+    private static readonly responseRecipientHeaderNames = [
+        'envelope-to',
+        'x-envelope-to',
+        'x-original-to'
+    ];
+    private static readonly fallbackResponseRecipientHeaderNames = [
+        'delivered-to',
+        'x-delivered-to'
+    ];
 
     from: string = null;
     mid: number = (DraftFormModel.newDraftCount--);
@@ -219,13 +228,52 @@ ${mailObj.sanitized_html}`;
     private setFromForResponse(mailObj, froms: Identity[]): void {
         if (froms.length > 0) {
             this.from = (
-                [].concat(mailObj.to || []).concat(mailObj.cc || []).find(
-                    addr => froms.find(fromObj => fromObj.email === addr.address.toLowerCase())
+                DraftFormModel.responseRecipientCandidates(mailObj).find(
+                    addr => froms.find(fromObj => fromObj.email.toLowerCase() === addr.address.toLowerCase())
                 ) || { address: froms[0].email }
             ).address.toLowerCase();
         } else {
             console.error('DraftDesk: No froms passed to setFromForResponse');
         }
+    }
+
+    private static responseRecipientCandidates(mailObj): MailAddressInfo[] {
+        const headers = mailObj.headers || {};
+        const visibleRecipients = [].concat(mailObj.to || []).concat(mailObj.cc || []);
+
+        return this.mailAddressesFromHeaders(headers, this.responseRecipientHeaderNames)
+            .concat(visibleRecipients)
+            .concat(this.mailAddressesFromHeaders(headers, this.fallbackResponseRecipientHeaderNames))
+            .filter((addr) => addr && addr.address);
+    }
+
+    private static mailAddressesFromHeaders(headers, headerNames: string[]): MailAddressInfo[] {
+        return headerNames
+            .flatMap(headerName => this.mailAddressesFromHeader(headers[headerName]));
+    }
+
+    private static mailAddressesFromHeader(header): MailAddressInfo[] {
+        if (!header) {
+            return [];
+        }
+        if (Array.isArray(header)) {
+            return header.flatMap(entry => this.mailAddressesFromHeader(entry));
+        }
+        if (header.value && Array.isArray(header.value)) {
+            return header.value
+                .filter(entry => entry && entry.address)
+                .map(entry => new MailAddressInfo(entry.name, entry.address));
+        }
+        if (header.address) {
+            return [new MailAddressInfo(header.name, header.address)];
+        }
+        if (header.text) {
+            return MailAddressInfo.parse(header.text);
+        }
+        if (typeof header === 'string') {
+            return MailAddressInfo.parse(header);
+        }
+        return [];
     }
 
     private setSubjectForResponse(mailObj, prefix): void {


### PR DESCRIPTION
Fixes #1032.

## Summary
- Prefer parsed envelope recipient headers (`Envelope-To`, `X-Envelope-To`, `X-Original-To`) when selecting the `From` identity for replies/forwards, so mailing-list messages can use the account identity that actually received the message instead of falling back to the first identity.
- Keep visible `To`/`Cc` recipients ahead of `Delivered-To` fallback headers, so a final mailbox delivery header does not override an explicit identity recipient.
- Add `DraftFormModel.reply()` regression coverage for the mailing-list envelope-recipient case and the `Delivered-To` fallback ordering.

## Tests
- `npm run test -- --watch=false --include src/app/compose/draftdesk.service.spec.ts` (`24 SUCCESS`)
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npx eslint src/app/compose/draftdesk.service.ts src/app/compose/draftdesk.service.spec.ts --quiet`
- `npm run lint -- --quiet`
- `git diff --check`
- `git diff --cached --check`
- `npm run policy` (current commit OK; historical upstream commit-message warnings still printed)
- `npm run test -- --watch=false` (`247 SUCCESS`, `2 skipped`; existing Angular template console noise)
- `SKIP_CHANGELOG=1 node src/build/pre-build.js`; `npx ng build --configuration production --base-href=/app/ runbox7`; `node src/build/post-build.js` (build hash `1271455b2f2deeec`, existing warnings)
- `git show --check --stat HEAD`
