### PR TITLE
Add event action to week and day calendar views

### DIFF
--- a/src/app/calendar-app/calendar-app.component.html
+++ b/src/app/calendar-app/calendar-app.component.html
@@ -97,6 +97,18 @@
     </span>
 </ng-template>
 
+<ng-template #addEventInViewButton>
+    <button mat-icon-button
+        *ngIf="view === RunboxCalendarView.Week || view === RunboxCalendarView.Day"
+        id="addEventInViewButton"
+        aria-label="Add event"
+        matTooltip="Add event"
+        (click)="addEvent(viewDate)"
+    >
+        <mat-icon svgIcon="plus-circle"></mat-icon>
+    </button>
+</ng-template>
+
 <mat-sidenav-container autosize>
     <mat-sidenav #sidemenu
         [opened]="sideMenuOpened"
@@ -220,6 +232,9 @@
                 <ng-container *ngTemplateOutlet="calendarTitle">
                 </ng-container>
 
+                <ng-container *ngTemplateOutlet="addEventInViewButton">
+                </ng-container>
+
                 <ng-container *ngTemplateOutlet="viewModeButtons"></ng-container>
             </div>
 
@@ -232,6 +247,9 @@
                     </ng-container>
 
                     <ng-container *ngTemplateOutlet="nextPeriodButton">
+                    </ng-container>
+
+                    <ng-container *ngTemplateOutlet="addEventInViewButton">
                     </ng-container>
                 </div>
             </ng-template>

--- a/src/app/calendar-app/calendar-app.component.spec.ts
+++ b/src/app/calendar-app/calendar-app.component.spec.ts
@@ -265,6 +265,30 @@ END:VCALENDAR
         expect(events.length).toBe(1, 'events are back on the screen');
     });
 
+    it('should show an add event action in week and day views', () => {
+        spyOn(component, 'addEvent');
+        fixture.detectChanges();
+
+        expect(fixture.debugElement.nativeElement.querySelector('button#addEventInViewButton'))
+            .toBeFalsy('month view already has per-day add event buttons');
+
+        component.setView(component.RunboxCalendarView.Week);
+        fixture.detectChanges();
+        let addEventButton = fixture.debugElement.nativeElement.querySelector('button#addEventInViewButton');
+        expect(addEventButton).toBeTruthy('week view has an add event action');
+
+        addEventButton.click();
+        expect(component.addEvent).toHaveBeenCalledOnceWith(component.viewDate);
+
+        component.setView(component.RunboxCalendarView.Day);
+        fixture.detectChanges();
+        addEventButton = fixture.debugElement.nativeElement.querySelector('button#addEventInViewButton');
+        expect(addEventButton).toBeTruthy('day view has an add event action');
+
+        addEventButton.click();
+        expect(component.addEvent).toHaveBeenCalledWith(component.viewDate);
+    });
+
     it('should display recurring events', () => {
         mockData['events'] = recurringEvents;
         component.calendarservice.syncCaldav(true);

--- a/src/app/calendar-app/calendar-app.component.ts
+++ b/src/app/calendar-app/calendar-app.component.ts
@@ -330,29 +330,31 @@ export class CalendarAppComponent implements OnDestroy {
 
     setView(view: RunboxCalendarView): void {
         this.view = view;
+
+        switch (this.view) {
+            case RunboxCalendarView.Overview: {
+                this.mwlView = null;
+                break;
+            }
+            case RunboxCalendarView.Month: {
+                this.mwlView = CalendarView.Month;
+                break;
+            }
+            case RunboxCalendarView.Week: {
+                this.mwlView = CalendarView.Week;
+                break;
+            }
+            case RunboxCalendarView.Day: {
+                this.mwlView = CalendarView.Day;
+                break;
+            }
+        }
+
         if (this.settings.lastUsedView !== view) {
             this.settings.lastUsedView = this.view;
             this.preferenceService.set(this.prefGroup, 'calendarSettings', this.settings);
-
-            switch (this.view) {
-                case RunboxCalendarView.Overview: {
-                    this.mwlView = null;
-                    break;
-                }
-                case RunboxCalendarView.Month: {
-                    this.mwlView = CalendarView.Month;
-                    break;
-                }
-                case RunboxCalendarView.Week: {
-                    this.mwlView = CalendarView.Week;
-                    break;
-                }
-                case RunboxCalendarView.Day: {
-                    this.mwlView = CalendarView.Day;
-                    break;
-                }
-            }
         }
+        this.cdr.markForCheck();
     }
 
     showAddCalendarDialog(): void {


### PR DESCRIPTION
Fixes #1108

## Summary

- adds an Add event icon button to the calendar toolbar in week and day views
- keeps month view unchanged, where each visible day already has its own add button
- keeps `mwlView` synchronized whenever `setView()` runs, even when the selected view already matches the stored preference

## Tests

- `npx ng test --include src/app/calendar-app/calendar-app.component.spec.ts --watch=false --browsers=FirefoxHeadless`
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npm run lint -- --quiet`
- `npm run policy`
- `SKIP_CHANGELOG=1 node src/build/pre-build.js && npx ng build runbox7 --configuration production --base-href=/app/ && node src/build/post-build.js`

## AI disclosure

AI assistance used: OpenAI Codex in the local development workspace. The agent was used for code edits, tests, validation commands, and PR text preparation.
