### PR TITLE
Remove deleted contacts immediately

### DIFF
--- a/src/app/contacts-app/contacts.service.spec.ts
+++ b/src/app/contacts-app/contacts.service.spec.ts
@@ -24,7 +24,7 @@ import { Contact } from './contact';
 import { ContactsService } from './contacts.service';
 import { HttpErrorResponse } from '@angular/common/http';
 import { RunboxWebmailAPI, RunboxMe, ContactSyncResult } from '../rmmapi/rbwebmail';
-import { of, ReplaySubject, firstValueFrom } from 'rxjs';
+import { of, ReplaySubject, firstValueFrom, Subject } from 'rxjs';
 import { take } from 'rxjs/operators';
 
 class MockPrefService {
@@ -43,6 +43,8 @@ class MockRMMAPI {
   prefs =  {'Desktop': {'version': 1, 'entries': new Map<string, any>()},
                  'Global': {'version': 1, 'entries': new Map<string, any>()}};
   me = of({ uid: 13 } as RunboxMe);
+  deletedContacts: Contact[] = [];
+  deleteContactResponse = new Subject<any>();
 
   syncContacts() {
     return of(new ContactSyncResult(`token-${(new Date()).getTime()}`, [
@@ -51,6 +53,11 @@ class MockRMMAPI {
         + 'UID:dead-cafe\r\nPHOTO:http://test.url\r\nEND:VCARD'
     )
     ], [], 0));
+  }
+
+  deleteContact(contact: Contact) {
+    this.deletedContacts.push(contact);
+    return this.deleteContactResponse.asObservable();
   }
 }
 
@@ -61,6 +68,7 @@ describe('ContactsService', () => {
   let sut: ContactsService;
 
   beforeEach(async () => {
+    localStorage.clear();
     rmmapi = new MockRMMAPI();
     storage = new StorageService(rmmapi as unknown as RunboxWebmailAPI);
     sut = new ContactsService(rmmapi as unknown as RunboxWebmailAPI, prefService, storage);
@@ -159,6 +167,50 @@ describe('ContactsService', () => {
           done();
         });
       }, 20);
+    });
+  });
+
+  describe('Contact deletion', () => {
+    it('should remove a deleted contact from local state before the backend request completes', async () => {
+      await firstValueFrom(sut.contactsSubject);
+      const contact = Contact.fromVcard(
+        'delete-url',
+        'BEGIN:VCARD\r\nVERSION:3.0\r\nFN:Delete Me\r\nEMAIL:delete-me@runbox.com\r\nUID:delete-me\r\nEND:VCARD'
+      );
+      sut.processContacts([contact]);
+
+      const deletePromise = sut.deleteContact(contact);
+      const contactsAfterLocalDelete = await firstValueFrom(sut.contactsSubject);
+
+      expect(rmmapi.deletedContacts).toEqual([contact]);
+      expect(contactsAfterLocalDelete.find(c => c.id === contact.id)).toBeUndefined();
+
+      rmmapi.deleteContactResponse.next({});
+      rmmapi.deleteContactResponse.complete();
+
+      await deletePromise;
+    });
+
+    it('should restore local contacts when backend deletion fails', async () => {
+      await firstValueFrom(sut.contactsSubject);
+      const initialContacts = [
+        Contact.fromVcard(
+          'delete-url',
+          'BEGIN:VCARD\r\nVERSION:3.0\r\nFN:Delete Me\r\nEMAIL:delete-me@runbox.com\r\nUID:delete-me\r\nEND:VCARD'
+        )
+      ];
+      sut.processContacts(initialContacts);
+      const [contact] = initialContacts;
+      const deleteError = new HttpErrorResponse({ status: 500, statusText: 'Server Error' });
+
+      const deletePromise = sut.deleteContact(contact).catch(e => e);
+      await firstValueFrom(sut.contactsSubject);
+
+      rmmapi.deleteContactResponse.error(deleteError);
+
+      expect(await deletePromise).toBe(deleteError);
+      const contactsAfterError = await firstValueFrom(sut.contactsSubject);
+      expect(contactsAfterError.map(c => c.id)).toEqual(initialContacts.map(c => c.id));
     });
   });
 

--- a/src/app/contacts-app/contacts.service.ts
+++ b/src/app/contacts-app/contacts.service.ts
@@ -295,14 +295,19 @@ export class ContactsService implements OnDestroy {
         return promise;
     }
 
-    deleteContact(contact: Contact): Promise<void> {
+    async deleteContact(contact: Contact): Promise<void> {
         this.activities.begin(Activity.DeletingContact);
 
-        const promise = this.deleteContactSilently(contact);
-        promise.finally(() => this.activities.end(Activity.DeletingContact));
-        promise.then(() => this.reload());
-
-        return promise;
+        const previousContacts = await this.removeContactsLocally([contact]);
+        try {
+            await this.deleteContactSilently(contact);
+            this.reload();
+        } catch (e) {
+            this.processContacts(previousContacts);
+            throw e;
+        } finally {
+            this.activities.end(Activity.DeletingContact);
+        }
     }
 
     deleteMultiple(contacts: Contact[]): Promise<void> {
@@ -387,7 +392,25 @@ export class ContactsService implements OnDestroy {
                 resolve();
             }, e => {
                 this.apiErrorHandler(e);
-                reject();
+                reject(e);
+            });
+        });
+    }
+
+    private removeContactsLocally(contactsToRemove: Contact[]): Promise<Contact[]> {
+        return new Promise(resolve => {
+            this.contactsSubject.pipe(take(1)).subscribe(currentContacts => {
+                const ids = new Set(contactsToRemove.map(c => c.id).filter(id => id));
+                const urls = new Set(contactsToRemove.map(c => c.url).filter(url => url));
+                const remainingContacts = currentContacts.filter(c =>
+                    !ids.has(c.id) && !urls.has(c.url)
+                );
+
+                if (remainingContacts.length !== currentContacts.length) {
+                    this.processContacts(remainingContacts);
+                }
+
+                resolve(currentContacts);
             });
         });
     }


### PR DESCRIPTION
Fixes #757.

## Summary
- Remove a deleted contact from `ContactsService` local state immediately when deletion starts, so the contact list and detail subscribers update before the backend delete/refresh finishes.
- Restore the previous local contact list if the backend delete fails, while preserving the existing error reporting path.
- Keep the existing post-delete `reload()` reconciliation on successful backend deletion.
- Add focused `ContactsService` coverage for optimistic local removal and failure rollback.

## Validation
- `npm ci`
- `npm run test -- --watch=false --browsers=FirefoxHeadless --include src/app/contacts-app/contacts.service.spec.ts` (`15 SUCCESS`)
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npx eslint src/app/contacts-app/contacts.service.ts src/app/contacts-app/contacts.service.spec.ts --quiet`
- `npm run test -- --watch=false --browsers=FirefoxHeadless --include src/app/contacts-app/*.spec.ts` (`38 SUCCESS`)
- `npm run lint -- --quiet`
- `git diff --check` (only existing CRLF normalization warnings)
- `npm run test -- --watch=false --browsers=FirefoxHeadless` (`247 SUCCESS`, `2 skipped`)
- `npm run policy` before and after commit (passes; historical upstream commit-message warnings are still printed)
- Manual production build with `SKIP_CHANGELOG=1` using `node src/build/pre-build.js`, `npx ng build --configuration production --base-href=/app/ runbox7`, and `node src/build/post-build.js` (build hash `7df4bd9a3448c246`; existing Angular/CommonJS warnings)
- `git diff --cached --check`
- `git show --check --stat --oneline HEAD`

No live Runbox account, Contacts data, backend API, or production service action was used for validation.
