### PR TITLE
Add Libravatar contact avatar lookup

### DIFF
--- a/src/app/contacts-app/contacts-settings.component.html
+++ b/src/app/contacts-app/contacts-settings.component.html
@@ -40,7 +40,8 @@
                 (change)="saveAvatarSource()"
             >
                 <mat-radio-button [value]="AvatarSource.REMOTE">
-                    Load from external services (like <a href="https://gravatar.com">gravatar.com</a>)
+                    Load from external services (like <a href="https://gravatar.com">gravatar.com</a>
+                    and <a href="https://www.libravatar.org">libravatar.org</a>)
                 </mat-radio-button>
                 <mat-radio-button [value]="AvatarSource.LOCAL">
                     Only show pictures stored locally

--- a/src/app/contacts-app/contacts.service.spec.ts
+++ b/src/app/contacts-app/contacts.service.spec.ts
@@ -59,15 +59,22 @@ describe('ContactsService', () => {
   let storage: StorageService;
   const prefService = new MockPrefService() as unknown as PreferencesService;
   let sut: ContactsService;
+  let fetchSpy: jasmine.Spy;
 
   beforeEach(async () => {
+    fetchSpy = spyOn(window, 'fetch').and.callFake((url: RequestInfo): Promise<Response> => {
+      const avatarUrl = url.toString();
+      const responseOk = (avatarUrl.includes('gravatar.com') && avatarUrl.includes('d770e753373e7b886680847fd773396d'))
+        || (avatarUrl.includes('libravatar.org') && avatarUrl.includes('291167d1fdc699e76ee26f977b87a906'));
+      return Promise.resolve({ ok: responseOk } as Response);
+    });
     rmmapi = new MockRMMAPI();
     storage = new StorageService(rmmapi as unknown as RunboxWebmailAPI);
     sut = new ContactsService(rmmapi as unknown as RunboxWebmailAPI, prefService, storage);
   });
 
   describe('Avatar lookup', () => {
-    it('should look up remote avatars (gravatar)', (done) => {
+    it('should look up remote avatars', (done) => {
       prefService.set(prefService.prefGroup, 'avatarSource', 'remote' );
 
       prefService.preferences.pipe(take(1)).subscribe(async _ => {
@@ -75,12 +82,22 @@ describe('ContactsService', () => {
         let avatarUrl = await sut.lookupAvatar('test+gravatar@runbox.com');
         expect(avatarUrl).toMatch(/gravatar/);
 
+        avatarUrl = await sut.lookupAvatar('test+libravatar@runbox.com');
+        expect(avatarUrl).toMatch(/libravatar/);
+
         // local avatar wins over gravatar
         avatarUrl = await sut.lookupAvatar('test@runbox.com');
         expect(avatarUrl).toMatch(/test.url/);
 
-        avatarUrl = await sut.lookupAvatar('test+no+gravatar@runbox.com');
+        avatarUrl = await sut.lookupAvatar('test+no+avatar@runbox.com');
         expect(avatarUrl).toBeFalsy();
+        expect(fetchSpy.calls.allArgs().map(args => args[0].toString())).toEqual([
+          jasmine.stringMatching(/gravatar\.com/),
+          jasmine.stringMatching(/gravatar\.com/),
+          jasmine.stringMatching(/libravatar\.org/),
+          jasmine.stringMatching(/gravatar\.com/),
+          jasmine.stringMatching(/libravatar\.org/),
+        ]);
 
         done();
       });

--- a/src/app/contacts-app/contacts.service.ts
+++ b/src/app/contacts-app/contacts.service.ts
@@ -45,7 +45,7 @@ interface AvatarCacheEntry {
 
 /* This caches avatar URLs, or `null`s in their absence.
  * Mostly useful for avatars not available in Contacts,
- * and loaded from external services like gravatar.
+ * and loaded from external services like Gravatar and Libravatar.
  *
  * Putting (gr)avatar URLs in <img src's> will cache them nicely,
  * except if they 404d last time around
@@ -349,14 +349,26 @@ export class ContactsService implements OnDestroy {
             return Promise.resolve(null);
         }
 
-        const hash = Md5.hashStr(email.toLowerCase());
-        const url = 'https://gravatar.com/avatar/' + hash + '?d=404';
+        const resolvedUrl = await this.lookupRemoteAvatar(email);
+        this.avatarCache.add(email, resolvedUrl);
+        return resolvedUrl;
+    }
 
-        return fetch(url).then(response => {
-            const resolvedUrl = response.ok ? url : null;
-            this.avatarCache.add(email, resolvedUrl);
-            return Promise.resolve(resolvedUrl);
-        });
+    private async lookupRemoteAvatar(email: string): Promise<string> {
+        const hash = Md5.hashStr(email.toLowerCase());
+        const urls = [
+            'https://gravatar.com/avatar/' + hash + '?d=404',
+            'https://seccdn.libravatar.org/avatar/' + hash + '?d=404',
+        ];
+
+        for (const url of urls) {
+            const response = await fetch(url);
+            if (response.ok) {
+                return url;
+            }
+        }
+
+        return null;
     }
 
     lookupContact(email: string): Promise<Contact> {


### PR DESCRIPTION
## Summary

- add Libravatar as a fallback after Gravatar for remote contact avatar lookups
- keep local contact photos preferred, and cache a missing avatar only after both remote services miss
- update the Contacts avatar setting text and cover Gravatar, Libravatar, and no-avatar lookup behavior in the Contacts service spec

## Testing

- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npm run lint -- --quiet`
- `npx ng test --include src/app/contacts-app/contacts.service.spec.ts --watch=false --browsers=FirefoxHeadless`
- `npm run policy` (passes; prints existing historical upstream commit-message warnings)
- `SKIP_CHANGELOG=1 node src/build/pre-build.js`
- `npx ng build runbox7 --configuration production --base-href=/app/`
- `node src/build/post-build.js`

## AI disclosure

I used OpenAI Codex to implement and test this change in:

- `src/app/contacts-app/contacts.service.ts`
- `src/app/contacts-app/contacts.service.spec.ts`
- `src/app/contacts-app/contacts-settings.component.html`

I reviewed the generated diff and ran the validation steps above.

Fixes #1177
