### PR TITLE
Keep calendar header visible while scrolling

### DIFF
--- a/src/app/calendar-app/calendar-app.component.html
+++ b/src/app/calendar-app/calendar-app.component.html
@@ -198,7 +198,7 @@
     </mat-sidenav>
 
     <mat-sidenav-content>
-        <mat-toolbar>
+        <mat-toolbar class="calendarToolbar">
             <button mat-icon-button (click)="sidemenu.toggle()">
                 <mat-icon svgIcon="menu"></mat-icon>
             </button>

--- a/src/app/calendar-app/calendar-app.component.scss
+++ b/src/app/calendar-app/calendar-app.component.scss
@@ -31,3 +31,21 @@
         padding: 16px;
     }
 }
+
+@media(min-width: 1025px) {
+    .calendarToolbar {
+        position: sticky;
+        top: 0;
+        z-index: 10;
+    }
+
+    :host ::ng-deep {
+        .cal-month-view .cal-header,
+        .cal-week-view .cal-day-headers {
+            background-color: #fff;
+            position: sticky;
+            top: 64px;
+            z-index: 9;
+        }
+    }
+}

--- a/src/app/calendar-app/calendar-app.component.spec.ts
+++ b/src/app/calendar-app/calendar-app.component.spec.ts
@@ -228,6 +228,13 @@ END:VCALENDAR
         expect(icon.style.color).toBe('pink');
     });
 
+    it('should mark the calendar toolbar for sticky positioning', () => {
+        fixture.detectChanges();
+
+        const toolbar = fixture.debugElement.nativeElement.querySelector('mat-toolbar.calendarToolbar');
+        expect(toolbar).toBeTruthy();
+    });
+
     it('should display events', () => {
         mockData['events'] = simpleEvents;
         component.calendarservice.syncCaldav(true);


### PR DESCRIPTION
Fixes #640

## Summary

- keep the calendar navigation toolbar visible while scrolling on large screens
- keep the month and week weekday header rows pinned below the toolbar
- add a focused spec for the toolbar class used by the sticky styles

## Testing

- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npx eslint src/app/calendar-app/calendar-app.component.ts src/app/calendar-app/calendar-app.component.spec.ts`
- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/calendar-app/calendar-app.component.spec.ts`
- `npm run lint -- --quiet`
- `npx ng test --watch=false --browsers=FirefoxHeadless` (`TOTAL: 246 SUCCESS`, 2 skipped; command exited 0)
- `npx ng build --configuration production --base-href=/app/ runbox7`
- `node src/build/post-build.js`
- `git diff --check`
- `npm run policy` (passes with existing historical commit-message warnings)

## AI disclosure

This contribution was developed with assistance from OpenAI Codex in the local working tree. Codex inspected the calendar component, edited the files in this PR, and ran the validation commands listed above.
