### PR TITLE
fix(spam): Now only submit Spam/Not spam once (2x confuses the backend)

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -714,14 +714,11 @@ export class AppComponent implements OnInit, AfterViewInit, CanvasTableSelectLis
         const userFolders = this.messagelistservice.folderListSubject.value;
         const currentFolderId = userFolders.find(fld => fld.folderPath === this.messagelistservice.currentFolder).folderId;
         const res = this.rmmapi.trainSpam({is_spam: params.is_spam, from_folder_id: currentFolderId, messages: messageIds});
-        res.subscribe(data => {
+        res.pipe(tap(data => {
           if ( data.status === 'error' ) {
             this.snackBar.open('There was an error with Spam functionality. Please select the messages and try again.', 'Dismiss');
           }
-        }, (err) => {
-          console.error('Error reporting spam', err);
-          this.snackBar.open('There was an error with Spam functionality.', 'Dismiss');
-        });
+        }));
         return res;
       },
       afterwards: (result) => this.snackBar.open(

--- a/src/app/rmmapi/rbwebmail.ts
+++ b/src/app/rmmapi/rbwebmail.ts
@@ -19,7 +19,7 @@
 
 import { Injectable, NgZone } from '@angular/core';
 import { Observable, from, of, Subject, AsyncSubject, firstValueFrom, throwError } from 'rxjs';
-import { catchError, concatMap, share, filter, map, mergeMap } from 'rxjs/operators';
+import { catchError, concatMap, share, filter, map, tap, mergeMap } from 'rxjs/operators';
 import { MessageInfo } from '../common/messageinfo';
 import { MailAddressInfo } from '../common/mailaddressinfo';
 import { FolderListEntry } from '../common/folderlistentry';
@@ -418,9 +418,9 @@ export class RunboxWebmailAPI {
         }
 
     subscribeShowBackendErrors(req: any) {
-        req.subscribe((res: any) => {
+      req.pipe(tap((res: any) => {
             this.showBackendErrors(res);
-        });
+      }));
     }
 
     showBackendErrors(res: any) {


### PR DESCRIPTION
Report from users that they get an error when marking several messages as "not spam". Due to the way RXJS was being used, we were POSTing twice to the spam endpoint. This sometimes caused the "check for entry in whitelist, if not then insert" code to check twice, then try and insert twice - the 2nd insert would fail as the first had already succeeded.

Fix also included that caused many other endpoints to be called twice.