### PR TITLE
Add inline preview line count option

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -347,6 +347,23 @@
                 Inline previews
               </mat-checkbox>
             </mat-list-item>
+            <mat-list-item *ngIf="canvastable && canvastable.showContentTextPreview"
+                           class="tableViewOptionsMenuElement contentPreviewLinesMenuItem"
+                           (click)="$event.stopPropagation()">
+              <mat-icon svgIcon="format-line-spacing"
+                        class="tableViewOptionsMenuElement"
+                        matTooltip="Inline preview lines"></mat-icon>
+              <span class="contentPreviewLinesLabel">Preview lines</span>
+              <mat-button-toggle-group
+                [ngModel]="contentPreviewLines"
+                (change)="saveContentPreviewLinesSetting($event.value)"
+                aria-label="Inline preview lines"
+                class="contentPreviewLinesToggle">
+                <mat-button-toggle *ngFor="let lineCount of contentPreviewLineOptions" [value]="lineCount">
+                  {{lineCount}}
+                </mat-button-toggle>
+              </mat-button-toggle-group>
+            </mat-list-item>
             <!-- currently only supporting threading for local index -->
             <mat-list-item>
               <mat-checkbox [(ngModel)]="conversationGroupingCheckbox"

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -10,6 +10,21 @@
     vertical-align: middle !important;
 }
 
+.contentPreviewLinesMenuItem {
+    height: 44px !important;
+}
+
+.contentPreviewLinesLabel {
+    display: inline-block;
+    min-width: 88px;
+    margin-left: 4px;
+    font-size: 13px;
+}
+
+.contentPreviewLinesToggle {
+    margin-left: 8px;
+}
+
 .contextToolButtonsRegular {
     position: absolute;
     display: flex;

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -71,6 +71,7 @@ const LOCAL_STORAGE_SETTING_MAILVIEWER_ON_RIGHT_SIDE_IF_MOBILE = 'mailViewerOnRi
 const LOCAL_STORAGE_SETTING_MAILVIEWER_ON_RIGHT_SIDE = 'mailViewerOnRightSide';
 const LOCAL_STORAGE_VIEWMODE = 'rmm7mailViewerViewMode';
 const LOCAL_STORAGE_SHOWCONTENTPREVIEW = 'rmm7mailViewerContentPreview';
+const LOCAL_STORAGE_CONTENTPREVIEWLINES = 'rmm7mailViewerContentPreviewLines';
 const LOCAL_STORAGE_KEEP_PANE = 'keepMessagePaneOpen';
 const LOCAL_STORAGE_SHOW_UNREAD_ONLY = 'rmm7mailViewerShowUnreadOnly';
 const LOCAL_STORAGE_SHOW_POPULAR_RECIPIENTS = 'showPopularRecipients';
@@ -86,6 +87,8 @@ const TOOLBAR_LIST_BUTTON_WIDTH = 30;
 export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectListener, DoCheck {
   showSelectOperations: boolean;
   showSelectMarkOpMenu: boolean;
+  contentPreviewLineOptions = [1, 2, 3];
+  contentPreviewLines = 1;
 
   lastSearchText = '';
   searchText = '';
@@ -299,6 +302,10 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
       // message list prefs
       if (this.canvastable) {
         this.canvastable.showContentTextPreview = prefs.get(`${this.preferenceService.prefGroup}:${LOCAL_STORAGE_SHOWCONTENTPREVIEW}`) === 'true';
+        this.contentPreviewLines = this.parseContentPreviewLines(
+          prefs.get(`${this.preferenceService.prefGroup}:${LOCAL_STORAGE_CONTENTPREVIEWLINES}`)
+        );
+        this.canvastable.contentTextPreviewLines = this.contentPreviewLines;
         this.canvastable.columnWidths = prefs.get(`${this.preferenceService.prefGroup}:canvasNamedColumnWidthsBySet`) || {};
       }
       this.keepMessagePaneOpen = prefs.get(`${this.preferenceService.prefGroup}:${LOCAL_STORAGE_KEEP_PANE}`) === 'true';
@@ -363,6 +370,12 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     this.canvastable = this.canvastablecontainer.canvastable;
     if (this.preferences.has(`${this.preferenceService.prefGroup}:${LOCAL_STORAGE_SHOWCONTENTPREVIEW}`)) {
       this.canvastable.showContentTextPreview = this.preferences.get(`${this.preferenceService.prefGroup}:${LOCAL_STORAGE_SHOWCONTENTPREVIEW}`) === 'true';
+    }
+    if (this.preferences.has(`${this.preferenceService.prefGroup}:${LOCAL_STORAGE_CONTENTPREVIEWLINES}`)) {
+      this.contentPreviewLines = this.parseContentPreviewLines(
+        this.preferences.get(`${this.preferenceService.prefGroup}:${LOCAL_STORAGE_CONTENTPREVIEWLINES}`)
+      );
+      this.canvastable.contentTextPreviewLines = this.contentPreviewLines;
     }
     if (this.preferences.has(`${this.preferenceService.prefGroup}:canvasNamedColumnWidthsBySet`)) {
       this.canvastable.columnWidths = this.preferences.get(`${this.preferenceService.prefGroup}:canvasNamedColumnWidthsBySet`) || {};
@@ -676,6 +689,21 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     const setting = this.canvastable.showContentTextPreview ? 'true' : 'false';
     this.preferenceService.set(this.preferenceService.prefGroup, LOCAL_STORAGE_SHOWCONTENTPREVIEW, setting);
 //    localStorage.setItem(LOCAL_STORAGE_SHOWCONTENTPREVIEW, setting);
+  }
+
+  saveContentPreviewLinesSetting(lines: number): void {
+    this.contentPreviewLines = this.parseContentPreviewLines(lines);
+    this.canvastable.contentTextPreviewLines = this.contentPreviewLines;
+    this.preferenceService.set(
+      this.preferenceService.prefGroup,
+      LOCAL_STORAGE_CONTENTPREVIEWLINES,
+      this.contentPreviewLines.toString()
+    );
+  }
+
+  private parseContentPreviewLines(lines: unknown): number {
+    const parsedLines = Number(lines);
+    return this.contentPreviewLineOptions.includes(parsedLines) ? parsedLines : 1;
   }
 
   public trainSpam(params) {

--- a/src/app/canvastable/canvastable.spec.ts
+++ b/src/app/canvastable/canvastable.spec.ts
@@ -73,4 +73,28 @@ describe('canvastable', () => {
         expect(fixture.componentInstance.canvastable.floatingTooltip).toBeTruthy();
         expect(fixture.componentInstance.canvastable.columnOverlay).toBeTruthy();
     });
+
+    it('should expand row height for the selected number of preview lines', () => {
+        const fixture = TestBed.createComponent(CanvasTableContainerComponent);
+        fixture.detectChanges();
+
+        const canvastable = fixture.componentInstance.canvastable;
+        canvastable.rowWrapMode = false;
+        canvastable.showContentTextPreview = false;
+
+        expect(canvastable.rowheight).toBe(28);
+
+        canvastable.showContentTextPreview = true;
+        canvastable.contentTextPreviewLines = 1;
+        expect(canvastable.rowheight).toBe(49);
+
+        canvastable.contentTextPreviewLines = 2;
+        expect(canvastable.rowheight).toBe(64);
+
+        canvastable.contentTextPreviewLines = 3;
+        expect(canvastable.rowheight).toBe(79);
+
+        canvastable.contentTextPreviewLines = 99;
+        expect(canvastable.contentTextPreviewLines).toBe(3);
+    });
 });

--- a/src/app/canvastable/canvastable.ts
+++ b/src/app/canvastable/canvastable.ts
@@ -204,6 +204,7 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
   public rowWrapModeDefaultSelectedColumn = 2;
 
   public _showContentTextPreview = false;
+  private _contentTextPreviewLines = 1;
 
   public hasChanges: boolean;
 
@@ -859,7 +860,19 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
 
   public set showContentTextPreview(showContentTextPreview: boolean) {
     this._showContentTextPreview = showContentTextPreview;
-    this.hasChanges = true;
+    this.updateRowMetrics();
+  }
+
+  public get contentTextPreviewLines(): number {
+    return this._contentTextPreviewLines;
+  }
+
+  public set contentTextPreviewLines(contentTextPreviewLines: number) {
+    const normalizedLines = Math.max(1, Math.min(3, Number(contentTextPreviewLines) || 1));
+    if (this._contentTextPreviewLines !== normalizedLines) {
+      this._contentTextPreviewLines = normalizedLines;
+      this.updateRowMetrics();
+    }
   }
 
   // When loading a url with a fragment containing a msg id - scroll to there
@@ -889,6 +902,14 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
       this.horizScroll + this.canv.scrollWidth > columnsTotalWidth) {
       this.horizScroll = columnsTotalWidth - this.canv.scrollWidth;
     }
+  }
+
+  private updateRowMetrics() {
+    if (this.canv) {
+      this.maxVisibleRows = this.canv.scrollHeight / this.rowheight;
+      this.enforceScrollLimit();
+    }
+    this.hasChanges = true;
   }
 
   /**
@@ -946,15 +967,46 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
 
   // Height of message list rows
   public get rowheight(): number {
-    return (this.rowWrapMode || this.showContentTextPreview ) ?
-      1.75 * this._rowheight : this._rowheight;
+    if (this.showContentTextPreview) {
+      return (1.75 * this._rowheight) + ((this.contentTextPreviewLines - 1) * 15);
+    }
+    return this.rowWrapMode ? 1.75 * this._rowheight : this._rowheight;
   }
 
   public set rowheight(rowheight: number) {
     if (this._rowheight !== rowheight) {
       this._rowheight = rowheight;
-      this.hasChanges = true;
+      this.updateRowMetrics();
     }
+  }
+
+  private getContentTextPreviewLines(contentPreviewText: string, maxWidth: number): string[] {
+    const normalizedText = (contentPreviewText || '').trim().replace(/\s+/g, ' ');
+    if (!normalizedText) {
+      return [];
+    }
+    if (this.contentTextPreviewLines === 1) {
+      return [normalizedText];
+    }
+
+    const lines: string[] = [];
+    let currentLine = '';
+    for (const word of normalizedText.split(' ')) {
+      if (lines.length >= this.contentTextPreviewLines) {
+        break;
+      }
+      const nextLine = currentLine ? `${currentLine} ${word}` : word;
+      if (!currentLine || this.ctx.measureText(nextLine).width <= maxWidth) {
+        currentLine = nextLine;
+      } else {
+        lines.push(currentLine);
+        currentLine = word;
+      }
+    }
+    if (currentLine && lines.length < this.contentTextPreviewLines) {
+      lines.push(currentLine);
+    }
+    return lines;
   }
 
   private dopaint() {
@@ -1038,6 +1090,7 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
 //      const rowobj = this.rows[rowIndex];
 
       const halfrowheight = (this.rowheight / 2);
+      const primaryHalfRowHeight = this.showContentTextPreview ? ((1.75 * this._rowheight) / 2) : halfrowheight;
       const rowy = (rowIndex - this.topindex) * this.rowheight;
       if (this.rows.rowExists(rowIndex)) {
         // Clear row area
@@ -1110,7 +1163,7 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
               this.ctx.fillStyle = this.textColor;
             }
             this.ctx.textAlign = 'center';
-            this.ctx.fillText(formattedVal + '', canvwidth - 36, rowy + halfrowheight - 15);
+            this.ctx.fillText(formattedVal + '', canvwidth - 36, rowy + primaryHalfRowHeight - 15);
 
             this.ctx.restore();
 
@@ -1134,7 +1187,7 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
               // Wrap rows if in row wrap mode (for e.g. mobile portrait view)
 
               // Check box
-              const texty: number = rowy + halfrowheight;
+              const texty: number = rowy + primaryHalfRowHeight;
               const textx: number = x - this.horizScroll;
 
               const width = col.width - this.colpaddingright - this.colpaddingleft;
@@ -1179,7 +1232,7 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
                     this.ctx.font = this.fontheight + 'px ' + this.fontFamily;
                     this.ctx.fillStyle = this.textColorLink;
                   }
-                  this.ctx.fillText(formattedVal, x, rowy + halfrowheight + 12
+                  this.ctx.fillText(formattedVal, x, rowy + primaryHalfRowHeight + 12
                         - (this.showContentTextPreview ? 12 : 0)
                       );
                   this.ctx.restore();
@@ -1189,14 +1242,14 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
                   this.ctx.save();
                   this.ctx.font = this.fontheightSmaller + 'px ' + this.fontFamily;
                   this.ctx.fillStyle = this.textColor;
-                  this.ctx.fillText(formattedVal, x, rowy + halfrowheight - 10
+                  this.ctx.fillText(formattedVal, x, rowy + primaryHalfRowHeight - 10
                     - (this.showContentTextPreview ? 8 : 0)
                     );
                   this.ctx.restore();
                 } else {
                   x = 128; // far enough to make the date above fit nicely
                   this.ctx.font = this.fontheightSmall + 'px ' + this.fontFamily;
-                  this.ctx.fillText(formattedVal, x, rowy + halfrowheight - 10
+                  this.ctx.fillText(formattedVal, x, rowy + primaryHalfRowHeight - 10
                     - (this.showContentTextPreview ? 8 : 0));
                   this.ctx.fillStyle = this.textColorLink;
                 }
@@ -1206,7 +1259,7 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
               // Normal no-wrap mode
 
               // Check box
-              const texty: number = rowy + halfrowheight - (this.showContentTextPreview ? 10 : 0);
+              const texty: number = rowy + primaryHalfRowHeight - (this.showContentTextPreview ? 10 : 0);
               let textx: number = x - this.horizScroll;
 
               const width = col.width - this.colpaddingright - this.colpaddingleft;
@@ -1276,9 +1329,15 @@ export class CanvasTableComponent implements AfterViewInit, DoCheck, OnInit {
             this.ctx.save();
             this.ctx.fillStyle = this.textColor;
             this.ctx.font = this.fontheightSmaller + 'px ' + this.fontFamily;
-          const contentTextPreviewColumnPadding = this.rowWrapMode ? 2 : 10; // Increase left padding of content preview
-            this.ctx.fillText(contentPreviewText, this.columns[0]. width + contentTextPreviewColumnPadding,
-              rowy + halfrowheight + (this.rowWrapMode ? 18 : 15));
+            const contentTextPreviewColumnPadding = this.rowWrapMode ? 2 : 10; // Increase left padding of content preview
+            const contentTextPreviewX = this.columns[0].width + contentTextPreviewColumnPadding;
+            const contentTextPreviewMaxWidth =
+              Math.max(0, canvwidth - contentTextPreviewX - this.scrollbarwidth - contentTextPreviewColumnPadding);
+            const contentTextPreviewLines = this.getContentTextPreviewLines(contentPreviewText, contentTextPreviewMaxWidth);
+            contentTextPreviewLines.forEach((line, lineIndex) => {
+              this.ctx.fillText(line, contentTextPreviewX,
+                rowy + primaryHalfRowHeight + (this.rowWrapMode ? 18 : 15) + (lineIndex * 15));
+            });
             this.ctx.restore();
           }
         }


### PR DESCRIPTION
## Summary
- Add a 1/2/3 line selector under the existing Inline previews option in the message-list view menu.
- Persist the selected inline preview line count as a device preference, defaulting to the current single-line behavior.
- Expand canvas row height and wrap preview text across the selected number of lines while keeping the main message row aligned.

Fixes #548

## Validation
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npx eslint src/app/app.component.ts src/app/canvastable/canvastable.ts src/app/canvastable/canvastable.spec.ts` (warnings only, existing warning patterns)
- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/canvastable/canvastable.spec.ts` (`2 SUCCESS`)
- `npm run lint` (exits 0 with existing 770 warnings)
- `npx ng test --watch=false --browsers=FirefoxHeadless` (`246 SUCCESS`, `2 skipped`, existing console noise)
- `node src/build/pre-build.js; npx ng build --configuration production --base-href=/app/ runbox7; node src/build/post-build.js` (exits 0 with existing warnings; generated changelog restored)
- `npm run policy` (exits 0; current commit OK, historical commit-message warnings remain)
- `git diff HEAD~1 HEAD --check`

## AI Disclosure
I used OpenAI Codex as a coding assistant for this contribution. Codex helped inspect the existing message-list preference/canvas code, implement the patch, add the focused spec, and run the validation commands listed above.
