### PR TITLE
Create local search index when no server index exists

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -130,7 +130,7 @@
               "src/assets",
               {
                 "glob": "xapianasm*",
-                "input": "node_modules/runbox-searchindex/",
+                "input": "node_modules/@runboxcom/runbox-searchindex/",
                 "output": "/"
               },
               "src/manifest.json"

--- a/src/app/xapian/empty-index.spec.ts
+++ b/src/app/xapian/empty-index.spec.ts
@@ -29,9 +29,10 @@ describe('SearchService without a server index', () => {
   let directory: string;
   let databaseOpen: boolean;
 
+  // Allow for loading and compiling the real WASM module under coverage instrumentation.
   beforeAll(async () => {
     await firstValueFrom(xapianLoadedSubject);
-  });
+  }, 30000);
 
   beforeEach(() => {
     directory = '/empty-index-' + Math.random().toString(36).slice(2);

--- a/src/app/xapian/empty-index.spec.ts
+++ b/src/app/xapian/empty-index.spec.ts
@@ -1,0 +1,101 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2018 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { firstValueFrom, of } from 'rxjs';
+import { SearchService, XAPIAN_GLASS_WR } from './searchservice';
+import { XapianAPI } from '@runboxcom/runbox-searchindex';
+import { xapianLoadedSubject } from './xapianwebloader';
+
+declare const FS;
+
+describe('SearchService without a server index', () => {
+  let service: SearchService;
+  let directory: string;
+  let databaseOpen: boolean;
+
+  beforeAll(async () => {
+    await firstValueFrom(xapianLoadedSubject);
+  });
+
+  beforeEach(() => {
+    directory = '/empty-index-' + Math.random().toString(36).slice(2);
+    FS.mkdir(directory);
+    FS.chdir(directory);
+    databaseOpen = false;
+    // Exercise the real database without starting unrelated constructor subscriptions.
+    service = Object.create(SearchService.prototype);
+    Object.assign(service, {
+      api: new XapianAPI(),
+      initSubject: of(false),
+      localSearchActivated: false,
+      stopIndexDownloadingInProgress: false,
+      indexWorker: { postMessage: jasmine.createSpy('postMessage') },
+      messagelistservice: { refreshFolderList: jasmine.createSpy('refreshFolderList') }
+    });
+    spyOn(service, 'init').and.stub();
+    spyOn(service, 'checkIfDownloadableIndexExists').and.returnValue(of(false));
+  });
+
+  afterEach(() => {
+    if (databaseOpen) {
+      service.api.closeXapianDatabase();
+    }
+    FS.chdir('/');
+    if (FS.analyzePath(directory + '/' + XAPIAN_GLASS_WR).exists) {
+      FS.readdir(directory + '/' + XAPIAN_GLASS_WR)
+        .filter(name => name !== '.' && name !== '..')
+        .forEach(name => FS.unlink(directory + '/' + XAPIAN_GLASS_WR + '/' + name));
+      FS.rmdir(directory + '/' + XAPIAN_GLASS_WR);
+    }
+    FS.rmdir(directory);
+  });
+
+  it('creates a readable empty index that accepts the first message on worker reopen', async () => {
+    const available = await firstValueFrom(service.downloadIndexFromServer());
+    expect(available).toBeTrue();
+    if (!available) {
+      return;
+    }
+    databaseOpen = true;
+    expect(service.localSearchActivated).toBeTrue();
+    expect(service.indexLastUpdateTime).toBe(0);
+    expect(service.stopIndexDownloadingInProgress).toBeFalse();
+    expect(service.api.getXapianDocCount()).toBe(0);
+    // Empty Xapian databases have no document-data file until their first document commit.
+    expect(FS.analyzePath(XAPIAN_GLASS_WR + '/docdata.glass').exists).toBeFalse();
+    service.api.closeXapianDatabase();
+    service.api.initXapianIndex(XAPIAN_GLASS_WR);
+    service.api.addSortableEmailToXapianIndex('Q1', 'Sender', 'SENDER', 'sender@example.com',
+      ['recipient@example.com'], 'Welcome', 'WELCOME', '20260908090000', 100,
+      'Synthetic welcome message', 'Inbox', false, false, false, false);
+    service.api.commitXapianUpdates();
+    service.api.closeXapianDatabase();
+    service.api.initXapianIndexReadOnly(XAPIAN_GLASS_WR);
+    expect(service.api.getXapianDocCount()).toBe(1);
+    expect(service.api.getDocumentData(1)).toContain('Q1');
+    expect(service.api.getDocumentData(1)).toContain('Welcome');
+  });
+
+  it('does not create an index after cancellation', async () => {
+    service.stopIndexDownloadingInProgress = true;
+    expect(await firstValueFrom(service.downloadIndexFromServer())).toBeFalse();
+    expect(service.localSearchActivated).toBeFalse();
+    expect(FS.analyzePath(XAPIAN_GLASS_WR).exists).toBeFalse();
+  });
+});

--- a/src/app/xapian/index.worker.ts
+++ b/src/app/xapian/index.worker.ts
@@ -184,7 +184,7 @@ class SearchIndexService {
           FS.mount(IDBFS, {}, this.partitionsdir);
 
           try {
-            console.log('Worker: Last index timestamp ', FS.stat('xapianglasswr/docdata.glass').mtime);
+            console.log('Worker: Last index timestamp ', FS.stat('xapianglasswr/iamglass').mtime);
 
             this.openStoredMainPartition();
 

--- a/src/app/xapian/searchservice.ts
+++ b/src/app/xapian/searchservice.ts
@@ -352,7 +352,7 @@ export class SearchService {
 
           try {
             // just fyi, we don't need this for reading
-            console.log('Last index timestamp ', FS.stat('xapianglasswr/docdata.glass').mtime);
+            console.log('Last index timestamp ', FS.stat('xapianglasswr/iamglass').mtime);
 
             this.openStoredMainPartition();
 
@@ -509,13 +509,25 @@ export class SearchService {
         mergeMap(() => this.checkIfDownloadableIndexExists()),
         mergeMap((res) => new Observable<boolean>( (observer) => {
         if (!res) {
-          this.localSearchActivated = false;
-          this.indexLastUpdateTime = 0;
-          this.indexDownloadingInProgress = false;
-          // restart updates
-          this.indexWorker.postMessage({'action': PostMessageAction.updateIndexWithNewChanges });
-          this.stopIndexDownloadingInProgress = true;
-          observer.next(false);
+          if (this.stopIndexDownloadingInProgress) {
+            observer.next(false);
+            observer.complete();
+            return;
+          }
+          // A new account can have mail before its server index is generated.
+          // Start an empty database so the worker can populate it from message history.
+          if (!this.localSearchActivated) {
+            this.api.initXapianIndex(XAPIAN_GLASS_WR);
+            this.api.commitXapianUpdates();
+            this.api.closeXapianDatabase();
+            this.openStoredMainPartition();
+            this.indexLastUpdateTime = 0;
+          }
+          this.localSearchActivated = true;
+          this.downloadProgress = null;
+          this.messagelistservice.refreshFolderList();
+          observer.next(true);
+          observer.complete();
           return;
         }
 


### PR DESCRIPTION
When a new account has no downloadable server index, accepting local synchronization currently returns failure. This creates an empty local index and continues the normal partition/worker handoff so message history can populate it.

Both startup paths inspect `iamglass` instead of requiring `docdata.glass`, which Xapian creates only when the first document is committed. Cancellation avoids creating an index, and an already active index is preserved.

Relates to #1485 and the reverted #1591. In addition to handling the missing document-data file, the fallback emits success and completes, allowing the normal synchronization subscriber to proceed.

Validation:
- Regression tests against upstream: the empty-index test fails as expected; cancellation passes.
- Same tests against the patch: both pass in Firefox 140 with the actual locked Xapian 0.2.4 WASM library. The test commits are separate from implementation.
- Lint and policy phases pass with existing warnings.
- Full unit run: 258 pass, 1 fail, 2 skipped. Unchanged upstream under the same container conditions: 256 pass, 1 fail, 2 skipped. Both fail `RBWebMail should cache message contents` because the expected `/rest/v1/email/123` request is absent. The full `npm run ci-tests` command therefore remains red; this PR is a draft.
- All 74 Cypress end-to-end tests pass. The production build passes.
- A separate Node worker/WASM probe confirms an existing empty reader can see its first worker-written document after file transfer and `reloadXapianDatabase()`. This is not a live-account or IndexedDB integration test.

AI disclosure: OpenAI Codex (GPT-6-based agent, Codex desktop harness; exact model revision and harness version unavailable) generated the implementation, tests, and this description and operated validation using Git, GitHub CLI, Docker, npm, Firefox and Cypress. No independent human review has been performed. No plugin-specific workflow was used for implementation or testing; a complete installed-plugin inventory was not available to report. Validation used restricted non-root containers without host folder mounts or credentials; network was enabled for the existing public-image fixture tests. No production account was tested.

Please consider this urgent issue's fix under the published feature/bug bounty program if eligible. If awarded, can payment be arranged through PayPal with details exchanged privately?
