### PR TITLE
Preserve calendar event duration when start changes

### DIFF
--- a/src/app/calendar-app/event-editor-dialog.component.spec.ts
+++ b/src/app/calendar-app/event-editor-dialog.component.spec.ts
@@ -1,0 +1,59 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { CalendarSettings } from './calendar-settings';
+import { EventEditorDialogComponent } from './event-editor-dialog.component';
+import { RunboxCalendar } from './runbox-calendar';
+import { RunboxCalendarEvent } from './runbox-calendar-event';
+
+describe('EventEditorDialogComponent', () => {
+    function createComponent(): EventEditorDialogComponent {
+        return new EventEditorDialogComponent(
+            {} as any,
+            { close: jasmine.createSpy('close') } as any,
+            {
+                calendars: [new RunboxCalendar({ id: 'test-calendar', displayname: 'Test Calendar' })],
+                event: RunboxCalendarEvent.newEmpty(),
+                is_new: true,
+                settings: new CalendarSettings({}),
+                start: new Date(2026, 0, 10),
+            }
+        );
+    }
+
+    it('should shift the end time by the same amount when the start time changes', () => {
+        const component = createComponent();
+        component.event_start = new Date(2026, 0, 10, 8, 0);
+        component.event_end = new Date(2026, 0, 10, 9, 30);
+
+        component.updateStart(new Date(2026, 0, 10, 7, 0));
+
+        expect(component.event_end).toEqual(new Date(2026, 0, 10, 8, 30));
+    });
+
+    it('should keep the event duration when the start date changes', () => {
+        const component = createComponent();
+        component.event_start = new Date(2026, 0, 10, 8, 0);
+        component.event_end = new Date(2026, 0, 10, 9, 30);
+
+        component.updateStart(new Date(2026, 0, 11, 8, 0));
+
+        expect(component.event_end).toEqual(new Date(2026, 0, 11, 9, 30));
+    });
+});

--- a/src/app/calendar-app/event-editor-dialog.component.ts
+++ b/src/app/calendar-app/event-editor-dialog.component.ts
@@ -317,6 +317,11 @@ export class EventEditorDialogComponent {
     // NB: ngModelChange has to be before ngModel (in template) to read
     // the old value
     public updateStart(value: Date) {
+        if (this.event_start && this.event_end) {
+            const startDeltaMs = value.getTime() - this.event_start.getTime();
+            this.event_end = new Date(this.event_end.getTime() + startDeltaMs);
+        }
+
         // Do this always, in case we fiddle with dates, then
         // set event_recurs:
         if (!this.event_recurs) {


### PR DESCRIPTION
Fixes #846

## Summary

- add regression coverage for preserving an event's duration when the start date/time changes
- shift the current end date/time by the same delta as the edited start value in the event editor

## Tests

- `npx ng test --include src/app/calendar-app/event-editor-dialog.component.spec.ts --watch=false --browsers=FirefoxHeadless` on the test-only commit before the fix: fails with `2 FAILED`
- `npx ng test --include src/app/calendar-app/event-editor-dialog.component.spec.ts --watch=false --browsers=FirefoxHeadless`: `2 SUCCESS`
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npm run lint -- --quiet`
- `npm run policy` (new commits pass; the script still reports pre-existing upstream commit-message warnings)
- `$env:SKIP_CHANGELOG='1'; node src/build/pre-build.js`
- `npx ng build runbox7 --configuration production --base-href=/app/`
- `node src/build/post-build.js`

## AI Disclosure

AI assistance used: OpenAI Codex in the local development workspace. The agent was used for code edits, tests, validation commands, commit splitting, and PR text preparation.
