### PR TITLE
feat(calendar): add calendar print option

### DIFF
--- a/src/app/calendar-app/calendar-app.component.html
+++ b/src/app/calendar-app/calendar-app.component.html
@@ -131,6 +131,11 @@
                 <p mat-line>Settings</p>
             </mat-list-item>
 
+            <mat-list-item id="printCalendarMenuButton" mat-button (click)="printCalendar()" class="calendarMenuButton">
+                <mat-icon mat-list-icon svgIcon="printer"></mat-icon>
+                <p mat-line>Print Calendar</p>
+            </mat-list-item>
+
             <a mat-list-item target="_blank" href="https://help.runbox.com/using-a-calendar-client-with-caldav/" class="calendarMenuButton">
                 <mat-icon mat-list-icon svgIcon="sync"></mat-icon>
                 <p mat-line>CalDAV Sync Guide</p>
@@ -198,7 +203,7 @@
     </mat-sidenav>
 
     <mat-sidenav-content>
-        <mat-toolbar>
+        <mat-toolbar class="calendarToolbar">
             <button mat-icon-button (click)="sidemenu.toggle()">
                 <mat-icon svgIcon="menu"></mat-icon>
             </button>
@@ -221,6 +226,16 @@
                 </ng-container>
 
                 <ng-container *ngTemplateOutlet="viewModeButtons"></ng-container>
+
+                <button mat-icon-button
+                    id="printCalendarToolbarButton"
+                    class="calendarToolbarButton"
+                    matTooltip="Print calendar"
+                    aria-label="Print calendar"
+                    (click)="printCalendar()"
+                >
+                    <mat-icon svgIcon="printer"></mat-icon>
+                </button>
             </div>
 
             <ng-template #mobileHeader>
@@ -237,7 +252,7 @@
             </ng-template>
         </mat-toolbar>
 
-        <div [ngSwitch]="view">
+        <div class="calendarPrintArea" [ngSwitch]="view">
           <app-calendar-overview
             *ngSwitchCase="RunboxCalendarView.Overview"
             [events]="shown_events"

--- a/src/app/calendar-app/calendar-app.component.spec.ts
+++ b/src/app/calendar-app/calendar-app.component.spec.ts
@@ -213,6 +213,10 @@ END:VCALENDAR
         component = fixture.componentInstance;
     });
 
+    afterEach(() => {
+        document.body.classList.remove('calendar-printing');
+    });
+
     it('should display calendars', () => {
         expect(component).toBeTruthy();
         component.calendarservice.syncCaldav();
@@ -226,6 +230,30 @@ END:VCALENDAR
 
         const icon = calendar.querySelector('.calendarColorLabel', 'test calendar has a correct icon colour');
         expect(icon.style.color).toBe('pink');
+    });
+
+    it('should display a calendar print option', () => {
+        fixture.detectChanges();
+
+        const toolbarButton = fixture.debugElement.nativeElement.querySelector('#printCalendarToolbarButton');
+        const menuButton = fixture.debugElement.nativeElement.querySelector('#printCalendarMenuButton');
+
+        expect(toolbarButton).toBeDefined();
+        expect(menuButton).toBeDefined();
+        expect(menuButton.innerText).toContain('Print Calendar');
+    });
+
+    it('should print the calendar using print mode styles', () => {
+        const print = spyOn(window, 'print');
+
+        component.printCalendar();
+
+        expect(document.body.classList.contains('calendar-printing')).toBe(true);
+        expect(print).toHaveBeenCalled();
+
+        window.dispatchEvent(new Event('afterprint'));
+
+        expect(document.body.classList.contains('calendar-printing')).toBe(false);
     });
 
     it('should display events', () => {

--- a/src/app/calendar-app/calendar-app.component.ts
+++ b/src/app/calendar-app/calendar-app.component.ts
@@ -100,6 +100,12 @@ export class CalendarAppComponent implements OnDestroy {
     shown_events: RunboxCalendarEvent[] = [];
 
     prefGroup = DefaultPrefGroups.Global;
+    private readonly calendarPrintClass = 'calendar-printing';
+
+    private readonly clearCalendarPrintMode = (): void => {
+        document.body.classList.remove(this.calendarPrintClass);
+        window.removeEventListener('afterprint', this.clearCalendarPrintMode);
+    };
 
     constructor(
         public  calendarservice: CalendarService,
@@ -164,6 +170,7 @@ export class CalendarAppComponent implements OnDestroy {
 
     ngOnDestroy() {
         clearInterval(this.viewRefreshInterval);
+        this.clearCalendarPrintMode();
     }
 
     addEvent(on?: Date): void {
@@ -326,6 +333,13 @@ export class CalendarAppComponent implements OnDestroy {
                 this.importEvents(result, ics);
             }
         });
+    }
+
+    printCalendar(): void {
+        document.body.classList.add(this.calendarPrintClass);
+        window.removeEventListener('afterprint', this.clearCalendarPrintMode);
+        window.addEventListener('afterprint', this.clearCalendarPrintMode);
+        window.print();
     }
 
     setView(view: RunboxCalendarView): void {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1392,6 +1392,57 @@ app-calendar-app-component mat-nav-list button {
     }
 }
 
+@media print {
+    body.calendar-printing {
+        overflow: visible !important;
+
+        rmm-headertoolbar,
+        #mainMenuContainer,
+        app-calendar-app-component mat-sidenav,
+        app-calendar-app-component .mat-drawer-backdrop,
+        app-calendar-app-component .calendarToolbar,
+        app-calendar-app-component .add-new-event {
+            display: none !important;
+        }
+
+        app-calendar-app-component,
+        app-calendar-app-component mat-sidenav-container,
+        app-calendar-app-component mat-sidenav-content,
+        app-calendar-app-component .mat-drawer-content,
+        app-calendar-app-component .calendarPrintArea {
+            display: block !important;
+            position: static !important;
+            height: auto !important;
+            min-height: 0 !important;
+            overflow: visible !important;
+            transform: none !important;
+            width: 100% !important;
+        }
+
+        app-calendar-app-component mat-sidenav-container {
+            bottom: auto !important;
+            left: 0 !important;
+            margin: 0 !important;
+            right: auto !important;
+            top: 0 !important;
+        }
+
+        app-calendar-app-component mat-sidenav-content,
+        app-calendar-app-component .mat-drawer-content {
+            margin: 0 !important;
+        }
+
+        app-calendar-app-component .cal-month-view,
+        app-calendar-app-component .cal-week-view,
+        app-calendar-app-component .cal-day-view {
+            break-inside: avoid;
+            page-break-inside: avoid;
+            print-color-adjust: exact;
+            -webkit-print-color-adjust: exact;
+        }
+    }
+}
+
 .calendarTitle {
     font-size: 20px !important;
     font-weight: bold;


### PR DESCRIPTION
## Summary

- add Print Calendar actions to the calendar side menu and desktop toolbar
- print the calendar view with a scoped print mode that hides the Runbox header, calendar toolbar, side menu, and add-event controls
- add component specs for the print controls and print-mode cleanup

## Tests

- `npm ci`
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npx eslint src/app/calendar-app/calendar-app.component.ts src/app/calendar-app/calendar-app.component.spec.ts`
- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/calendar-app/calendar-app.component.spec.ts`
- `npm run lint -- --quiet`
- `npx ng test --watch=false --browsers=FirefoxHeadless`
- `node src/build/pre-build.js`
- `npx ng build --configuration production --base-href=/app/ runbox7`
- `node src/build/post-build.js`
- `git diff --check`
- `git diff --cached --check`
- `npm run policy`

`npm run policy` exits successfully; it still prints historical upstream commit-message warnings unrelated to this PR.

## AI disclosure

I used OpenAI Codex (GPT-5) to help implement and test this PR. The AI-assisted work was in the calendar component template/class/spec and the print-specific global stylesheet rules.

Closes #1057
