### PR TITLE
Add previous and next message buttons

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -171,6 +171,10 @@
       <single-mail-viewer #singlemailviewer
       [messageActionsHandler]="messageActionsHandler"
       [adjustableHeight]="false"
+      [canNavigatePreviousMessage]="canNavigateOpenMessage(-1)"
+      [canNavigateNextMessage]="canNavigateOpenMessage(1)"
+      (previousMessage)="navigateOpenMessage(-1)"
+      (nextMessage)="navigateOpenMessage(1)"
       (afterLoadMessage)="updateMessageListHeight()"
       (orientationChangeRequest)="mailViewerOrientationChangeRequest($event)"
       (onClose)="singleMailViewerClosed($event)"></single-mail-viewer>
@@ -419,6 +423,10 @@
           [adjustableHeight]="true"
           [showVerticalSplitButton]="allowMailViewerOrientationChange"
           [messageActionsHandler]="messageActionsHandler"
+          [canNavigatePreviousMessage]="canNavigateOpenMessage(-1)"
+          [canNavigateNextMessage]="canNavigateOpenMessage(1)"
+          (previousMessage)="navigateOpenMessage(-1)"
+          (nextMessage)="navigateOpenMessage(1)"
           (afterLoadMessage)="updateMessageListHeight()"
           (orientationChangeRequest)="mailViewerOrientationChangeRequest($event)"
           (onClose)="singleMailViewerClosed($event)"></single-mail-viewer>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -236,23 +236,11 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     this.renderer.listen(window, 'keydown', (evt: KeyboardEvent) => {
       if (this.singlemailviewer.messageId) {
         if (evt.code === 'ArrowUp') {
-          // slightly ugly as we need to call *this* rowSelected, not
-          // the cvtable one
-          const newRowIndex = this.canvastable.rows.openedRowIndex - 1;
-          if (newRowIndex >= 0) {
-            this.rowSelected(newRowIndex, 3, false);
-            this.canvastable.scrollUp();
-            this.canvastable.hasChanges = true;
+          if (this.navigateOpenMessage(-1)) {
             evt.preventDefault();
           }
         } else if (evt.code === 'ArrowDown') {
-          // slightly ugly as we need to call *this* rowSelected, not
-          // the cvtable one
-          const newRowIndex = this.canvastable.rows.openedRowIndex + 1;
-          if (newRowIndex < this.canvastable.rows.rowCount()) {
-            this.rowSelected(newRowIndex, 3, false);
-            this.canvastable.scrollDown();
-            this.canvastable.hasChanges = true;
+          if (this.navigateOpenMessage(1)) {
             evt.preventDefault();
           }
         }
@@ -926,6 +914,38 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     } else {
       this.singlemailviewer.close();
     }
+  }
+
+  public canNavigateOpenMessage(offset: number): boolean {
+    if (!this.singlemailviewer?.messageId || !this.canvastable?.rows) {
+      return false;
+    }
+
+    const openedRowIndex = this.canvastable.rows.openedRowIndex;
+    if (openedRowIndex === null || openedRowIndex === undefined) {
+      return false;
+    }
+
+    const newRowIndex = openedRowIndex + offset;
+    return newRowIndex >= 0 && newRowIndex < this.canvastable.rows.rowCount();
+  }
+
+  public navigateOpenMessage(offset: number): boolean {
+    if (!this.canNavigateOpenMessage(offset)) {
+      return false;
+    }
+
+    // Use AppComponent.rowSelected so URL, preview, selection, and conversation
+    // behavior stay identical to clicking a message-list row.
+    const newRowIndex = this.canvastable.rows.openedRowIndex + offset;
+    this.rowSelected(newRowIndex, 3, false);
+    if (offset < 0) {
+      this.canvastable.scrollUp();
+    } else {
+      this.canvastable.scrollDown();
+    }
+    this.canvastable.hasChanges = true;
+    return true;
   }
 
   public rowSelected(rowIndex: number, columnIndex: number, multiSelect?: boolean) {

--- a/src/app/mailviewer/singlemailviewer.component.html
+++ b/src/app/mailviewer/singlemailviewer.component.html
@@ -194,6 +194,14 @@
     </div>
 
     <div class="messageActionButtonsRight">
+      <button class="messageNavigationPrevious" mat-icon-button matTooltip="Previous message" aria-label="Previous message"
+              [disabled]="!canNavigatePreviousMessage" (click)="previousMessage.emit()">
+        <mat-icon svgIcon="chevron-up"></mat-icon>
+      </button>
+      <button class="messageNavigationNext" mat-icon-button matTooltip="Next message" aria-label="Next message"
+              [disabled]="!canNavigateNextMessage" (click)="nextMessage.emit()">
+        <mat-icon svgIcon="chevron-down"></mat-icon>
+      </button>
       <button mat-icon-button matTooltip="Print message (Please consider the environment before printing this email)" (click)="print()" id="buttonPrint">
 	<mat-icon svgIcon="printer"></mat-icon>
       </button>

--- a/src/app/mailviewer/singlemailviewer.component.spec.ts
+++ b/src/app/mailviewer/singlemailviewer.component.spec.ts
@@ -30,6 +30,7 @@ import { MatExpansionModule } from '@angular/material/expansion';
 import { MatGridListModule } from '@angular/material/grid-list';
 import { MatIcon, MatIconModule } from '@angular/material/icon';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { MatListModule } from '@angular/material/list';
 import { MatLegacyMenuModule as MatMenuModule } from '@angular/material/legacy-menu';
 import { MatLegacyRadioModule as MatRadioModule } from '@angular/material/legacy-radio';
 import { MatToolbarModule } from '@angular/material/toolbar';
@@ -43,6 +44,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { AvatarBarComponent } from './avatar-bar.component';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Router } from '@angular/router';
+import { By } from '@angular/platform-browser';
 
 import { RunboxWebmailAPI, MessageContents } from '../rmmapi/rbwebmail';
 import { ContactsService } from '../contacts-app/contacts.service';
@@ -105,6 +107,7 @@ describe('SingleMailViewerComponent', () => {
         ResizerModule,
         MatIconModule,
         MatIconTestingModule,
+        MatListModule,
         MatGridListModule,
         MatToolbarModule,
         MatTooltipModule,
@@ -230,6 +233,39 @@ describe('SingleMailViewerComponent', () => {
 
       expect(component.mailObj.attachments[1].downloadURL.indexOf('blob:')).toBe(0);
     }));
+
+  it('should emit previous and next message events from toolbar buttons', fakeAsync(() => {
+    const previousSpy = jasmine.createSpy('previousMessage');
+    const nextSpy = jasmine.createSpy('nextMessage');
+    component.previousMessage.subscribe(previousSpy);
+    component.nextMessage.subscribe(nextSpy);
+    component.canNavigatePreviousMessage = true;
+    component.canNavigateNextMessage = true;
+
+    component.messageId = 22;
+    tick(1);
+    fixture.detectChanges();
+
+    fixture.debugElement.query(By.css('.messageNavigationPrevious')).triggerEventHandler('click', new MouseEvent('click'));
+    fixture.debugElement.query(By.css('.messageNavigationNext')).triggerEventHandler('click', new MouseEvent('click'));
+
+    expect(previousSpy).toHaveBeenCalledTimes(1);
+    expect(nextSpy).toHaveBeenCalledTimes(1);
+    flush();
+  }));
+
+  it('should disable message navigation buttons at list boundaries', fakeAsync(() => {
+    component.canNavigatePreviousMessage = false;
+    component.canNavigateNextMessage = false;
+
+    component.messageId = 22;
+    tick(1);
+    fixture.detectChanges();
+
+    expect(fixture.debugElement.query(By.css('.messageNavigationPrevious')).nativeElement.disabled).toBeTrue();
+    expect(fixture.debugElement.query(By.css('.messageNavigationNext')).nativeElement.disabled).toBeTrue();
+    flush();
+  }));
 
   describe('mailto: link interceptor', () => {
     let messageContentsElement: HTMLElement;

--- a/src/app/mailviewer/singlemailviewer.component.ts
+++ b/src/app/mailviewer/singlemailviewer.component.ts
@@ -81,10 +81,14 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
   @Output() afterViewInit: EventEmitter<any> = new EventEmitter();
   @Output() orientationChangeRequest: EventEmitter<string> = new EventEmitter();
   @Output() afterLoadMessage: EventEmitter<boolean> = new EventEmitter();
+  @Output() previousMessage: EventEmitter<void> = new EventEmitter();
+  @Output() nextMessage: EventEmitter<void> = new EventEmitter();
 
   @Input() messageActionsHandler: MessageActions;
   @Input() adjustableHeight: boolean;
   @Input() showVerticalSplitButton = false;
+  @Input() canNavigatePreviousMessage = false;
+  @Input() canNavigateNextMessage = false;
 
   @ViewChild('printFrame') printFrame: ElementRef;
   @ViewChild('messageContents') messageContents: ElementRef;


### PR DESCRIPTION
Fixes #709.

## Summary
- Add previous/next icon buttons to the open message toolbar so users can move between messages without closing the viewer.
- Reuse the same AppComponent row-navigation path as the existing ArrowUp/ArrowDown handling, keeping URL fragments, selected/opened rows, scroll position, and conversation behavior aligned with row clicks.
- Disable the navigation buttons at the first/last visible message and add focused toolbar coverage for emitted navigation events and disabled boundary states.

## Tests
- `npm run test -- --watch=false --browsers=FirefoxHeadless --include src/app/mailviewer/singlemailviewer.component.spec.ts` (`10 SUCCESS`)
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npx eslint src/app/app.component.ts src/app/app.component.html src/app/mailviewer/singlemailviewer.component.ts src/app/mailviewer/singlemailviewer.component.html src/app/mailviewer/singlemailviewer.component.spec.ts --quiet`
- `npm run lint -- --quiet`
- `git diff --check`
- `git diff --cached --check`
- `npm run policy` (current commit OK; historical upstream commit-message warnings still printed)
- `npm run test -- --watch=false --browsers=FirefoxHeadless` (`247 SUCCESS`, `2 skipped`; existing console noise)
- `SKIP_CHANGELOG=1 node src/build/pre-build.js`; `npx ng build --configuration production --base-href=/app/ runbox7`; `node src/build/post-build.js` (build hash `28f534589702de88`, existing warnings)
- `git show --check --stat HEAD`
