### PR TITLE
fix(mailviewer): hide entire inline attachment entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,16 @@ You can run the individual tests using one of the following commands:
 Or run them all at once with `npm run ci-tests` -- this option will run the tests with the same settings as our CI setup,
 making sure that any errors will be caught before your code becomes public.
 
+### Inline attachment display
+
+In the HTML message view, images embedded in the message do not create separate
+attachment rows or grid tiles. Downloadable files remain listed, and their download
+and decryption actions retain the original MIME attachment indices. Inline images
+remain available in the attachment list when viewing plain text or when the HTML
+sandbox is unavailable.
+
+The regression checks are in `src/app/mailviewer/singlemailviewer.component.spec.ts`.
+
 ## Further help
 
 To get more help on the Angular CLI use `npx ng help` or go check out the [Angular CLI README](https://github.com/angular/angular-cli/blob/master/README.md).

--- a/src/app/mailviewer/singlemailviewer.component.html
+++ b/src/app/mailviewer/singlemailviewer.component.html
@@ -284,11 +284,13 @@
     
       <ng-container>
         <mat-list>
-          <mat-list-item class="link-pointer" *ngFor="let att of mailObj.attachments; let i=index" (click)="openAttachment(att)">
-            <ng-container *ngIf="!att.internal || !(mailContentHTML && showHTML && SUPPORTS_IFRAME_SANDBOX)">
+          <ng-container *ngFor="let att of mailObj.attachments">
+            <mat-list-item class="link-pointer"
+              *ngIf="!att.internal || !(mailContentHTML && showHTML && SUPPORTS_IFRAME_SANDBOX)"
+              (click)="openAttachment(att)">
               <mat-icon mat-list-icon svgIcon="{{attachmentIconFromContentType(att.contentType)}}"></mat-icon> <span>{{att.filename}}</span><span style="flex-grow: 1"></span><span>{{att.sizeDisplay}}</span>
-            </ng-container>
-          </mat-list-item>
+            </mat-list-item>
+          </ng-container>
         </mat-list>
       </ng-container>
     </mat-expansion-panel>
@@ -388,33 +390,32 @@
     <mat-card #attachmentsSection *ngIf="showAttachments">
       <mat-card-content>
         <mat-grid-list [cols]="attachmentAreaCols" gutterSize="5px">
-          <mat-grid-tile
-            *ngFor="let att of mailObj.attachments; let i=index"
-            (click)="openAttachment(att)"
-            style="max-width: 150px">
-            <mat-grid-tile-header>
-              <span class="string-ellipsis">{{att.sizeDisplay}}</span>
-            </mat-grid-tile-header>
-              <ng-container *ngIf="!att.internal || !(mailContentHTML && showHTML && SUPPORTS_IFRAME_SANDBOX)">
-                <ng-container *ngIf="att.thumbnailURL; else attachment_icon">
-                  <img  matListAvatar
-                    [src]="att.thumbnailURL" />
-                </ng-container>
-                <ng-template #attachment_icon>
-                  <mat-icon class="icon-bigger" matListAvatar svgIcon="{{attachmentIconFromContentType(att.contentType)}}"></mat-icon>
-                </ng-template>
-                <mat-grid-tile-footer style="display: flex; text-align: center; justify-content: space-between;">
-                    <span class="string-ellipsis">{{att.filename}}</span>
-                    <button mat-icon-button *ngIf="att.filename==='encrypted.asc'"
-                      matTooltip="Decrypt message"
-                      (click)="decryptAttachment(i);$event.stopPropagation()"
-                    ><mat-icon svgIcon="lock-open"></mat-icon></button>
-                    <button mat-icon-button
-                      (click)="downloadAttachmentFromServer(i);$event.stopPropagation()"
-                    ><mat-icon svgIcon="cloud-download"></mat-icon></button>
-                </mat-grid-tile-footer>
+          <ng-container *ngFor="let att of mailObj.attachments; let i=index">
+            <mat-grid-tile
+              *ngIf="!att.internal || !(mailContentHTML && showHTML && SUPPORTS_IFRAME_SANDBOX)"
+              (click)="openAttachment(att)"
+              style="max-width: 150px">
+              <mat-grid-tile-header>
+                <span class="string-ellipsis">{{att.sizeDisplay}}</span>
+              </mat-grid-tile-header>
+              <ng-container *ngIf="att.thumbnailURL; else attachment_icon">
+                <img matListAvatar [src]="att.thumbnailURL" />
               </ng-container>
-          </mat-grid-tile>
+              <ng-template #attachment_icon>
+                <mat-icon class="icon-bigger" matListAvatar svgIcon="{{attachmentIconFromContentType(att.contentType)}}"></mat-icon>
+              </ng-template>
+              <mat-grid-tile-footer style="display: flex; text-align: center; justify-content: space-between;">
+                <span class="string-ellipsis">{{att.filename}}</span>
+                <button mat-icon-button *ngIf="att.filename==='encrypted.asc'"
+                  matTooltip="Decrypt message"
+                  (click)="decryptAttachment(i);$event.stopPropagation()"
+                ><mat-icon svgIcon="lock-open"></mat-icon></button>
+                <button mat-icon-button
+                  (click)="downloadAttachmentFromServer(i);$event.stopPropagation()"
+                ><mat-icon svgIcon="cloud-download"></mat-icon></button>
+              </mat-grid-tile-footer>
+            </mat-grid-tile>
+          </ng-container>
         </mat-grid-list>
 
       </mat-card-content>

--- a/src/app/mailviewer/singlemailviewer.component.spec.ts
+++ b/src/app/mailviewer/singlemailviewer.component.spec.ts
@@ -31,6 +31,7 @@ import { MatGridListModule } from '@angular/material/grid-list';
 import { MatIcon, MatIconModule } from '@angular/material/icon';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { MatLegacyMenuModule as MatMenuModule } from '@angular/material/legacy-menu';
+import { MatLegacyListModule as MatListModule } from '@angular/material/legacy-list';
 import { MatLegacyRadioModule as MatRadioModule } from '@angular/material/legacy-radio';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatLegacyTooltipModule as MatTooltipModule } from '@angular/material/legacy-tooltip';
@@ -100,6 +101,7 @@ describe('SingleMailViewerComponent', () => {
         MatButtonModule,
         MatRadioModule,
         MatMenuModule,
+        MatListModule,
         MatCardModule,
         MatDialogModule,
         ResizerModule,
@@ -230,6 +232,88 @@ describe('SingleMailViewerComponent', () => {
 
       expect(component.mailObj.attachments[1].downloadURL.indexOf('blob:')).toBe(0);
     }));
+
+  describe('attachment display', () => {
+    function showMixedAttachments() {
+      const html = '<p>Message</p><img src="cid:first"><img src="cid:second">';
+      spyOn(TestBed.inject(RunboxWebmailAPI), 'getMessageContents').and.returnValue(of(
+        Object.assign(new MessageContents(), {
+          headers: {
+            from: { value: [{ address: 'test@example.com', name: 'Test' }] },
+            date: '2026-07-03T08:43:31.000Z',
+            subject: 'Inline images and downloadable attachments'
+          },
+          text: { text: 'Message', html, textAsHtml: '<p>Message</p>' },
+          sanitized_html: html,
+          sanitized_html_without_images: html,
+          attachments: [
+            { cid: 'first', filename: '', contentType: 'image/png', size: 512 },
+            { filename: 'report.pdf', contentType: 'application/pdf', size: 2048 },
+            { cid: 'second', filename: 'logo.png', contentType: 'image/png', size: 1024 },
+            { filename: 'encrypted.asc', contentType: 'application/pgp-encrypted', size: 4096 }
+          ]
+        })
+      ));
+      component.messageId = 22;
+      component.showHTML = true;
+      component.SUPPORTS_IFRAME_SANDBOX = true;
+      fixture.detectChanges();
+      tick(1);
+      fixture.detectChanges();
+    }
+
+    it('omits inline image rows and tiles from mixed HTML attachments', fakeAsync(() => {
+      showMixedAttachments();
+
+      // #1991: hiding only the contents leaves clickable blank rows and size-only tiles.
+      expect(component.mailObj.attachments.map(att => att.internal)).toEqual([true, false, true, false]);
+      const rows = fixture.nativeElement.querySelectorAll('#attachmentsListHeader mat-list-item');
+      const tiles = fixture.nativeElement.querySelectorAll('mat-grid-tile');
+      expect(rows.length).toBe(2);
+      expect(tiles.length).toBe(2);
+      expect(Array.from(rows).map((row: HTMLElement) => row.textContent)).toEqual([
+        jasmine.stringMatching(/report\.pdf/), jasmine.stringMatching(/encrypted\.asc/)
+      ]);
+      expect(Array.from(tiles).map((tile: HTMLElement) => tile.textContent)).toEqual([
+        jasmine.stringMatching(/report\.pdf/), jasmine.stringMatching(/encrypted\.asc/)
+      ]);
+      flush();
+    }));
+
+    it('keeps attachment actions tied to original MIME attachment indices', fakeAsync(() => {
+      showMixedAttachments();
+      const open = spyOn(component, 'openAttachment');
+      const download = spyOn(component, 'downloadAttachmentFromServer');
+      const decrypt = spyOn(component, 'decryptAttachment');
+      const rows = fixture.nativeElement.querySelectorAll('#attachmentsListHeader mat-list-item');
+      const tiles = fixture.nativeElement.querySelectorAll('mat-grid-tile');
+
+      rows[0].click();
+      expect(open).toHaveBeenCalledWith(component.mailObj.attachments[1]);
+      const reportTile = Array.from(tiles).find((tile: HTMLElement) => tile.textContent.includes('report.pdf')) as HTMLElement;
+      reportTile.querySelector('button').click();
+      expect(download).toHaveBeenCalledWith(1);
+      const encryptedTile = Array.from(tiles).find((tile: HTMLElement) => tile.textContent.includes('encrypted.asc')) as HTMLElement;
+      const encryptedButtons = encryptedTile.querySelectorAll('button');
+      encryptedButtons[0].click();
+      encryptedButtons[1].click();
+      expect(decrypt).toHaveBeenCalledWith(3);
+      expect(download).toHaveBeenCalledWith(3);
+      flush();
+    }));
+
+    it('keeps inline images available when viewing plain text or without an HTML sandbox', fakeAsync(() => {
+      showMixedAttachments();
+      for (const [showHTML, sandbox] of [[false, true], [true, false]]) {
+        component.showHTML = showHTML;
+        component.SUPPORTS_IFRAME_SANDBOX = sandbox;
+        fixture.detectChanges();
+        expect(fixture.nativeElement.querySelectorAll('#attachmentsListHeader mat-list-item').length).toBe(4);
+        expect(fixture.nativeElement.querySelectorAll('mat-grid-tile').length).toBe(4);
+      }
+      flush();
+    }));
+  });
 
   describe('mailto: link interceptor', () => {
     let messageContentsElement: HTMLElement;


### PR DESCRIPTION
Mixed HTML messages containing inline images and normal files currently create blank, clickable attachment rows and size-only grid tiles. Move the existing inline-image visibility condition onto each whole row and tile, while preserving original MIME indices for download and decryption.

- Add rendered-template regressions for the mixed attachment case, click targets, and plain-text/non-sandbox controls.
- Keep MIME classification and existing tooltip behavior unchanged.
- Document attachment visibility in the README.

Closes #1991.

Duplicate review: historical #1017/#1069 introduced inline-image handling; #1697 corrected the aggregate visible count. Neither removes the empty per-item containers. Open #1985 adds attachment tooltips/aria labels and addresses a separate issue.

Validation:
- On unpatched master: focused Firefox suite **2 failed, 9 passed**.
- With this patch: **11 focused tests passed**.
- Full `npm run ci-tests`: **passed, exit 0** — lint/policy, **260 unit tests**, **74 Cypress tests**, and production build.
- An initial unrelated canvas-selection failure reproduced on unchanged master, then the full suite passed on rerun without unrelated edits. Existing suite warnings remain.
- Local fixture data and real Angular rendering/attachment processing were used; no production mailbox was accessed. Node 16.20.2, Firefox 155; temporary external launcher works around a macOS 27 Firefox startup issue.

Tests are in a separate cherry-pickable commit: `8f5b736d`; template fix: `1c4fd52c`.

AI disclosure: This contribution was prepared and submitted by Codex with the user's explicit authorization. GPT-6 and companion agents investigated duplicates, reproduced the bug, wrote the regression tests/template change/documentation, and reviewed/validated the result. Harness: Codex desktop; installed Codex CLI reports 0.153.4, while desktop version is unknown. No manual human review, authorship or testing is claimed.

<details>
<summary>Local configured plugin inventory (including disabled entries)</summary>

This lists every plugin entry in the local Codex configuration. Enabled/disabled states are included rather than implying that every configured plugin participated in this change. Only the contribution tools described above were used for this patch.

- `build-ios-apps@openai-curated` — enabled
- `build-web-apps@openai-curated` — enabled
- `coderabbit@openai-curated` — enabled
- `documents@openai-primary-runtime` — enabled
- `presentations@openai-primary-runtime` — enabled
- `spreadsheets@openai-primary-runtime` — enabled
- `test-android-apps@openai-curated` — enabled
- `caveman@caveman-repo` — enabled
- `frontend-design@claude-plugins-official` — enabled
- `security-guidance@claude-plugins-official` — enabled
- `superpowers@claude-plugins-official` — enabled
- `compound-engineering@compound-engineering-plugin` — enabled
- `github@openai-curated` — enabled
- `figma@openai-curated` — enabled
- `codex-security@openai-curated` — enabled
- `pdf@openai-primary-runtime` — enabled
- `template-creator@openai-primary-runtime` — enabled
- `computer-use@openai-bundled` — enabled
- `visualize@openai-bundled` — enabled
- `browser@openai-bundled` — enabled
- `claude-seo@agricidaniel-seo` — enabled
- `code-review@claude-plugins-official` — enabled
- `coderabbit@claude-plugins-official` — enabled
- `skill-creator@claude-plugins-official` — enabled
- `cloudflare@cloudflare` — enabled
- `context-mode@context-mode` — enabled
- `evals-skills@hamelsmu-evals-skills` — enabled
- `andrej-karpathy-skills@karpathy-skills` — enabled
- `last30days@last30days-skill` — enabled
- `marketing-skills@marketingskills` — enabled
- `qmd@qmd` — enabled
- `ui-ux-pro-max@ui-ux-pro-max-skill` — enabled
- `adspirer-ads-agent@claude-cowork` — enabled
- `anthropic-skills@claude-cowork` — enabled
- `brand-voice@claude-cowork` — enabled
- `cowork-plugin-management@claude-cowork` — enabled
- `data@claude-cowork` — enabled
- `design@claude-cowork` — enabled
- `engineering@claude-cowork` — enabled
- `enterprise-search@claude-cowork` — enabled
- `figma@claude-cowork` — enabled
- `legal@claude-cowork` — enabled
- `marketing@claude-cowork` — enabled
- `miro@claude-cowork` — enabled
- `operations@claude-cowork` — enabled
- `pdf-viewer@claude-cowork` — enabled
- `postiz@claude-cowork` — enabled
- `product-management@claude-cowork` — enabled
- `productivity@claude-cowork` — enabled
- `sales@claude-cowork` — enabled
- `searchfit-seo@claude-cowork` — enabled
- `small-business@claude-cowork` — enabled
- `apollo@claude-cowork` — enabled
- `bio-research@claude-cowork` — enabled
- `common-room@claude-cowork` — enabled
- `customer-support@claude-cowork` — enabled
- `finance@claude-cowork` — enabled
- `human-resources@claude-cowork` — enabled
- `slack-by-salesforce@claude-cowork` — enabled
- `chrome@openai-bundled` — enabled
- `linkedin-copy-system@personal` — enabled
- `hostinger@claude-plugins-official` — enabled
- `record-and-replay@openai-bundled` — enabled
- `codex-app-tools@openai-bundled` — enabled
- `sites@openai-bundled` — enabled

</details>
