### PR TITLE
fix(xapian): invalidate getDocData cache after index reload

### DIFF
--- a/src/app/xapian/searchservice.spec.ts
+++ b/src/app/xapian/searchservice.spec.ts
@@ -28,7 +28,7 @@ import { MatLegacySnackBarModule as MatSnackBarModule } from '@angular/material/
 
 import { MessageListService } from '../rmmapi/messagelist.service';
 import { XapianAPI } from '@runboxcom/runbox-searchindex/rmmxapianapi';
-import { firstValueFrom } from 'rxjs';
+import { AsyncSubject, BehaviorSubject, Subject, of, firstValueFrom } from 'rxjs';
 import { xapianLoadedSubject } from './xapianwebloader';
 import { PostMessageAction } from './messageactions';
 
@@ -326,5 +326,115 @@ describe('SearchService', () => {
 
         FS.chdir('/');
         FS.unmount('/' + localdir);
+    });
+});
+
+describe('SearchService.getDocData cache', () => {
+
+    let searchService: SearchService;
+    let mockApi: any;
+    let mockModule: { documenttermlistresult: string[] };
+
+    beforeEach(() => {
+        mockModule = { documenttermlistresult: [] };
+        (window as any).Module = mockModule;
+        (window as any).FS = {
+            syncfs: (_populate: boolean, cb: () => void) => cb(),
+        };
+
+        const RealWorker = (window as any).Worker;
+        (window as any).Worker = class {
+            postMessage() {}
+            onmessage: any = null;
+            onerror: any = null;
+            terminate() {}
+            addEventListener() {}
+        };
+
+        searchService = new SearchService(
+            {
+                me: new AsyncSubject(),
+                messageFlagChangeSubject: new Subject(),
+                getMessageContents: () => of({ status: 'success', text: { text: '' } }),
+                deleteCachedMessageContents: () => {},
+            } as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            {
+                folderListSubject: new BehaviorSubject([]),
+                refreshFolderList: () => Promise.resolve([]),
+                searchservice: new AsyncSubject(),
+            } as any,
+        );
+
+        (window as any).Worker = RealWorker;
+
+        mockApi = {
+            getDocumentData: jasmine.createSpy().and.returnValue('Q123\tsender@test.com\tTest Subject'),
+            documentXTermList: jasmine.createSpy(),
+            reloadXapianDatabase: jasmine.createSpy(),
+        };
+        searchService.api = mockApi;
+        searchService.messageTextCache = new Map([[123, 'preview text']]);
+    });
+
+    afterEach(() => {
+        delete (window as any).Module;
+        delete (window as any).FS;
+    });
+
+    it('returns fresh seen flag after index reload', () => {
+        mockModule.documenttermlistresult = [];
+        const before = searchService.getDocData(1);
+        expect(before.seen).toBeFalsy();
+
+        mockModule.documenttermlistresult = ['XFseen'];
+        searchService.indexUpdatedSubject.next(undefined);
+
+        const after = searchService.getDocData(1);
+        expect(after.seen).toBe(true);
+    });
+
+    it('returns fresh flagged flag after index reload', () => {
+        mockModule.documenttermlistresult = [];
+        const before = searchService.getDocData(1);
+        expect(before.flagged).toBeFalsy();
+
+        mockModule.documenttermlistresult = ['XFflagged'];
+        searchService.indexUpdatedSubject.next(undefined);
+
+        const after = searchService.getDocData(1);
+        expect(after.flagged).toBe(true);
+    });
+
+    it('reflects multiple flag changes in one reload', () => {
+        mockModule.documenttermlistresult = [];
+        searchService.getDocData(1);
+
+        mockModule.documenttermlistresult = ['XFseen', 'XFflagged'];
+        searchService.indexUpdatedSubject.next(undefined);
+
+        const after = searchService.getDocData(1);
+        expect(after.seen).toBe(true);
+        expect(after.flagged).toBe(true);
+    });
+
+    it('still caches between calls when no reload happened', () => {
+        mockModule.documenttermlistresult = [];
+        searchService.getDocData(1);
+        expect(mockApi.getDocumentData).toHaveBeenCalledTimes(1);
+
+        searchService.getDocData(1);
+        expect(mockApi.getDocumentData).toHaveBeenCalledTimes(1);
+    });
+
+    it('does fresh lookup for a different docid without reload', () => {
+        mockModule.documenttermlistresult = [];
+        searchService.getDocData(1);
+        expect(mockApi.getDocumentData).toHaveBeenCalledTimes(1);
+
+        searchService.getDocData(2);
+        expect(mockApi.getDocumentData).toHaveBeenCalledTimes(2);
     });
 });

--- a/src/app/xapian/searchservice.ts
+++ b/src/app/xapian/searchservice.ts
@@ -263,6 +263,9 @@ export class SearchService {
             // console.log(FS.stat(`${this.partitionsdir}/${f}`));
           // });
         this.api.reloadXapianDatabase();
+        // Invalidate the single-doc cache so getDocData reads fresh data
+        // from the reloaded database instead of returning stale values
+        this.currentXapianDocId = null;
         this.indexReloadedSubject.next(undefined);
       });
     });


### PR DESCRIPTION
## Root cause

`getDocData` in `searchservice.ts` uses a single-doc cache (`currentXapianDocId` / `currentDocData`) to avoid redundant Xapian lookups when the display requests the same document multiple times per row render.

After a flag change (seen, flagged, answered), the worker adds/removes the term, commits, and fires `indexUpdatedSubject`. The main thread syncs from IndexedDB via `FS.syncfs`, reloads the Xapian database, and fires `indexReloadedSubject`. But the cache was never invalidated, so `getDocData` returned stale data for the last-accessed docid.

This affected **all flag-based display updates**: bold/unread state, flag icons, answered indicators. The Angular 16 upgrade (commit 50b8e5db) shifted rendering timing enough to expose the pre-existing cache bug.

## Fix

One line: clear `currentXapianDocId` after `reloadXapianDatabase()` and before `indexReloadedSubject.next()`, so consumers always read fresh data from the reloaded database.

## Tests

5 new tests in `searchservice.spec.ts`, all running on master (no dependency on accessible-table or MessageDisplay code):
- Seen flag visible after reload
- Flagged flag visible after reload
- Multiple flags (seen + flagged) in one reload
- Cache still works between calls without reload (no perf regression)
- Different docid triggers fresh lookup without reload (existing behavior preserved)

Full suite: 262 passing, 0 failing.

## Scope

Fix lives entirely in `searchservice.ts`. Works on master and on the accessible-table branch. Tests are importable to either branch.