### PR TITLE
build(test): configure Karma browsers from env

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,6 +1,17 @@
 // Karma configuration file, see link for more information
 // https://karma-runner.github.io/1.0/config/configuration-file.html
 
+const DEFAULT_BROWSERS = ['Firefox'];
+
+function configuredBrowsers(envValue) {
+  if (!envValue) {
+    return DEFAULT_BROWSERS;
+  }
+
+  const browsers = envValue.split(',').map((browser) => browser.trim()).filter(Boolean);
+  return browsers.length ? browsers : DEFAULT_BROWSERS;
+}
+
 module.exports = function (config) {
   config.set({
     basePath: '',
@@ -27,7 +38,9 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['Firefox'],
+    browsers: configuredBrowsers(process.env.KARMA_BROWSERS),
     singleRun: false
   });
 };
+
+module.exports.configuredBrowsers = configuredBrowsers;

--- a/policy-tests/check-karma-browsers.js
+++ b/policy-tests/check-karma-browsers.js
@@ -1,0 +1,14 @@
+const assert = require('assert');
+const karmaConfig = require('../karma.conf.js');
+
+assert.deepStrictEqual(karmaConfig.configuredBrowsers(undefined), ['Firefox']);
+assert.deepStrictEqual(karmaConfig.configuredBrowsers(''), ['Firefox']);
+assert.deepStrictEqual(karmaConfig.configuredBrowsers('FirefoxHeadless'), ['FirefoxHeadless']);
+assert.deepStrictEqual(
+  karmaConfig.configuredBrowsers('ChromeHeadless, FirefoxHeadless'),
+  ['ChromeHeadless', 'FirefoxHeadless']
+);
+assert.deepStrictEqual(
+  karmaConfig.configuredBrowsers(' , FirefoxHeadless ,, '),
+  ['FirefoxHeadless']
+);

--- a/policy-tests/run-all.js
+++ b/policy-tests/run-all.js
@@ -1,2 +1,3 @@
 require('./check-licenses.js');
 require('./check-commit-log.js');
+require('./check-karma-browsers.js');


### PR DESCRIPTION
## Summary

- Closes #551 by letting Karma browser launchers be selected with `KARMA_BROWSERS`.
- Keeps the current Firefox default when the variable is unset or empty.
- Parses comma-separated browser lists such as `ChromeHeadless, FirefoxHeadless`.
- Adds policy-test coverage for default, empty, single-browser, multi-browser, and trimmed values.

## Validation

- Red baseline before the implementation commit: `npm run policy` failed with `TypeError: karmaConfig.configuredBrowsers is not a function` from `policy-tests/check-karma-browsers.js`.
- `npm run policy` (passes; output still includes existing historical commit-message warnings)
- `$env:KARMA_BROWSERS='FirefoxHeadless'; npx ng test runbox7 --watch=false --include=src/app/storage.service.spec.ts` (passes, logs `Launching browsers FirefoxHeadless`, `TOTAL: 11 SUCCESS`)
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npm run lint -- --quiet`
- `git diff --check origin/master...HEAD`
- `$env:SKIP_CHANGELOG='1'; node src/build/pre-build.js; npx ng build --configuration production --base-href=/app/ runbox7; node src/build/post-build.js` (passes, build hash `a28fc9fd44996baa`)

## AI disclosure

This PR was prepared with OpenAI Codex assistance. I used Codex to inspect the issue and current Karma setup, draft the focused policy test and implementation, and run the validation commands listed above.
