### PR TITLE
fix(folder): place created folders after parent subtree

### DIFF
--- a/src/app/folder/folderlist.component.spec.ts
+++ b/src/app/folder/folderlist.component.spec.ts
@@ -230,26 +230,59 @@ describe('FolderListComponent', () => {
         expect(moveEvent.order).toEqual([1, 7, 6, 5, 3, 2, 4]);
     });
 
-    it('should create new folder in root', async () => {
+    it('should create new folder in root', () => {
         const comp = new FolderListComponent(dialog, hotkeyMock);
         comp.selectedFolder = 'Inbox';
         const folders = [
-            new FolderListEntry(1, 50, 40, 'inbox', 'folder1', 'folder2', 0),
+            new FolderListEntry(1, 50, 40, 'inbox', 'Inbox', 'Inbox', 0),
             new FolderListEntry(2, 50, 40, 'user', 'folder2', 'folder2', 0),
         ];
-        const foldersSubject = new BehaviorSubject(folders);
-        comp.folders = foldersSubject;
+        comp.folders = new BehaviorSubject(folders);
 
-        comp.createFolder.subscribe((ev: CreateFolderEvent) =>
-            foldersSubject.next([...folders, new FolderListEntry(3, 50, 40, 'user', ev.name, 'folder2', 0)])
-        );
+        let createEvent: CreateFolderEvent;
+        comp.createFolder.subscribe((ev: CreateFolderEvent) => createEvent = ev);
         comp.addFolder();
-        const newListOfFolders = await firstValueFrom(comp.folders);
 
-        console.log(newListOfFolders);
+        expect(createEvent.parentId).toEqual(0);
+        expect(createEvent.name).toEqual('testtest');
+        expect(createEvent.order).toEqual([1, 2, -1]);
+    });
 
-        expect(newListOfFolders.length).toEqual(3);
-        expect(newListOfFolders[2].folderName).toEqual('testtest');
-        expect(newListOfFolders[2].folderLevel).toEqual(0);
+    it('should create a selected user folder child after its existing subtree', () => {
+        const comp = new FolderListComponent(dialog, hotkeyMock);
+        comp.selectedFolder = 'folder2';
+        comp.folders = new BehaviorSubject([
+            new FolderListEntry(1, 50, 40, 'inbox', 'Inbox', 'Inbox', 0),
+            new FolderListEntry(2, 50, 40, 'user', 'folder2', 'folder2', 0),
+            new FolderListEntry(3, 50, 40, 'user', 'subfolder', 'folder2.subfolder', 1),
+            new FolderListEntry(4, 50, 40, 'user', 'folder3', 'folder3', 0),
+        ]);
+
+        let createEvent: CreateFolderEvent;
+        comp.createFolder.subscribe((ev: CreateFolderEvent) => createEvent = ev);
+        comp.addFolder();
+
+        expect(createEvent.parentId).toEqual(2);
+        expect(createEvent.name).toEqual('testtest');
+        expect(createEvent.order).toEqual([1, 2, 3, -1, 4]);
+    });
+
+    it('should create a menu-selected subfolder after its existing subtree', () => {
+        const comp = new FolderListComponent(dialog, hotkeyMock);
+        const parentFolder = new FolderListEntry(2, 50, 40, 'user', 'folder2', 'folder2', 0);
+        comp.folders = new BehaviorSubject([
+            new FolderListEntry(1, 50, 40, 'inbox', 'Inbox', 'Inbox', 0),
+            parentFolder,
+            new FolderListEntry(3, 50, 40, 'user', 'subfolder', 'folder2.subfolder', 1),
+            new FolderListEntry(4, 50, 40, 'user', 'folder3', 'folder3', 0),
+        ]);
+
+        let createEvent: CreateFolderEvent;
+        comp.createFolder.subscribe((ev: CreateFolderEvent) => createEvent = ev);
+        comp.addSubFolderDialog(parentFolder);
+
+        expect(createEvent.parentId).toEqual(2);
+        expect(createEvent.name).toEqual('testtest');
+        expect(createEvent.order).toEqual([1, 2, 3, -1, 4]);
     });
 });

--- a/src/app/folder/folderlist.component.ts
+++ b/src/app/folder/folderlist.component.ts
@@ -287,15 +287,12 @@ export class FolderListComponent implements OnChanges {
                 filter(res => res && res.length > 0),
             ).subscribe(newFolderName => {
                 // order needs to be: this.folders, with newFolder inserted
-                // after its parent .. put a "-1" there
+                // after the parent subtree .. put a "-1" there
                 this.folders.pipe(take(1)).subscribe((folders) => {
-                    const order = folders.map(folder => folder.folderId);
-                    const parentInd = order.findIndex((ind) => parentFolderId);
-                    order.splice(parentInd > -1 ? parentInd : 0, 0, -1);
                     this.createFolder.emit({
                         parentId: parentFolderId,
                         name:     newFolderName,
-                        order:    order,
+                        order:    this.createFolderOrder(folders, parentFolderId),
                     });
                 });
             });
@@ -316,16 +313,37 @@ export class FolderListComponent implements OnChanges {
             filter(res => res && res.length > 0),
         ).subscribe(newFolderName => {
             this.folders.pipe(take(1)).subscribe((folders) => {
-                const order = folders.map(f => f.folderId);
-                const parentInd = order.findIndex((ind) => folder.folderId);
-                order.splice(parentInd > -1 ? parentInd : 0, 0, -1);
                 this.createFolder.emit({
                     parentId: folder.folderId,
                     name:     newFolderName,
-                    order:    order,
+                    order:    this.createFolderOrder(folders, folder.folderId),
                 });
             });
         });
+    }
+
+    private createFolderOrder(folders: FolderListEntry[], parentFolderId: number): number[] {
+        const order = folders.map(folder => folder.folderId);
+
+        if (!parentFolderId) {
+            return [...order, -1];
+        }
+
+        const parentIndex = folders.findIndex(folder => folder.folderId === parentFolderId);
+        if (parentIndex === -1) {
+            return [...order, -1];
+        }
+
+        let insertIndex = parentIndex + 1;
+        while (
+            insertIndex < folders.length
+            && folders[insertIndex].folderLevel > folders[parentIndex].folderLevel
+        ) {
+            insertIndex++;
+        }
+
+        order.splice(insertIndex, 0, -1);
+        return order;
     }
 
     renameFolderDialog(folder: FolderListEntry): void {


### PR DESCRIPTION
Fixes #506.

## Summary
- Add a shared folder-creation order helper that inserts the new-folder placeholder by matching the actual parent folder id.
- Append new root folders after the existing folder list, and insert new subfolders after the selected parent folder's current descendant subtree.
- Add focused FolderList coverage for root-folder creation, selected-folder child creation, and menu-selected subfolder creation.

## Testing
- `npm ci`
- `npx ng test runbox7 --watch=false --browsers=FirefoxHeadless --include src/app/folder/folderlist.component.spec.ts` (4 success; existing folder move console logs)
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npx eslint src/app/folder/folderlist.component.ts src/app/folder/folderlist.component.spec.ts --quiet`
- `npm run lint -- --quiet`
- `git diff --check origin/master...HEAD`
- `git show --stat --oneline --check HEAD`
- `npm run policy` (current commits OK; historical upstream commit-message warnings still printed)
- `$env:SKIP_CHANGELOG='1'; node src/build/pre-build.js; npx ng build --configuration production --base-href=/app/ runbox7; node src/build/post-build.js` (production build hash `686c1ba4c6401b75`; existing Angular/Sass/CommonJS warnings)

## AI Disclosure
I used OpenAI Codex/GPT-5 in a local development workspace to inspect the relevant code, implement this change, and run the validation commands listed above. I reviewed the resulting diff and validation output before submitting.
