### PR TITLE
Export individual contacts

### DIFF
--- a/src/app/contacts-app/contact-details/contact-details.component.html
+++ b/src/app/contacts-app/contact-details/contact-details.component.html
@@ -234,6 +234,10 @@
         <mat-toolbar style="position: fixed; bottom: 0;">
             <a mat-button (click)="save()">Save changes</a>
             <a mat-button (click)="rollback()" *ngIf="contact.id && !mobileQuery.matches">Discard changes</a>
+            <button mat-button type="button" (click)="downloadContactVcard()" *ngIf="contact.id">
+                <mat-icon svgIcon="cloud-download"></mat-icon>
+                Export contact
+            </button>
             <a mat-button (click)="delete()" *ngIf="contact.id">Delete this contact</a>
         </mat-toolbar>
     </form>

--- a/src/app/contacts-app/contact-details/contact-details.component.spec.ts
+++ b/src/app/contacts-app/contact-details/contact-details.component.spec.ts
@@ -1,0 +1,85 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { UntypedFormBuilder } from '@angular/forms';
+import { of, ReplaySubject } from 'rxjs';
+import { Contact } from '../contact';
+import { ContactDetailsComponent } from './contact-details.component';
+
+describe('ContactDetailsComponent', () => {
+    function createComponent(): ContactDetailsComponent {
+        const preferences = new ReplaySubject<Map<string, any>>(1);
+        preferences.next(new Map([['Desktop:avatarSource', 'none']]));
+
+        return new ContactDetailsComponent(
+            {} as any,
+            { matches: false } as any,
+            { preferences, prefGroup: 'Desktop' } as any,
+            new UntypedFormBuilder(),
+            {} as any,
+            {} as any,
+            { params: of({}), queryParams: of({}) } as any,
+            {} as any,
+            {
+                contactCategories: of([]),
+                lookupAvatar: () => Promise.resolve(null),
+            } as any,
+            {} as any,
+            {} as any,
+        );
+    }
+
+    it('downloads the current contact as a vCard file', async () => {
+        const component = createComponent();
+        component.contact = Contact.fromVcard('test-url', 'BEGIN:VCARD\r\nVERSION:3.0\r\nFN:Alice Test\r\nUID:test-id\r\nEMAIL:alice@example.com\r\nEND:VCARD');
+
+        const anchor = document.createElement('a');
+        spyOn(anchor, 'click');
+        spyOn(document, 'createElement').and.returnValue(anchor);
+        const createObjectUrlSpy = spyOn(URL, 'createObjectURL').and.returnValue('blob:contact');
+        const revokeObjectUrlSpy = spyOn(URL, 'revokeObjectURL');
+
+        component.downloadContactVcard();
+
+        const blob = createObjectUrlSpy.calls.mostRecent().args[0] as Blob;
+        expect(blob.type).toBe('text/vcard;charset=utf-8');
+        expect(await blob.text()).toContain('FN:Alice Test');
+        expect(anchor.href).toBe('blob:contact');
+        expect(anchor.download).toBe('Alice Test.vcf');
+        expect(anchor.click).toHaveBeenCalled();
+        expect(revokeObjectUrlSpy).toHaveBeenCalledWith('blob:contact');
+    });
+
+    it('uses a safe filename for contact exports', () => {
+        const component = createComponent();
+        component.contact = new Contact({});
+        component.contact.id = 'test-id';
+        component.contact.nickname = 'Alice / Bob <Team>';
+
+        const anchor = document.createElement('a');
+        spyOn(anchor, 'click');
+        spyOn(document, 'createElement').and.returnValue(anchor);
+        spyOn(URL, 'createObjectURL').and.returnValue('blob:contact');
+        spyOn(URL, 'revokeObjectURL');
+
+        component.downloadContactVcard();
+
+        expect(anchor.download).toBe('Alice _ Bob _Team_.vcf');
+    });
+});

--- a/src/app/contacts-app/contact-details/contact-details.component.ts
+++ b/src/app/contacts-app/contact-details/contact-details.component.ts
@@ -404,6 +404,25 @@ export class ContactDetailsComponent {
         this.loadContactPhoto(this.contact.photo = undefined);
     }
 
+    downloadContactVcard(): void {
+        const vcardUrl = URL.createObjectURL(new Blob([this.contact.vcard()], { type: 'text/vcard;charset=utf-8' }));
+        const link = document.createElement('a');
+        link.href = vcardUrl;
+        link.download = this.contactExportFilename();
+        link.click();
+        URL.revokeObjectURL(vcardUrl);
+    }
+
+    private contactExportFilename(): string {
+        const name = (this.contact.display_name() || this.contact.id || 'contact')
+            .trim()
+            .replace(/[<>:"/\\|?*\x00-\x1F]/g, '_')
+            .replace(/\s+/g, ' ')
+            .replace(/[. ]+$/g, '');
+
+        return `${name || 'contact'}.vcf`;
+    }
+
     showUploadDialog() {
         this.picUploadInput.nativeElement.click();
     }


### PR DESCRIPTION
Fixes #687.

## Summary
- add an Export contact action to saved contact details
- download the selected contact as a local `.vcf` file using the existing vCard serializer
- derive a safe filename from the contact display name and revoke the generated object URL after starting the download

## Validation
- npm ci
- npm run test -- --watch=false --browsers=FirefoxHeadless --include src/app/contacts-app/contact-details/contact-details.component.spec.ts
- npx tsc -p src/tsconfig.app.json --noEmit
- npx tsc -p src/tsconfig.spec.json --noEmit
- npx eslint src/app/contacts-app/contact-details/contact-details.component.ts src/app/contacts-app/contact-details/contact-details.component.html src/app/contacts-app/contact-details/contact-details.component.spec.ts --quiet
- npm run lint -- --quiet
- git diff --check
- npm run test -- --watch=false --browsers=FirefoxHeadless
- SKIP_CHANGELOG=1 node src/build/pre-build.js && npx ng build --configuration production --base-href=/app/ runbox7 && node src/build/post-build.js
- npm run policy
- git show --check --stat --oneline HEAD
