### PR TITLE
Compose messages to contact groups

### DIFF
--- a/src/app/compose/draftdesk.component.ts
+++ b/src/app/compose/draftdesk.component.ts
@@ -51,9 +51,18 @@ export class DraftDeskComponent implements OnInit {
     ngOnInit() {
         this.route.queryParams
             .subscribe(params => {
-                if (params['to']) {
+                if (params['to'] || params['cc'] || params['bcc']) {
                     this.draftDeskservice.newDraft(
-                        DraftFormModel.create(-1, this.draftDeskservice.fromsSubject.value[0], params['to'], '')
+                        DraftFormModel.createWithRecipients(
+                            -1,
+                            this.draftDeskservice.fromsSubject.value[0],
+                            {
+                                to: params['to'],
+                                cc: params['cc'],
+                                bcc: params['bcc'],
+                            },
+                            ''
+                        )
                     ).then(() => this.updateDraftsInView());
                 } else if (params['new']) {
                     // Can't create a new draft until froms has been loaded

--- a/src/app/compose/draftdesk.service.spec.ts
+++ b/src/app/compose/draftdesk.service.spec.ts
@@ -408,6 +408,19 @@ Subject: Test subject <br />
             '"Test Runbox" <to@runbox.com>',
             'Some blahblah');
         expect(draft.isUnsaved()).toBe(false);
+
+        draft = DraftFormModel.createWithRecipients(
+            -1,
+            Identity.fromObject({'email':'from@runbox.com'}),
+            {
+                to: 'to1@runbox.com,to2@runbox.com',
+                cc: 'cc@runbox.com',
+                bcc: 'bcc@runbox.com',
+            },
+            '');
+        expect(draft.to.map(r => r.address)).toEqual(['to1@runbox.com', 'to2@runbox.com']);
+        expect(draft.cc[0].address).toBe('cc@runbox.com');
+        expect(draft.bcc[0].address).toBe('bcc@runbox.com');
         done();
     });
 });

--- a/src/app/compose/draftdesk.service.ts
+++ b/src/app/compose/draftdesk.service.ts
@@ -87,6 +87,18 @@ export class DraftFormModel {
         return ret;
     }
 
+    public static createWithRecipients(
+        draftId: number,
+        fromAddress: Identity,
+        recipients: { to?: string; cc?: string; bcc?: string },
+        subject: string,
+    ): DraftFormModel {
+        const ret = DraftFormModel.create(draftId, fromAddress, recipients.to, subject);
+        ret.cc = recipients.cc ? MailAddressInfo.parse(recipients.cc) : [];
+        ret.bcc = recipients.bcc ? MailAddressInfo.parse(recipients.bcc) : [];
+        return ret;
+    }
+
     public static reply(mailObj, froms: Identity[], all: boolean, useHTML: boolean): DraftFormModel {
         const ret = new DraftFormModel();
         ret.reply_to_id = mailObj.mid;

--- a/src/app/contacts-app/contact-details/contact-details.component.html
+++ b/src/app/contacts-app/contact-details/contact-details.component.html
@@ -105,6 +105,27 @@
         <div *ngIf="contact.kind === kind.GROUP">
             <h3> Members </h3>
 
+            <div class="contact-details-row">
+                <button mat-button type="button"
+                    [disabled]="loadedGroupMembers.length === 0"
+                    (click)="composeGroupRecipients('to')"
+                >
+                    <mat-icon svgIcon="email"></mat-icon> Email group
+                </button>
+                <button mat-button type="button"
+                    [disabled]="loadedGroupMembers.length === 0"
+                    (click)="composeGroupRecipients('cc')"
+                >
+                    <mat-icon svgIcon="email-outline"></mat-icon> Cc group
+                </button>
+                <button mat-button type="button"
+                    [disabled]="loadedGroupMembers.length === 0"
+                    (click)="composeGroupRecipients('bcc')"
+                >
+                    <mat-icon svgIcon="email-lock"></mat-icon> Bcc group
+                </button>
+            </div>
+
             <div
                 (drop)="addMember($event)"
                 [ngStyle]="{ 'border':  (loadedGroupMembers.length === 0 || contactIsDragged) ? '2px dotted' : '',

--- a/src/app/contacts-app/contact-details/contact-details.component.ts
+++ b/src/app/contacts-app/contact-details/contact-details.component.ts
@@ -373,6 +373,22 @@ export class ContactDetailsComponent {
         this.loadGroupMembers();
     }
 
+    async composeGroupRecipients(recipientField: 'to' | 'cc' | 'bcc'): Promise<void> {
+        const members = await Promise.all(this.loadedGroupMembers);
+        const recipientQuery = Contact.groupRecipientQuery(members);
+
+        if (!recipientQuery) {
+            this.snackBar.open('This group has no email addresses', 'Ok');
+            return;
+        }
+
+        this.router.navigate(['/compose'], {
+            queryParams: {
+                [recipientField]: recipientQuery
+            }
+        });
+    }
+
     onPicUploaded(uploadEvent: any) {
         const file = uploadEvent.target.files[0];
 

--- a/src/app/contacts-app/contact.spec.ts
+++ b/src/app/contacts-app/contact.spec.ts
@@ -210,6 +210,33 @@ END:VCARD`);
         expect(sut.members[1].email).toBe('sybil@syb.il');
     });
 
+    it('can build recipient lists from group members', () => {
+        const contact = new Contact({ email: 'member@example.com' });
+        const duplicateContact = new Contact({ email: 'MEMBER@example.com' });
+        const group = Contact.fromVcard(null, `BEGIN:VCARD
+VERSION:4.0
+KIND:group
+MEMBER:mailto:subscriber@example.com
+MEMBER;X-EMAIL=resolved@example.com;X-CN=Resolved:urn:uuid:f00d
+MEMBER:urn:uuid:deleted
+END:VCARD`);
+
+        const emails = Contact.groupRecipientEmails([
+            contact,
+            duplicateContact,
+            group.members[0],
+            group.members[1],
+            group.members[2],
+        ]);
+
+        expect(emails).toEqual([
+            'member@example.com',
+            'subscriber@example.com',
+            'resolved@example.com',
+        ]);
+        expect(Contact.groupRecipientQuery([contact, group.members[0]])).toBe('member@example.com,subscriber@example.com');
+    });
+
     it('can parse org and department correctly', () => {
         let sut = Contact.fromVcard(null, `BEGIN:VCARD
 VERSION:3.0

--- a/src/app/contacts-app/contact.ts
+++ b/src/app/contacts-app/contact.ts
@@ -140,6 +140,30 @@ export class Contact {
     component: ICAL.Component;
     url:       string;
 
+    static groupRecipientEmails(members: Array<Contact | GroupMember>): string[] {
+        const seenEmails = new Set<string>();
+        const emails: string[] = [];
+
+        for (const member of members) {
+            const email = member instanceof Contact ? member.primary_email() : member.email;
+            const normalizedEmail = email ? email.trim() : '';
+            const normalizedKey = normalizedEmail.toLowerCase();
+
+            if (!normalizedKey || seenEmails.has(normalizedKey)) {
+                continue;
+            }
+
+            seenEmails.add(normalizedKey);
+            emails.push(normalizedEmail);
+        }
+
+        return emails;
+    }
+
+    static groupRecipientQuery(members: Array<Contact | GroupMember>): string {
+        return Contact.groupRecipientEmails(members).join(',');
+    }
+
     private static preprocessVcf(vcf: string): string {
         // since ical.js can't parse these
         // (not until https://github.com/mozilla-comm/ical.js/pull/442/files is merged anyway)


### PR DESCRIPTION
Fixes #892.

## Summary
- add To, Cc, and Bcc compose actions to contact group details
- resolve group members to unique email recipients, including direct mailto/X-EMAIL members and contact primary emails
- allow compose drafts opened from query params to prefill cc and bcc recipients

## Validation
- npm ci
- npm run test -- --watch=false --browsers=FirefoxHeadless --include src/app/contacts-app/contact.spec.ts --include src/app/compose/draftdesk.service.spec.ts
- npx tsc -p src/tsconfig.app.json --noEmit
- npx tsc -p src/tsconfig.spec.json --noEmit
- npx eslint src/app/contacts-app/contact.ts src/app/contacts-app/contact-details/contact-details.component.ts src/app/contacts-app/contact-details/contact-details.component.html src/app/compose/draftdesk.component.ts src/app/compose/draftdesk.service.ts src/app/contacts-app/contact.spec.ts src/app/compose/draftdesk.service.spec.ts --quiet
- npm run lint -- --quiet
- git diff --check
- npm run test -- --watch=false --browsers=FirefoxHeadless
- SKIP_CHANGELOG=1 node src/build/pre-build.js && npx ng build --configuration production --base-href=/app/ runbox7 && node src/build/post-build.js
- npm run policy
- git show --check --stat --oneline HEAD
