### PR TITLE
fix(mail): widen folder pane resize area

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -5,7 +5,8 @@
       [fixedInViewport]="mobileQuery.matches"
       fixedTopGap="0"
       id="sideMenu"
-      appResizable>
+      appResizable
+      [resizableGrabWidth]="14">
     <mat-nav-list dense>      
       <app-sidenav-menu (closeMenu)="sidemenu.close()"></app-sidenav-menu>
 


### PR DESCRIPTION
## Summary

- Widen the folder pane resize grab area by configuring the existing sidebar `appResizable` instance with a 14px grab width.
- Keep the visible sidebar divider at the existing 1px style via the current `#sideMenu` CSS.
- Leave the shared resizer directive and right-side message preview divider unchanged.

Closes #541

## Testing

- `npm ci`
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `git diff --check`
- `npm run lint -- --quiet`
- `npx ng test --watch=false --browsers=FirefoxHeadless`
- `node src/build/pre-build.js; npx ng build --configuration production --base-href=/app/ runbox7; node src/build/post-build.js`
- `npm run policy`
- `git show --stat --oneline --check HEAD`

Note: the first production-build attempt used a shallow clone and the changelog pre-build step could not resolve its historical base commit. I fetched full history and reran the same pre-build/build/post-build sequence with explicit exit-code checks; that run passed.

## AI Disclosure

I used AI assistance to inspect the issue/source, make this small template change, and run validation. I reviewed the diff and test results before submitting.
