### PR TITLE
fix(calendar): make mobile calendar title fit

### DIFF
--- a/src/app/calendar-app/calendar-app.component.html
+++ b/src/app/calendar-app/calendar-app.component.html
@@ -93,7 +93,12 @@
 
 <ng-template #calendarTitle>
     <span class="calendarTitle">
-        {{ mwlView ? (viewDate | calendarDate:(mwlView + 'ViewTitle'):'en') : 'Overview' }}
+        <ng-container *ngIf="mobileCalendarTitle as title; else defaultCalendarTitle">
+            {{ title }}
+        </ng-container>
+        <ng-template #defaultCalendarTitle>
+            {{ mwlView ? (viewDate | calendarDate:(mwlView + 'ViewTitle'):'en') : 'Overview' }}
+        </ng-template>
     </span>
 </ng-template>
 
@@ -224,7 +229,7 @@
             </div>
 
             <ng-template #mobileHeader>
-                <div style="display: flex; justify-content: center; align-items: center; width: 100%;">
+                <div class="calendarMobileHeader">
                     <ng-container *ngTemplateOutlet="previousPeriodButton">
                     </ng-container>
 

--- a/src/app/calendar-app/calendar-app.component.scss
+++ b/src/app/calendar-app/calendar-app.component.scss
@@ -18,6 +18,33 @@
     }
 }
 
+.calendarTitle {
+    margin: 0 12px;
+}
+
+.calendarMobileHeader {
+    align-items: center;
+    display: flex;
+    flex: 1 1 auto;
+    justify-content: center;
+    min-width: 0;
+
+    .calendarTitle {
+        flex: 1 1 auto;
+        min-width: 0;
+        overflow: hidden;
+        text-align: center;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .calendarToolbarButton {
+        flex: 0 0 auto;
+        min-width: 40px;
+        padding: 0 8px;
+    }
+}
+
 .updateInfo {
     &:hover {
         background-color: #fff;

--- a/src/app/calendar-app/calendar-app.component.spec.ts
+++ b/src/app/calendar-app/calendar-app.component.spec.ts
@@ -40,6 +40,7 @@ import { MatIcon } from '@angular/material/icon';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import moment from 'moment';
 import ICAL from 'ical.js';
+import { RunboxCalendarView } from './runbox-calendar-view';
 
 describe('CalendarAppComponent', () => {
     let component: CalendarAppComponent;
@@ -226,6 +227,19 @@ END:VCALENDAR
 
         const icon = calendar.querySelector('.calendarColorLabel', 'test calendar has a correct icon colour');
         expect(icon.style.color).toBe('pink');
+    });
+
+    it('should use a short title in mobile day view', () => {
+        component.mobileQuery.matches = true;
+        component.viewDate = new Date(2020, 4, 23);
+        component.setView(RunboxCalendarView.Day);
+
+        fixture.detectChanges();
+
+        const title = fixture.debugElement.nativeElement.querySelector('.calendarTitle');
+
+        expect(component.mobileCalendarTitle).toBe('Sat, May 23, 2020');
+        expect(title.innerText.trim()).toBe('Sat, May 23, 2020');
     });
 
     it('should display events', () => {

--- a/src/app/calendar-app/calendar-app.component.ts
+++ b/src/app/calendar-app/calendar-app.component.ts
@@ -24,6 +24,7 @@ import {
     OnDestroy,
     ViewChild,
 } from '@angular/core';
+import { formatDate } from '@angular/common';
 
 import { ActivatedRoute, Router } from '@angular/router';
 
@@ -164,6 +165,19 @@ export class CalendarAppComponent implements OnDestroy {
 
     ngOnDestroy() {
         clearInterval(this.viewRefreshInterval);
+    }
+
+    get mobileCalendarTitle(): string | null {
+        if (!this.mobileQuery.matches || this.view !== RunboxCalendarView.Day) {
+            return null;
+        }
+
+        const currentYear = new Date().getFullYear();
+        const titleFormat = this.viewDate.getFullYear() === currentYear
+            ? 'EEE, MMM d'
+            : 'EEE, MMM d, y';
+
+        return formatDate(this.viewDate, titleFormat, 'en');
     }
 
     addEvent(on?: Date): void {


### PR DESCRIPTION
## Summary

- Use a compact mobile day-view title such as `Sat, May 23, 2020` instead of the full weekday title.
- Replace the mobile calendar toolbar's `width: 100%` inline header with a flex-safe container so the menu button, previous/next buttons, and title can share the viewport width.
- Constrain the mobile toolbar title with nowrap/ellipsis so longer titles cannot push controls off-screen.
- Add a regression spec for the mobile day-view title.

Closes #575

## Testing

- `npm ci`
- Pre-fix focused spec failed as expected with `TS2339: Property 'mobileCalendarTitle' does not exist on type 'CalendarAppComponent'`.
- `npx ng test runbox7 --watch=false --browsers=FirefoxHeadless --include=src/app/calendar-app/calendar-app.component.spec.ts`
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npm run lint -- --quiet`
- `npm run policy` (branch commits OK; existing historical upstream commit-message warnings remain)
- `git diff --check origin/master...HEAD`
- `git show --check --stat --oneline HEAD`
- PowerShell-native production sequence: `SKIP_CHANGELOG=1`, `node src/build/pre-build.js`, `npx ng build --configuration production --base-href=/app/ runbox7`, `node src/build/post-build.js` (existing Angular/CommonJS/theming warnings only; hash `a0cd623a2e43ef64`)

## AI Disclosure

I used OpenAI Codex to inspect the issue and current source, make the code/test changes, and run the validation commands listed above.
