### PR TITLE
Fix editing drafts from search results

### DIFF
--- a/src/app/compose/draftdesk.component.spec.ts
+++ b/src/app/compose/draftdesk.component.spec.ts
@@ -1,0 +1,107 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2022 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { BehaviorSubject } from 'rxjs';
+
+import { Identity } from '../profiles/profile.service';
+import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
+import { DraftDeskComponent } from './draftdesk.component';
+import { DraftDeskService, DraftFormModel } from './draftdesk.service';
+
+interface DraftDeskServiceStub {
+    draftModels: BehaviorSubject<DraftFormModel[]>;
+    fromsSubject: BehaviorSubject<Identity[]>;
+    isEditing: number;
+    newDraft: jasmine.Spy;
+    deleteDraft: jasmine.Spy;
+}
+
+describe('DraftDeskComponent', () => {
+    let fixture: ComponentFixture<DraftDeskComponent>;
+    let component: DraftDeskComponent;
+    let queryParams: BehaviorSubject<Record<string, string>>;
+    let draftDeskService: DraftDeskServiceStub;
+    const defaultIdentity = Identity.fromObject({ email: 'me@example.com' });
+
+    const createDraft = (mid: number) => DraftFormModel.create(
+        mid,
+        defaultIdentity,
+        '',
+        `Draft ${mid}`
+    );
+
+    beforeEach(async () => {
+        queryParams = new BehaviorSubject({});
+        draftDeskService = {
+            draftModels: new BehaviorSubject<DraftFormModel[]>([]),
+            fromsSubject: new BehaviorSubject<Identity[]>([defaultIdentity]),
+            isEditing: -1,
+            newDraft: jasmine.createSpy('newDraft').and.returnValue(Promise.resolve()),
+            deleteDraft: jasmine.createSpy('deleteDraft')
+        };
+
+        await TestBed.configureTestingModule({
+            declarations: [DraftDeskComponent],
+            providers: [
+                { provide: ActivatedRoute, useValue: { queryParams: queryParams.asObservable() } },
+                { provide: Router, useValue: { navigate: jasmine.createSpy('navigate') } },
+                { provide: RunboxWebmailAPI, useValue: {} },
+                { provide: DraftDeskService, useValue: draftDeskService }
+            ]
+        })
+            .overrideComponent(DraftDeskComponent, { set: { template: '' } })
+            .compileComponents();
+
+        fixture = TestBed.createComponent(DraftDeskComponent);
+        component = fixture.componentInstance;
+    });
+
+    it('should open the draft requested by query parameter for editing', () => {
+        draftDeskService.draftModels.next([createDraft(42)]);
+        queryParams.next({ edit: '42' });
+
+        fixture.detectChanges();
+
+        expect(draftDeskService.isEditing).toBe(42);
+        expect(component.draftModelsInView[0].mid).toBe(42);
+    });
+
+    it('should keep a requested draft visible when it is outside the first page', () => {
+        const drafts = [110, 109, 108, 107, 106, 105, 104, 103, 102, 101, 42]
+            .map(createDraft);
+        draftDeskService.draftModels.next(drafts);
+        queryParams.next({ edit: '42' });
+
+        fixture.detectChanges();
+
+        expect(component.draftModelsInView.some((draft) => draft.mid === 42)).toBeTrue();
+        expect(component.draftModelsInView.length).toBe(10);
+    });
+
+    it('should ignore invalid edit query parameters', () => {
+        queryParams.next({ edit: 'not-a-number' });
+
+        fixture.detectChanges();
+
+        expect(draftDeskService.isEditing).toBe(-1);
+        expect(component.draftModelsInView).toEqual([]);
+    });
+});

--- a/src/app/compose/draftdesk.component.ts
+++ b/src/app/compose/draftdesk.component.ts
@@ -35,6 +35,7 @@ export class DraftDeskComponent implements OnInit {
     public hasMoreDrafts = false;
     public currentMaxDraftsInView: number = MAX_DRAFTS_IN_VIEW;
     private hasInitialized = false;
+    private draftToEdit: number = null;
 
     constructor(
         public rmmapi: RunboxWebmailAPI,
@@ -43,7 +44,7 @@ export class DraftDeskComponent implements OnInit {
         public draftDeskservice: DraftDeskService) {
 
         this.draftDeskservice.draftModels.subscribe(
-            drafts => this.updateDraftsInView(),
+            _drafts => this.updateDraftsInView(),
             err => console.log(err)
         );
     }
@@ -51,7 +52,9 @@ export class DraftDeskComponent implements OnInit {
     ngOnInit() {
         this.route.queryParams
             .subscribe(params => {
-                if (params['to']) {
+                if (params['edit']) {
+                    this.editDraft(parseInt(params['edit'], 10));
+                } else if (params['to']) {
                     this.draftDeskservice.newDraft(
                         DraftFormModel.create(-1, this.draftDeskservice.fromsSubject.value[0], params['to'], '')
                     ).then(() => this.updateDraftsInView());
@@ -109,10 +112,32 @@ export class DraftDeskComponent implements OnInit {
         } else {
             this.draftModelsInView = this.draftDeskservice.draftModels.value.slice(0, this.currentMaxDraftsInView);
         }
+        this.keepDraftToEditInView();
+        this.hasMoreDrafts = this.currentMaxDraftsInView < this.draftDeskservice.draftModels.value.length;
     }
 
     draftDeleted(messageId) {
         this.draftDeskservice.deleteDraft(messageId);
+    }
+
+    editDraft(messageId: number) {
+        if (!Number.isInteger(messageId) || messageId <= 0) {
+            return;
+        }
+        this.draftToEdit = messageId;
+        this.draftDeskservice.isEditing = messageId;
+        this.updateDraftsInView();
+    }
+
+    private keepDraftToEditInView() {
+        if (!this.draftToEdit || this.draftModelsInView.some((draft) => draft.mid === this.draftToEdit)) {
+            return;
+        }
+        const draft = this.draftDeskservice.draftModels.value.find((model) => model.mid === this.draftToEdit);
+        if (draft) {
+            this.draftModelsInView.splice(0, 0, draft);
+            this.draftModelsInView = this.draftModelsInView.slice(0, this.currentMaxDraftsInView);
+        }
     }
 
     exitToTable() {

--- a/src/app/mailviewer/singlemailviewer.component.html
+++ b/src/app/mailviewer/singlemailviewer.component.html
@@ -194,6 +194,9 @@
     </div>
 
     <div class="messageActionButtonsRight">
+      <button mat-icon-button *ngIf="isDraftMessage()" matTooltip="Edit draft" (click)="editDraft()">
+        <mat-icon svgIcon="pencil"></mat-icon>
+      </button>
       <button mat-icon-button matTooltip="Print message (Please consider the environment before printing this email)" (click)="print()" id="buttonPrint">
 	<mat-icon svgIcon="printer"></mat-icon>
       </button>

--- a/src/app/mailviewer/singlemailviewer.component.spec.ts
+++ b/src/app/mailviewer/singlemailviewer.component.spec.ts
@@ -231,6 +231,29 @@ describe('SingleMailViewerComponent', () => {
       expect(component.mailObj.attachments[1].downloadURL.indexOf('blob:')).toBe(0);
     }));
 
+  it('should navigate to Draft Desk to edit a draft message', fakeAsync(() => {
+    const navigateSpy = spyOn(router, 'navigate').and.returnValue(Promise.resolve(true));
+    component.messageId = 22;
+    component.folder = 'Drafts';
+
+    component.editDraft();
+    tick();
+
+    expect(navigateSpy).toHaveBeenCalledWith(
+      ['/compose'],
+      { queryParams: { edit: 22 } }
+    );
+    expect(component.messageId).toBeNull();
+  }));
+
+  it('should identify messages in Drafts as editable drafts', () => {
+    component.folder = 'Drafts';
+    expect(component.isDraftMessage()).toBeTrue();
+
+    component.folder = 'Inbox';
+    expect(component.isDraftMessage()).toBeFalse();
+  });
+
   describe('mailto: link interceptor', () => {
     let messageContentsElement: HTMLElement;
     let mailtoLink: HTMLAnchorElement;

--- a/src/app/mailviewer/singlemailviewer.component.ts
+++ b/src/app/mailviewer/singlemailviewer.component.ts
@@ -228,6 +228,15 @@ export class SingleMailViewerComponent implements OnInit, DoCheck, AfterViewInit
     this.router.navigate(['/compose'], { queryParams: { to } });
   }
 
+  public isDraftMessage(): boolean {
+    return this.folder === 'Drafts';
+  }
+
+  public editDraft() {
+    this.router.navigate(['/compose'], { queryParams: { edit: this.messageId } })
+      .then(() => this.close());
+  }
+
   public close(actionstring?: string) {
     const doClose = () => {
       if (this.resizer) {


### PR DESCRIPTION
Fixes #625.

## Summary

- Add an Edit draft toolbar action when the opened message reports that it is in Drafts.
- Route that action to Draft Desk as `/compose?edit=<messageId>` and close the viewer after navigation.
- Teach Draft Desk to honor the `edit` query parameter by setting the existing editing state and keeping the requested draft in the visible draft list even when it is outside the first page.

## Validation

- `npx tsc -p tsconfig.json --noEmit`
- `npx eslint src/app/compose/draftdesk.component.ts src/app/compose/draftdesk.component.spec.ts src/app/mailviewer/singlemailviewer.component.ts src/app/mailviewer/singlemailviewer.component.html src/app/mailviewer/singlemailviewer.component.spec.ts` (existing mailviewer warnings only, no errors)
- `npx ng test --watch=false --browsers=FirefoxHeadless --include src/app/mailviewer/singlemailviewer.component.spec.ts --include src/app/compose/draftdesk.component.spec.ts` (`13 SUCCESS`)
- `npx ng test --watch=false --browsers=FirefoxHeadless --include src/app/compose/*.spec.ts --include src/app/mailviewer/singlemailviewer.component.spec.ts` (`42 SUCCESS`)
- `npx ng test --watch=false --browsers=FirefoxHeadless` (`250 SUCCESS`, `2 skipped`, exit code 0; a late post-success Firefox disconnect line was printed)
- `git diff --check`
- `npm run policy` (current commit OK; historical upstream commit-message warnings remain)
- Production build with `node src/build/pre-build.js; npx ng build --configuration production --base-href=/app/ runbox7; node src/build/post-build.js` (hash `9326c4716075b4fb`, existing warnings only)

No live Runbox account, mailbox, or backend action was used.

## AI use

This PR was prepared with OpenAI Codex assistance for source review, code edits, and local command execution in my development workspace. I reviewed the generated changes and validation output before submission.
