### PR TITLE
fix(compose): preserve writing space before reply signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,17 @@ You can run the individual tests using one of the following commands:
 Or run them all at once with `npm run ci-tests` -- this option will run the tests with the same settings as our CI setup,
 making sure that any errors will be caught before your code becomes public.
 
+### Reply signature spacing
+
+Replies and Reply All should leave two line breaks before the sender's signature,
+so typing at the start does not run into the signature. HTML replies need visible
+`<br>` elements; newline characters alone do not create that space. Switching the
+sender identity before editing should replace the signature and keep the space.
+
+The focused regression checks are in `src/app/compose/compose.component.spec.ts`:
+
+`npm run test -- --watch=false --browsers=FirefoxHeadless --include=src/app/compose/compose.component.spec.ts`
+
 ## Further help
 
 To get more help on the Angular CLI use `npx ng help` or go check out the [Angular CLI README](https://github.com/angular/angular-cli/blob/master/README.md).

--- a/src/app/compose/compose.component.spec.ts
+++ b/src/app/compose/compose.component.spec.ts
@@ -1,5 +1,5 @@
 // --------- BEGIN RUNBOX LICENSE ---------
-// Copyright (C) 2026 Runbox Solutions AS (runbox.com).
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
 //
 // This file is part of Runbox 7.
 //

--- a/src/app/compose/compose.component.spec.ts
+++ b/src/app/compose/compose.component.spec.ts
@@ -1,0 +1,195 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { ElementRef, NgZone } from '@angular/core';
+import { fakeAsync, tick } from '@angular/core/testing';
+import { UntypedFormBuilder } from '@angular/forms';
+import { BehaviorSubject } from 'rxjs';
+import { DefaultPrefGroups, PreferencesService } from '../common/preferences.service';
+import { MailAddressInfo } from '../common/mailaddressinfo';
+import { Identity } from '../profiles/profile.service';
+import { ComposeComponent } from './compose.component';
+import { DraftDeskService, DraftFormModel } from './draftdesk.service';
+import { RecipientsService } from './recipients.service';
+
+describe('ComposeComponent reply writing space', () => {
+    let registeredListeners: jasmine.Spy;
+
+    beforeEach(() => {
+        registeredListeners = spyOn(window, 'addEventListener').and.callThrough();
+    });
+
+    afterEach(() => {
+        registeredListeners.calls.allArgs().forEach(([type, listener, options]) => {
+            if (type === 'dragover' || type === 'dragleave') {
+                window.removeEventListener(type, listener, options);
+            }
+        });
+    });
+
+    function identity(signature = '', useHTML = false): Identity {
+        return Identity.fromObject({
+            email: 'recipient@example.com',
+            from_name: 'Recipient',
+            signature,
+            is_signature_html: useHTML,
+        });
+    }
+
+    function reply(from: Identity, useHTML = false, all = false): DraftFormModel {
+        return DraftFormModel.reply({
+            mid: 42,
+            headers: { 'message-id': '<original@example.com>' },
+            from: [{ name: 'Sender', address: 'sender@example.com' }],
+            to: [{ name: 'Recipient', address: from.email }],
+            cc: [{ name: 'Other recipient', address: 'other@example.com' }],
+            date: new Date('2026-09-01T12:00:00Z'),
+            subject: 'Reply spacing',
+            rawtext: 'Original message',
+            sanitized_html: '<p>Original message</p>',
+        }, [from], all, useHTML);
+    }
+
+    function openCompose(model: DraftFormModel, froms: Identity[], defaultHTML = false): ComposeComponent {
+        const preferences = new Map<string, string>([
+            [`${DefaultPrefGroups.Global}:composeInHTMLByDefault`, String(defaultHTML)],
+        ]);
+        const component = new ComposeComponent(
+            null, null, null,
+            { fromsSubject: new BehaviorSubject(froms) } as DraftDeskService,
+            null, null, new UntypedFormBuilder(), null, null,
+            { recentlyUsed: new BehaviorSubject<MailAddressInfo[]>([]) } as unknown as RecipientsService,
+            { preferences: new BehaviorSubject(preferences), prefGroup: 'compose' } as unknown as PreferencesService,
+            new NgZone({ enableLongStackTrace: false }),
+        );
+        component.model = model;
+        component.messageTextArea = new ElementRef(document.createElement('textarea'));
+        // Exercise form changes without sending an autosave request to the mail backend.
+        spyOn(component, 'submit');
+        component.ngOnInit();
+        tick();
+        return component;
+    }
+
+    function expectHTMLWritingSpace(html: string, signatureText: string): void {
+        const body = document.createElement('div');
+        body.innerHTML = html;
+        const content = Array.from(body.childNodes).filter(node =>
+            node.nodeType !== Node.TEXT_NODE || node.textContent.trim().length > 0);
+
+        // HTML whitespace is not a visible line break: the editor needs two leading BR elements.
+        expect(content[0]?.nodeName).toBe('BR');
+        expect(content[1]?.nodeName).toBe('BR');
+        expect(content[2]?.textContent).toContain(signatureText);
+        expect(body.textContent).toContain('Original message');
+    }
+
+    [false, true].forEach(all => {
+        it(`keeps two blank lines before a plain signature in ${all ? 'reply all' : 'reply'}`, fakeAsync(() => {
+            const from = identity('Regards, Recipient');
+            const component = openCompose(reply(from, false, all), [from]);
+            const body = component.formGroup.controls.msg_body.value as string;
+
+            expect(body.startsWith('\n\nRegards, Recipient')).toBeTrue();
+            expect(body).toContain('> Original message');
+            expect(component.model.cc.length).toBe(all ? 1 : 0);
+        }));
+    });
+
+    it('keeps two visible breaks before an HTML signature in an HTML reply', fakeAsync(() => {
+        const from = identity('<p>Regards, Recipient</p>', true);
+        const component = openCompose(reply(from, true), [from]);
+
+        expect(component.formGroup.controls.useHTML.value).toBeTrue();
+        expectHTMLWritingSpace(component.formGroup.controls.html.value, 'Regards, Recipient');
+    }));
+
+    it('keeps two visible breaks before a plain signature when replying in HTML', fakeAsync(() => {
+        const from = identity('Regards, Recipient');
+        const component = openCompose(reply(from, true), [from]);
+
+        expectHTMLWritingSpace(component.formGroup.controls.html.value, 'Regards, Recipient');
+    }));
+
+    it('preserves reply writing space when the compose preference selects HTML', fakeAsync(() => {
+        const from = identity('Regards, Recipient');
+        const component = openCompose(reply(from), [from], true);
+
+        expect(component.formGroup.controls.useHTML.value).toBeTrue();
+        expectHTMLWritingSpace(component.formGroup.controls.html.value, 'Regards, Recipient');
+    }));
+
+    [false, true].forEach(useHTML => {
+        it(`does not add more spacing to an unsigned ${useHTML ? 'HTML' : 'plain'} reply`, fakeAsync(() => {
+            const from = identity();
+            const model = reply(from, useHTML);
+            const originalBody = useHTML ? model.html : model.msg_body;
+            const component = openCompose(model, [from]);
+
+            expect(component.formGroup.controls[useHTML ? 'html' : 'msg_body'].value).toBe(originalBody);
+        }));
+    });
+
+    it('does not change signature placement in a new non-reply draft', fakeAsync(() => {
+        const from = identity('Regards, Recipient');
+        const draft = DraftFormModel.create(-1, from, 'sender@example.com', 'New message');
+        const component = openCompose(draft, [from]);
+
+        expect(component.formGroup.controls.msg_body.value).toBe('Regards, Recipient\n\n');
+    }));
+
+    it('retains writing space while replacing a pristine reply signature after an identity change', fakeAsync(() => {
+        const from = identity('Original signature');
+        const second = Identity.fromObject({
+            email: 'second@example.com',
+            from_name: 'Second identity',
+            signature: 'Replacement signature $&',
+            is_signature_html: false,
+        });
+        const component = openCompose(reply(from), [from, second]);
+
+        component.formGroup.controls.from.setValue(second.nameAndAddress);
+        tick(1000);
+        const body = component.formGroup.controls.msg_body.value as string;
+
+        expect(body.startsWith('\n\nReplacement signature $&')).toBeTrue();
+        expect(body).not.toContain('Original signature');
+        expect(body.split('Replacement signature').length - 1).toBe(1);
+        expect(body).toContain('> Original message');
+        tick(1000);
+    }));
+
+    it('keeps writing space when adding a signature to a pristine unsigned reply', fakeAsync(() => {
+        const from = identity();
+        const second = Identity.fromObject({
+            email: 'second@example.com',
+            from_name: 'Second identity',
+            signature: 'Regards, Second identity',
+            is_signature_html: false,
+        });
+        const component = openCompose(reply(from), [from, second]);
+
+        component.formGroup.controls.from.setValue(second.nameAndAddress);
+        tick(1000);
+
+        expect(component.formGroup.controls.msg_body.value).toMatch(/^\n\nRegards, Second identity/);
+        expect(component.formGroup.controls.msg_body.value).toContain('> Original message');
+        tick(1000);
+    }));
+});

--- a/src/app/compose/compose.component.ts
+++ b/src/app/compose/compose.component.ts
@@ -126,6 +126,8 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
     }
 
     ngOnInit() {
+        const signaturePrefix = (useHTML: boolean) => this.model.replying ?
+            (useHTML ? '<br />\n<br />' : '\n\n') : '';
         if (this.model.isUnsaved()) {
             this.editing = true;
             this.isUnsaved = true;
@@ -144,9 +146,9 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
                     // Sig is HTML, or Reply/Fwd Draft is HTML (contains .html)
                     if ( from.is_signature_html || this.model.useHTML) {
                         this.model.useHTML = true;
-                        this.model.html = this.signature.concat('\n\n', this.model.html || this.model.msg_body);
+                        this.model.html = signaturePrefix(true).concat(this.signature, '\n\n', this.model.html || this.model.msg_body);
                     } else {
-                        this.model.msg_body = this.signature.concat('\n\n', this.model.msg_body);
+                        this.model.msg_body = signaturePrefix(false).concat(this.signature, '\n\n', this.model.msg_body);
                     }
 
                 }
@@ -228,21 +230,23 @@ export class ComposeComponent implements AfterViewInit, OnDestroy, OnInit {
                     if ( this.signature && from.signature ) {
                         // replaces current signature with new one
                         const new_signature = from.signature;
-                        const rgx = new RegExp('^' + this.signature, 'g');
-                        const msg_body = this.formGroup.controls.msg_body.value.replace(rgx, new_signature);
+                        const escaped_signature = this.signature.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+                        const rgx = new RegExp('^((?:\\r?\\n|<br\\s*/?>)*)' + escaped_signature);
+                        const replaceSignature = (_match: string, spacing: string) => spacing + new_signature;
+                        const msg_body = this.formGroup.controls.msg_body.value.replace(rgx, replaceSignature);
                         this.signature = new_signature;
                         if (this.formGroup.value.useHTML && this.editor) {
-                            this.model.html = this.model.html.replace(rgx, new_signature);
+                            this.model.html = this.model.html.replace(rgx, replaceSignature);
                             this.editor.setContent(this.model.html);
                         } else {
                             this.formGroup.controls.msg_body.setValue(msg_body);
                         }
                     } else if ( !this.signature && from.signature) {
                         this.has_pasted_signature = true;
-                        const msg_body = from.signature.concat('\n\n', this.model.msg_body);
+                        const msg_body = signaturePrefix(false).concat(from.signature, '\n\n', this.model.msg_body);
                         this.signature = from.signature;
                         if (from.is_signature_html || (this.formGroup.value.useHTML && this.editor)) {
-                            this.model.html = this.signature.concat('\n\n', this.model.html);
+                            this.model.html = signaturePrefix(true).concat(this.signature, '\n\n', this.model.html);
                             if (!this.formGroup.value.useHTML) {
                                 this.formGroup.controls.msg_body.setValue(true);
                                 this.htmlToggled();


### PR DESCRIPTION
Opening a reply with a configured signature places the signature before the blank writing space. Preserve two leading line breaks in plain-text and HTML replies, including Reply All and sender-identity changes.

This addresses the remaining signature case after merged #1760 and relates to #911; unsigned replies already received the original spacing fix.

### Changes
- Insert reply-only blank space before signatures.
- Preserve leading newline/BR spacing when changing signatures and treat signature text literally.
- Add separately cherry-pickable regression tests and document the focused checks.

### Validation
- `npm run ci-tests` completed with exit 0: lint, policy, **267 unit tests**, **74 application tests**, and production build.
- Cherry-picking only test commits `902ca9d3` and `e5d6d8b6` onto unpatched master reproduces **7 failed / 3 passed**; all **10 focused tests pass** with implementation commit `37ad3e42`.
- Local browser verification: selecting a signed identity in a reply preserves two leading newline characters; TinyMCE preserves two rendered BR elements before the signature after switching to HTML.
- Tests use the repository's local fixture backend; no production mailbox was used. Existing lint/build/test-console warnings remain and did not fail the suite.
- Environment: Node 16.20.2, Firefox 155.0.1. A temporary LaunchServices wrapper handles Firefox's macOS 27 direct-launch issue; no repository runner configuration was changed.

### AI disclosure and submission authorization
This contribution was prepared and submitted using **Codex (GPT-6)**, with explicit authorization from **@riazul007-error** after the complete diff and validation were made available for review. This is an agent-submitted PR; no claim is made that the human manually wrote or tested it.

Harness: Codex desktop/API tools; installed CLI reports `codex-cli 0.153.4`. The desktop application version was not available. The primary agent implemented the source change and documentation and ran validation. Companion agents researched duplicate PRs, prepared regression tests, diagnosed the local Firefox launcher, and reviewed the diff.

Tools used for this contribution: GitHub CLI, shell/git/npm, context-mode, browser automation, and Codex agent collaboration. Gmail/browser correspondence concerned bounty eligibility separately from this code review.

<details>
<summary>Local configured plugin inventory (including disabled entries)</summary>

This lists every plugin entry in the local Codex configuration. Enabled/disabled states are included rather than implying that every configured plugin participated in this change. Only the contribution tools described above were used for this patch.

- `build-ios-apps@openai-curated` — enabled
- `build-web-apps@openai-curated` — enabled
- `coderabbit@openai-curated` — enabled
- `documents@openai-primary-runtime` — enabled
- `presentations@openai-primary-runtime` — enabled
- `spreadsheets@openai-primary-runtime` — enabled
- `test-android-apps@openai-curated` — enabled
- `caveman@caveman-repo` — enabled
- `frontend-design@claude-plugins-official` — enabled
- `security-guidance@claude-plugins-official` — enabled
- `superpowers@claude-plugins-official` — enabled
- `compound-engineering@compound-engineering-plugin` — enabled
- `github@openai-curated` — enabled
- `figma@openai-curated` — enabled
- `codex-security@openai-curated` — enabled
- `pdf@openai-primary-runtime` — enabled
- `template-creator@openai-primary-runtime` — enabled
- `computer-use@openai-bundled` — enabled
- `visualize@openai-bundled` — enabled
- `browser@openai-bundled` — enabled
- `claude-seo@agricidaniel-seo` — enabled
- `code-review@claude-plugins-official` — enabled
- `coderabbit@claude-plugins-official` — enabled
- `skill-creator@claude-plugins-official` — enabled
- `cloudflare@cloudflare` — enabled
- `context-mode@context-mode` — enabled
- `evals-skills@hamelsmu-evals-skills` — enabled
- `andrej-karpathy-skills@karpathy-skills` — enabled
- `last30days@last30days-skill` — enabled
- `marketing-skills@marketingskills` — enabled
- `qmd@qmd` — enabled
- `ui-ux-pro-max@ui-ux-pro-max-skill` — enabled
- `adspirer-ads-agent@claude-cowork` — enabled
- `anthropic-skills@claude-cowork` — enabled
- `brand-voice@claude-cowork` — enabled
- `cowork-plugin-management@claude-cowork` — enabled
- `data@claude-cowork` — enabled
- `design@claude-cowork` — enabled
- `engineering@claude-cowork` — enabled
- `enterprise-search@claude-cowork` — enabled
- `figma@claude-cowork` — enabled
- `legal@claude-cowork` — enabled
- `marketing@claude-cowork` — enabled
- `miro@claude-cowork` — enabled
- `operations@claude-cowork` — enabled
- `pdf-viewer@claude-cowork` — enabled
- `postiz@claude-cowork` — enabled
- `product-management@claude-cowork` — enabled
- `productivity@claude-cowork` — enabled
- `sales@claude-cowork` — enabled
- `searchfit-seo@claude-cowork` — enabled
- `small-business@claude-cowork` — enabled
- `apollo@claude-cowork` — enabled
- `bio-research@claude-cowork` — enabled
- `common-room@claude-cowork` — enabled
- `customer-support@claude-cowork` — enabled
- `finance@claude-cowork` — enabled
- `human-resources@claude-cowork` — enabled
- `slack-by-salesforce@claude-cowork` — enabled
- `chrome@openai-bundled` — enabled
- `linkedin-copy-system@personal` — enabled
- `hostinger@claude-plugins-official` — enabled
- `record-and-replay@openai-bundled` — enabled
- `codex-app-tools@openai-bundled` — enabled
- `sites@openai-bundled` — enabled

</details>

