### PR TITLE
feat(overview): show message dates

### DIFF
--- a/src/app/start/sender-hilights.component.scss
+++ b/src/app/start/sender-hilights.component.scss
@@ -58,6 +58,13 @@
     .subject li {
         list-style-type: square;
     }
+    .emailDate {
+        color: rgba(0, 0, 0, 0.54);
+        display: inline-block;
+        font-size: 0.75em;
+        margin-right: 0.5em;
+        white-space: nowrap;
+    }
     .subject a {
         text-decoration: none !important;
     }

--- a/src/app/start/sender-hilights.component.spec.ts
+++ b/src/app/start/sender-hilights.component.spec.ts
@@ -1,0 +1,85 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatLegacyButtonModule as MatButtonModule } from '@angular/material/legacy-button';
+import { MatLegacyCardModule as MatCardModule } from '@angular/material/legacy-card';
+import { MatIconModule } from '@angular/material/icon';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { SearchIndexDocumentData } from '../xapian/searchservice';
+import { SenderHilightsComponent } from './sender-hilights.component';
+
+describe('SenderHilightsComponent', () => {
+    let component: SenderHilightsComponent;
+    let fixture: ComponentFixture<SenderHilightsComponent>;
+
+    const message = (date?: string): SearchIndexDocumentData => ({
+        id: 'M123',
+        date,
+        folder: 'Inbox',
+        from: 'sender@example.com',
+        subject: 'Quarterly report',
+        recipients: ['me@example.com'],
+        textcontent: '',
+    });
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            declarations: [SenderHilightsComponent],
+            imports: [
+                MatButtonModule,
+                MatCardModule,
+                MatIconModule,
+                RouterTestingModule,
+            ],
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(SenderHilightsComponent);
+        component = fixture.componentInstance;
+    });
+
+    it('shows message dates before subjects when overview messages have indexed dates', () => {
+        component.sender = {
+            icon: 'person',
+            name: 'Sender',
+            emails: [message('202001020304')],
+        };
+        component.ngOnChanges();
+
+        fixture.detectChanges();
+
+        const compiled = fixture.nativeElement as HTMLElement;
+        expect(compiled.querySelector('.emailDate').textContent.trim()).toBe('2020-01-02');
+        expect(compiled.textContent).toContain('Quarterly report');
+    });
+
+    it('omits the message date when the overview message has no indexed date', () => {
+        component.sender = {
+            icon: 'person',
+            name: 'Sender',
+            emails: [message()],
+        };
+        component.ngOnChanges();
+
+        fixture.detectChanges();
+
+        expect((fixture.nativeElement as HTMLElement).querySelector('.emailDate')).toBeNull();
+    });
+});

--- a/src/app/start/sender-hilights.component.ts
+++ b/src/app/start/sender-hilights.component.ts
@@ -19,6 +19,7 @@
 
 import { Component, ChangeDetectionStrategy, Input, OnChanges, Output, EventEmitter } from '@angular/core';
 
+import { MessageTableRowTool } from '../messagetable/messagetablerow';
 import { SearchIndexDocumentData } from '../xapian/searchservice';
 import { ContactHilights } from './startdesk.component';
 
@@ -34,6 +35,7 @@ import { ContactHilights } from './startdesk.component';
   <div class="subject">
     <ul>
       <li *ngFor="let email of shownEmails">
+          <span class="emailDate" *ngIf="messageDate(email) as date">{{ date }}</span>
           <a routerLink="/" [fragment]="emailPath(email)"> {{ email.subject }} </a>
       </li>
     </ul>
@@ -75,5 +77,12 @@ export class SenderHilightsComponent implements OnChanges {
         const folderPath = email.folder.replace(/\./, '/');
         const id = email.id.slice(1);
         return `${folderPath}:${id}`;
+    }
+
+    public messageDate(email: SearchIndexDocumentData): string {
+        if (!email.date) {
+            return '';
+        }
+        return MessageTableRowTool.formatTimestampFromStringWithoutSeparators(email.date);
     }
 }

--- a/src/app/xapian/searchservice.ts
+++ b/src/app/xapian/searchservice.ts
@@ -53,6 +53,7 @@ export const XAPIAN_GLASS_WR = 'xapianglasswr';
 // FIXME: Also in index.worker.ts
 export class SearchIndexDocumentData {
   id: string;
+  date?: string;
   from: string;
   subject: string;
   recipients: string[];
@@ -851,6 +852,7 @@ export class SearchService {
 
           this.currentDocData = {
             id: docdataparts[0],
+            date: this.api.getStringValue(docid, 2),
             from: docdataparts[1],
             subject: docdataparts[2],
             recipients: [],


### PR DESCRIPTION
Part of #1482.

## Summary
- Expose the indexed message date on `SearchIndexDocumentData` from the existing Xapian date string value.
- Show that formatted date before each subject in the Overview sender highlights.
- Keep Overview rendering tolerant of messages without an indexed date, and add focused component coverage for both dated and undated messages.

## Testing
- `npm ci`
- `npx ng test --watch=false --browsers=FirefoxHeadless --include=src/app/start/sender-hilights.component.spec.ts` (2 success)
- `npx tsc -p src/tsconfig.app.json --noEmit`
- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npx eslint src/app/start/sender-hilights.component.ts src/app/start/sender-hilights.component.spec.ts src/app/xapian/searchservice.ts --quiet`
- `npm run lint -- --quiet`
- `git diff --check origin/master...HEAD`
- `git show --stat --oneline --check HEAD`
- `npm run policy` (current commit OK; historical upstream commit-message warnings still printed)
- `$env:SKIP_CHANGELOG='1'; node src/build/pre-build.js; npx ng build --configuration production --base-href=/app/ runbox7; node src/build/post-build.js` (production build hash `6570d1a892a1ff90`; existing Angular/Sass/CommonJS warnings)

## AI Disclosure
I used OpenAI Codex/GPT-5 in a local development workspace to inspect the relevant code, implement this change, and run the validation commands listed above. I reviewed the resulting diff and validation output before submitting.
