### PR TITLE
fix(mail): open next message after delete

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -232,6 +232,7 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
     this.messageActionsHandler.searchService = searchService;
     this.messageActionsHandler.messageListService = messagelistservice;
     this.messageActionsHandler.snackBar = snackBar;
+    this.messageActionsHandler.deleteMessageHandler = (messageIds: number[]) => this.deleteMessages(messageIds);
 
     this.renderer.listen(window, 'keydown', (evt: KeyboardEvent) => {
       if (this.singlemailviewer.messageId) {
@@ -809,14 +810,22 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
 
   // Delete selected messages in current canvastable view
   // If looking at Trash, this will be "delete permanently"
-  public deleteMessages() {
-    const messageIds = this.canvastable.rows.selectedMessageIds();
+  public deleteMessages(messageIds = this.canvastable.rows.selectedMessageIds()) {
+    if (messageIds.length === 0) {
+      return;
+    }
+
+    const currentMessageId = this.singlemailviewer?.messageId;
+    const deletingOpenMessage = !!currentMessageId && messageIds.includes(currentMessageId);
+    const nextMessageId = deletingOpenMessage
+      ? this.canvastable.rows.getMessageIdAfterRemoving(messageIds, currentMessageId)
+      : null;
 
     this.messageActionsHandler.updateMessages({
       messageIds: messageIds,
       updateLocal: (msgIds: number[]) => {
         // remove from message display
-        this.canvastable.rows.removeMessages(messageIds);
+        this.canvastable.rows.removeMessages(msgIds);
         this.searchService.deleteMessages(msgIds);
         if (this.selectedFolder === this.messagelistservice.trashFolderName) {
           this.messagelistservice.deleteTrashMessages(msgIds);
@@ -824,8 +833,12 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
           this.messagelistservice.moveMessages(msgIds, this.messagelistservice.trashFolderName);
         }
         this.clearSelection();
-        if (this.singlemailviewer && this.singlemailviewer.messageId && msgIds.includes(this.singlemailviewer.messageId)) {
-          this.singlemailviewer.close();
+        if (deletingOpenMessage) {
+          if (this.keepMessagePaneOpen && nextMessageId) {
+            this.selectRowByMessageId(nextMessageId);
+          } else if (this.singlemailviewer) {
+            this.singlemailviewer.close();
+          }
         }
       },
       updateRemote: (msgIds: number[]) => this.rmmapi.deleteMessages(msgIds)

--- a/src/app/canvastable/canvastable.spec.ts
+++ b/src/app/canvastable/canvastable.spec.ts
@@ -73,4 +73,30 @@ describe('canvastable', () => {
         expect(fixture.componentInstance.canvastable.floatingTooltip).toBeTruthy();
         expect(fixture.componentInstance.canvastable.columnOverlay).toBeTruthy();
     });
+
+    describe('message delete navigation', () => {
+        it('returns the next visible message after the opened message is removed', () => {
+            const rows = new MessageList([{ id: 10 }, { id: 20 }, { id: 30 }]);
+
+            expect(rows.getMessageIdAfterRemoving([20], 20)).toBe(30);
+        });
+
+        it('skips other removed messages when finding the next message', () => {
+            const rows = new MessageList([{ id: 10 }, { id: 20 }, { id: 30 }, { id: 40 }]);
+
+            expect(rows.getMessageIdAfterRemoving([20, 30], 20)).toBe(40);
+        });
+
+        it('falls back to the previous visible message at the end of the list', () => {
+            const rows = new MessageList([{ id: 10 }, { id: 20 }, { id: 30 }]);
+
+            expect(rows.getMessageIdAfterRemoving([30], 30)).toBe(20);
+        });
+
+        it('returns null when no visible messages remain', () => {
+            const rows = new MessageList([{ id: 10 }, { id: 20 }]);
+
+            expect(rows.getMessageIdAfterRemoving([10, 20], 10)).toBeNull();
+        });
+    });
 });

--- a/src/app/common/messagedisplay.ts
+++ b/src/app/common/messagedisplay.ts
@@ -95,6 +95,34 @@ export abstract class MessageDisplay {
     });
   }
 
+  public getMessageIdAfterRemoving(messageIds: number[], currentMessageId: number): number {
+    if (!currentMessageId) {
+      return null;
+    }
+
+    const currentRowIndex = this.findRowByMessageId(currentMessageId);
+    if (currentRowIndex < 0) {
+      return null;
+    }
+
+    const removedMessageIds = new Set(messageIds);
+    for (let index = currentRowIndex + 1; index < this.rowCount(); index++) {
+      const messageId = this.getRowMessageId(index);
+      if (!removedMessageIds.has(messageId)) {
+        return messageId;
+      }
+    }
+
+    for (let index = currentRowIndex - 1; index >= 0; index--) {
+      const messageId = this.getRowMessageId(index);
+      if (!removedMessageIds.has(messageId)) {
+        return messageId;
+      }
+    }
+
+    return null;
+  }
+
   public removeMessages(messageIds: number[]) {
     const filteredRows = [];
     this.rows.forEach((value, index) => {

--- a/src/app/mailviewer/rmm7messageactions.ts
+++ b/src/app/mailviewer/rmm7messageactions.ts
@@ -38,6 +38,7 @@ export class RMM7MessageActions implements MessageActions {
     messageListService: MessageListService;
     draftDeskService: DraftDeskService;
     rmmapi: RunboxWebmailAPI;
+    deleteMessageHandler?: (messageIds: number[]) => void;
 
     public updateMessages(args: { messageIds: number[],
                                   updateLocal: (messageIds: number[]) => void,
@@ -94,6 +95,11 @@ export class RMM7MessageActions implements MessageActions {
     }
 
     public deleteMessage() {
+        if (this.deleteMessageHandler) {
+            this.deleteMessageHandler([this.mailViewerComponent.messageId]);
+            return;
+        }
+
         this.updateMessages({
             messageIds: [this.mailViewerComponent.messageId],
             updateLocal: (msgIds: number[]) => {


### PR DESCRIPTION
Fixes #708.

## Summary
- Route the single-message delete toolbar action through the same list-aware delete flow used by selected message deletes.
- When the deleted message is currently open and "Keep preview pane open" is enabled, select and open the next visible message after the removed message IDs, falling back to the previous visible message at the end of the list.
- Keep the existing close-the-viewer behavior when the preview pane is not configured to stay open or no visible messages remain.
- Add focused coverage for the row helper that chooses the next surviving message.

## Testing
- `npm ci`
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npx eslint src/app/app.component.ts src/app/common/messagedisplay.ts src/app/mailviewer/rmm7messageactions.ts src/app/canvastable/canvastable.spec.ts`
- `npx ng test --include=src/app/canvastable/canvastable.spec.ts --watch=false --browsers=FirefoxHeadless` (`TOTAL: 5 SUCCESS`; Firefox printed a post-success disconnect line but the command exited 0)
- `npm run lint -- --quiet`
- `npm run policy`
- `npx ng test --watch=false --browsers=FirefoxHeadless` (`TOTAL: 249 SUCCESS`, `2 skipped`)
- `node src/build/pre-build.js && npx ng build --configuration production --base-href=/app/ runbox7 && node src/build/post-build.js` (build hash `9f88e81dcf7769f9`, with existing Angular/CommonJS warnings)
- `git diff --check`
- `git diff HEAD~1..HEAD --check`
- `git show --stat --oneline --check HEAD`

## AI disclosure
Codex assisted with issue triage, implementation, tests, and validation for `src/app/app.component.ts`, `src/app/common/messagedisplay.ts`, `src/app/mailviewer/rmm7messageactions.ts`, and `src/app/canvastable/canvastable.spec.ts`.
