### PR TITLE
fix(domainregister): compare email domain quota numerically

### DIFF
--- a/src/app/domainregister/domainregister.component.html
+++ b/src/app/domainregister/domainregister.component.html
@@ -507,11 +507,11 @@
             <br />
             <p>Here you can purchase and register new domain names.</p>
 
-                    <div style='background: #C7DFFF; padding: 15px;' class='default_margintop' *ngIf="tld_list && tld_list.length && domain_quota_used >= domain_quota_allowed">
+                    <div style='background: #C7DFFF; padding: 15px;' class='default_margintop' *ngIf="tld_list && tld_list.length && is_domain_quota_limit_reached()">
                         <h2 class="mat-h2">Email Domain quota limit</h2>
                         <p>You have reached your Email Domain quota limit. Your account is using {{domain_quota_used}} of its {{domain_quota_allowed}} total <a href='/mail/account_domain'>Email Domains</a>. Please <a href="/app/account/components">purchase more Email Hosting products</a> first.</p>
                     </div>
-                    <div style='background: #C7DFFF; padding: 15px;' class='default_margintop' *ngIf="tld_list && tld_list.length && domain_quota_used < domain_quota_allowed">
+                    <div style='background: #C7DFFF; padding: 15px;' class='default_margintop' *ngIf="tld_list && tld_list.length && !is_domain_quota_limit_reached()">
                       <mat-card-header style="display: flex; width: 100%">
                           <mat-card-title style="flex-grow: 1">
                               <h2 class="mat-h2">Register a new domain name</h2>

--- a/src/app/domainregister/domainregister.component.spec.ts
+++ b/src/app/domainregister/domainregister.component.spec.ts
@@ -1,0 +1,91 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { of } from 'rxjs';
+
+import { DomainRegisterComponent } from './domainregister.component';
+
+describe('DomainRegisterComponent quota checks', () => {
+    function createComponent() {
+        const http = {
+            get: jasmine.createSpy('get').and.returnValues(
+                of({
+                    result: {
+                        product_list: [
+                            {
+                                tld: 'com',
+                                period: '1',
+                                price: '10.00',
+                                supports_whois_privacy: 0,
+                                privacy_price: '0.00'
+                            }
+                        ]
+                    }
+                }),
+                of({
+                    result: {
+                        domain_quota_allowed: '20',
+                        domain_quota_used: '7'
+                    }
+                })
+            ),
+            post: jasmine.createSpy('post').and.returnValue(of({
+                result: {
+                    is_available: 0,
+                    products: [],
+                    privacy_products: []
+                }
+            }))
+        };
+        const snackBar = {
+            open: jasmine.createSpy('open')
+        };
+        const rmmapi = {
+            me: of({ is_trial: false })
+        };
+
+        const component = new DomainRegisterComponent(
+            http as any,
+            snackBar as any,
+            rmmapi as any
+        );
+
+        return { component, http, snackBar };
+    }
+
+    it('allows availability checks when string quota values are below the limit', () => {
+        const { component, http, snackBar } = createComponent();
+
+        component.domain_wanted = 'example.com';
+        component.domain_quota_used = '7' as any;
+        component.domain_quota_allowed = '20' as any;
+
+        component.check_avail();
+
+        expect(http.post).toHaveBeenCalledWith(
+            '/rest/v1/domain_registration/enom/check_avail',
+            { sld: 'example', tld: 'com' }
+        );
+        expect(snackBar.open).not.toHaveBeenCalledWith(
+            'You have reached your allowed Email Domain quota. Please purchase more Email Hosting products.',
+            'Dismiss',
+            jasmine.anything()
+        );
+    });
+});

--- a/src/app/domainregister/domainregister.component.spec.ts
+++ b/src/app/domainregister/domainregister.component.spec.ts
@@ -45,13 +45,33 @@ describe('DomainRegisterComponent quota checks', () => {
                     }
                 })
             ),
-            post: jasmine.createSpy('post').and.returnValue(of({
-                result: {
-                    is_available: 0,
-                    products: [],
-                    privacy_products: []
-                }
-            }))
+            post: jasmine.createSpy('post').and.returnValues(
+                of({
+                    result: {
+                        is_available: 0,
+                        products: [],
+                        privacy_products: []
+                    }
+                }),
+                of({
+                    result: {
+                        agreement: {
+                            generic: null,
+                            specific: null
+                        }
+                    }
+                }),
+                of({
+                    result: {
+                        specific_docs: []
+                    }
+                }),
+                of({
+                    result: {
+                        generic_docs: []
+                    }
+                })
+            )
         };
         const snackBar = {
             open: jasmine.createSpy('open')

--- a/src/app/domainregister/domainregister.component.ts
+++ b/src/app/domainregister/domainregister.component.ts
@@ -61,6 +61,20 @@ export interface ElementTld {
   privacy_price: string;
 }
 
+export function emailDomainQuotaCount(value: unknown): number {
+  const count = Number(value);
+  return Number.isFinite(count) ? count : 0;
+}
+
+export function isEmailDomainQuotaLimitReached(used: unknown, allowed: unknown): boolean {
+  const usedCount = emailDomainQuotaCount(used);
+  const allowedCount = emailDomainQuotaCount(allowed);
+
+  return usedCount > 0
+    && allowedCount > 0
+    && usedCount >= allowedCount;
+}
+
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
   selector: 'domain-register',
@@ -157,6 +171,10 @@ export class DomainRegisterComponent implements AfterViewInit {
     return this.is_available ? 'primary' : 'button';
   };
 
+  public is_domain_quota_limit_reached = function () {
+    return isEmailDomainQuotaLimitReached(this.domain_quota_used, this.domain_quota_allowed);
+  };
+
   public calculate_total = function () {
     // eslint-disable-next-line no-eval
     this.total_price = eval(this.selected_product.price[0].price);
@@ -194,7 +212,7 @@ export class DomainRegisterComponent implements AfterViewInit {
 
   public check_avail = function () {
     if (this.is_btn_search_domain_disabled) { return; }
-    if ( this.domain_quota_used && this.domain_quota_allowed && this.domain_quota_used >= this.domain_quota_allowed ) {
+    if ( this.is_domain_quota_limit_reached() ) {
         return this.show_error('You have reached your allowed Email Domain quota. Please purchase more Email Hosting products.', 'Dismiss');
     }
     this.is_btn_search_domain_disabled = true;
@@ -820,9 +838,9 @@ export class DomainRegisterComponent implements AfterViewInit {
     const req = this.http.get('/rest/v1/email_hosting/domains_quota');
     req.pipe(timeout(180000))
       .subscribe((result: any) => {
-        this.domain_quota_allowed = result.result.domain_quota_allowed;
-        this.domain_quota_used = result.result.domain_quota_used;
-        if ( this.domain_quota_used >= this.domain_quota_allowed ) {
+        this.domain_quota_allowed = emailDomainQuotaCount(result.result.domain_quota_allowed);
+        this.domain_quota_used = emailDomainQuotaCount(result.result.domain_quota_used);
+        if ( this.is_domain_quota_limit_reached() ) {
             this.show_error('You have reached your allowed Email Domain quota. Please purchase more Email Hosting products.', 'Dismiss');
         }
       },


### PR DESCRIPTION
## Summary

Fix #1994 by normalizing the email-domain quota values before comparing them. This prevents numeric strings such as `7` and `20` from being compared lexicographically and incorrectly tripping the quota-limit path.

The PR keeps the regression test in its own commit, followed by the fix commit, so the test can be cherry-picked independently.

## Duplicate check

- Checked open and closed PRs for `1994`, `domain quota`, and `Email Domain quota`.
- Found only old merged PR #864 from 2020; I did not find an open or closed duplicate for this string-comparison regression.

## Validation

- `npx tsc -p src/tsconfig.spec.json --noEmit`
- `npm run lint -- --quiet`
- `git diff --check HEAD~2..HEAD`

Not run locally:

- `npm run ci-tests`: this environment does not currently have a working Firefox/Karma browser runtime available, so I kept validation to the static checks above instead of reporting full CI coverage.

## AI-use disclosure

This contribution was prepared with AI assistance.

- Model/agent: OpenAI Codex, GPT-5 based coding agent.
- Harness: Codex desktop/local shell environment; exact harness version not shown in the session.
- Tools used for this PR: local shell commands, npm/TypeScript/Angular lint tooling, GitHub CLI.
- Available installed connector/plugin classes in the session included GitHub, Gmail, Chrome/browser, and document/data tooling; only local shell and GitHub CLI were used to prepare and submit this PR.
- AI touched the issue analysis, regression test, implementation, validation commands, commit preparation, and PR description.
- The account owner reviewed/approved submission in the Codex task before this PR was opened.
