### PR TITLE
fix(contacts): normalize custom field type labels

### DIFF
--- a/src/app/contacts-app/contact.spec.ts
+++ b/src/app/contacts-app/contact.spec.ts
@@ -253,6 +253,41 @@ END:VCARD`);
         expect(sut.addresses.length).toBe(2);
     });
 
+    it('can display custom x-prefixed field types from Android vcards', () => {
+        const sut = Contact.fromVcard(null, `BEGIN:VCARD
+VERSION:3.0
+PRODID:-//Sabre//Sabre VObject 4.2.0//EN
+UID:f205d9d6-f5cb-4625-be9f-54557a6c3bf0
+FN:Name Surname
+N:Surname;Name;;;
+GROUP1.TEL;TYPE=x-starý,PREF:+1234567890
+TEL;TYPE=cell:+0987654321
+GROUP1.X-ABLABEL:Starý
+GROUP2.X-ABLABEL:Obsolete
+EMAIL;TYPE=PREF:name@domain.com
+GROUP2.EMAIL;TYPE=x-obsolete:name@anotherdomain.com
+END:VCARD`);
+
+        expect(sut.phones[0].types).toEqual(['starý', 'pref']);
+        expect(sut.phones[1].types).toEqual(['cell']);
+        expect(sut.emails[0].types).toEqual(['pref']);
+        expect(sut.emails[1].types).toEqual(['obsolete']);
+    });
+
+    it('can save custom field types with x-prefixes in vcards', () => {
+        const sut = new Contact({});
+
+        sut.phones = [
+            { types: ['cell'], value: '+0987654321' },
+            { types: ['starý'], value: '+1234567890' },
+        ];
+
+        const vcard = sut.vcard();
+
+        expect(vcard).toContain('TEL;TYPE=cell:+0987654321');
+        expect(vcard).toContain('TEL;TYPE=x-starý:+1234567890');
+    });
+
     it('contact with exceptionally empty name shows up as email', () => {
         /* eslint-disable no-trailing-spaces */
         const sut = Contact.fromVcard(null, `BEGIN:VCARD

--- a/src/app/contacts-app/contact.ts
+++ b/src/app/contacts-app/contact.ts
@@ -140,6 +140,52 @@ export class Contact {
     component: ICAL.Component;
     url:       string;
 
+    private static readonly standardPropertyTypes = new Set([
+        'acquaintance',
+        'agent',
+        'bbs',
+        'car',
+        'cell',
+        'child',
+        'co-resident',
+        'co-worker',
+        'colleague',
+        'contact',
+        'crush',
+        'date',
+        'dom',
+        'emergency',
+        'fax',
+        'friend',
+        'home',
+        'internet',
+        'intl',
+        'isdn',
+        'kin',
+        'me',
+        'met',
+        'modem',
+        'msg',
+        'muse',
+        'neighbor',
+        'pager',
+        'parcel',
+        'parent',
+        'pcs',
+        'personal',
+        'postal',
+        'pref',
+        'sibling',
+        'spouse',
+        'sweetheart',
+        'text',
+        'textphone',
+        'video',
+        'voice',
+        'work',
+        'x400',
+    ]);
+
     private static preprocessVcf(vcf: string): string {
         // since ical.js can't parse these
         // (not until https://github.com/mozilla-comm/ical.js/pull/442/files is merged anyway)
@@ -148,6 +194,18 @@ export class Contact {
         // `group = 1*(ALPHA / DIGIT / "-")`, as in https://tools.ietf.org/html/rfc6350#section-3.3
         const group = /^[a-z0-9\-]+\./gmi;
         return vcf.replace(group, '');
+    }
+
+    private static displayPropertyType(type: string): string {
+        return type.toLowerCase().replace(/^x-/, '');
+    }
+
+    private static serializePropertyType(type: string): string {
+        const lowerType = type.toLowerCase();
+        if (lowerType.startsWith('x-') || Contact.standardPropertyTypes.has(lowerType)) {
+            return lowerType;
+        }
+        return 'x-' + lowerType;
     }
 
     // may throw ICAL.ParserError if input is not a valid vcf
@@ -233,7 +291,7 @@ export class Contact {
         for (const e of values) {
             const prop = this.component.addPropertyWithValue(name, e.value);
             if (e.types.length > 0) {
-                prop.setParameter('type', e.types);
+                prop.setParameter('type', e.types.map(Contact.serializePropertyType));
             }
         }
     }
@@ -245,7 +303,7 @@ export class Contact {
         } else if (typeof types === 'string') {
             types = [types];
         }
-        return types.map(t => t.toLowerCase());
+        return types.map(Contact.displayPropertyType);
     }
 
     private normalizeStringProperty(p: ICAL.Property): StringValueWithTypes {
@@ -433,7 +491,7 @@ export class Contact {
         for (const e of values) {
             const prop = this.component.addPropertyWithValue('adr', e.value.values);
             if (e.types.length > 0) {
-                prop.setParameter('type', e.types);
+                prop.setParameter('type', e.types.map(Contact.serializePropertyType));
             }
         }
     }


### PR DESCRIPTION
## Summary

Fixes #244.

This updates the contact model so custom vCard field types stored as `TYPE=x-...` are shown to users without the transport-only `x-` prefix, then saved back with the prefix when they are not known vCard type values.

The Android-style vCard sample from the issue now parses `TYPE=x-starý` as the editable label `starý`, preserves standard labels such as `pref` and `cell`, and serializes an edited custom label back as `TYPE=x-starý`.

## Validation

- `npm ci`
- Red check before the fix: `npx ng test runbox7 --watch=false --browsers=FirefoxHeadless --include=src/app/contacts-app/contact.spec.ts` failed with `2 FAILED, 23 SUCCESS` because the model exposed `x-starý`/`x-obsolete` and saved `TYPE=starý`
- `npx ng test runbox7 --watch=false --browsers=FirefoxHeadless --include=src/app/contacts-app/contact.spec.ts` passed with `25 SUCCESS`
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npm run lint -- --quiet`
- `npm run policy` passed for the current commits; it still reports existing historical commit-message warnings
- `git diff --check origin/master...HEAD`
- `git show --check --stat --oneline HEAD`
- `npx ng test runbox7 --watch=false --browsers=FirefoxHeadless` passed with `247 SUCCESS` and 2 existing skipped tests
- `SKIP_CHANGELOG=1; node src/build/pre-build.js; npx ng build --configuration production --base-href=/app/ runbox7; node src/build/post-build.js` passed with existing Angular/CommonJS/theming warnings; build hash `391ab3d473a443c7`

## AI Disclosure

I used OpenAI Codex to inspect the issue and current source, make the code/test changes, and run the validation commands listed above.
