### PR TITLE
fix(toolbar): describe icons during touch exploration

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,19 @@ You can run the individual tests using one of the following commands:
 Or run them all at once with `npm run ci-tests` -- this option will run the tests with the same settings as our CI setup,
 making sure that any errors will be caught before your code becomes public.
 
+### Touch descriptions in action toolbars
+
+On a touch screen, hold an icon for half a second to reveal its description, then slide across
+nearby icons to read theirs. Releasing the finger does not run an action; a separate tap does.
+This applies to header navigation, the mail and message toolbars, draft controls and mobile
+message-action buttons. Moving before the hold begins keeps the normal scrolling gesture.
+
+To verify locally, start the mock backend and app using the commands above. In a mobile browser
+or browser touch emulation, hold a header link, slide to another link, and release: the route
+must remain unchanged. A subsequent tap should navigate. Repeat with a message action or menu
+button; holding must not execute the action or open the menu. Ordinary mouse and keyboard
+activation should still work.
+
 ## Further help
 
 To get more help on the Angular CLI use `npx ng help` or go check out the [Angular CLI README](https://github.com/angular/angular-cli/blob/master/README.md).

--- a/e2e/cypress/integration/touch-toolbar.ts
+++ b/e2e/cypress/integration/touch-toolbar.ts
@@ -1,0 +1,198 @@
+/// <reference types="cypress" />
+
+describe('Exploring toolbar descriptions with native touch', () => {
+    interface Point { x: number; y: number; }
+    type TouchPhase = 'touchStart' | 'touchMove' | 'touchEnd' | 'touchCancel';
+    let touching = false;
+    const touchListeners: (() => void)[] = [];
+
+    function protocol(command: string, params: Record<string, unknown>) {
+        return Cypress.automation('remote:debugger:protocol', { command, params });
+    }
+
+    function sendTouch(type: TouchPhase, point?: Point) {
+        return protocol('Input.dispatchTouchEvent', {
+            type,
+            touchPoints: point ? [{ x: point.x, y: point.y, id: 1, radiusX: 1, radiusY: 1, force: 1 }] : []
+        }).then(() => { touching = !!point; });
+    }
+
+    function pointOn(selector: string) {
+        let stableElement: HTMLElement | undefined;
+        let stableBounds: DOMRect | undefined;
+        let stableSince = 0;
+        return cy.get<HTMLElement>(selector).should('be.visible').should(elements => {
+            expect(elements.length, 'one native touch target').to.equal(1);
+            const element = elements[0];
+            const bounds = element.getBoundingClientRect();
+            const now = performance.now();
+            // The viewer animates its layout for 200 ms; measure only after a quiet interval.
+            if (element !== stableElement || !stableBounds ||
+                Math.abs(bounds.left - stableBounds.left) > 0.25 ||
+                Math.abs(bounds.top - stableBounds.top) > 0.25 ||
+                Math.abs(bounds.width - stableBounds.width) > 0.25 ||
+                Math.abs(bounds.height - stableBounds.height) > 0.25) {
+                stableElement = element;
+                stableBounds = bounds;
+                stableSince = now;
+            }
+            expect(now - stableSince, 'native touch target bounds have settled for 250 ms').to.be.at.least(250);
+        }).then(elements => {
+            const element = elements[0];
+            const bounds = element.getBoundingClientRect();
+            const localX = bounds.left + bounds.width / 2;
+            const localY = bounds.top + bounds.height / 2;
+            expect(element.contains(element.ownerDocument.elementFromPoint(localX, localY)),
+                'native touch target is not covered').to.equal(true);
+
+            // Cypress 12 owns this runner iframe; the cross-origin AUT's frameElement is null.
+            const runner = Cypress as typeof Cypress & { $autIframe?: JQuery<HTMLIFrameElement> };
+            expect(runner.$autIframe?.length, 'one Cypress AUT iframe').to.equal(1);
+            const frame = runner.$autIframe?.[0];
+            if (!frame) { throw new Error('Cypress did not expose its AUT iframe'); }
+            expect(frame.contentWindow === element.ownerDocument.defaultView,
+                'iframe belongs to the selected AUT document').to.equal(true);
+            const frameBounds = frame.getBoundingClientRect();
+            const view = frame.ownerDocument.defaultView;
+            if (!view) { throw new Error('The Cypress iframe has no runner window'); }
+            expect(frame.offsetWidth, 'unscaled iframe width').to.be.greaterThan(0);
+            expect(frame.offsetHeight, 'unscaled iframe height').to.be.greaterThan(0);
+            const x = frameBounds.left + (localX + frame.clientLeft) * frameBounds.width / frame.offsetWidth;
+            const y = frameBounds.top + (localY + frame.clientTop) * frameBounds.height / frame.offsetHeight;
+            expect(x, 'touch x is inside the runner viewport').to.be.within(0, view.innerWidth);
+            expect(y, 'touch y is inside the runner viewport').to.be.within(0, view.innerHeight);
+            expect(frame.ownerDocument.elementFromPoint(x, y) === frame,
+                'native input reaches the AUT iframe').to.equal(true);
+            return { x, y, target: element };
+        });
+    }
+
+    function startTouch(selector: string) {
+        let received: TouchEvent | undefined;
+        let control: Element | undefined;
+        const observe = (event: Event) => { received = event as TouchEvent; };
+        return pointOn(selector).then(point => {
+            control = point.target.closest('a, button, [role="button"]') || point.target;
+            control.addEventListener('touchstart', observe, { capture: true, once: true });
+            touchListeners.push(() => control?.removeEventListener('touchstart', observe, true));
+            return sendTouch('touchStart', point);
+        }).should(() => {
+            expect(received?.isTrusted, `trusted touchstart reaches ${selector}`).to.equal(true);
+            expect(control?.contains(received?.target as Node), 'touchstart targets the intended AUT control').to.equal(true);
+        });
+    }
+
+    function tap(selector: string) {
+        return startTouch(selector).then(() => Cypress.Promise.delay(50)).then(() => sendTouch('touchEnd'));
+    }
+
+    function navigationDescription(selector: string, visible: boolean) {
+        return cy.get<HTMLElement>(`${selector} .mainMenuDesc`).should(elements => {
+            const label = elements[0];
+            const bounds = label.getBoundingClientRect();
+            const toolbarElement = label.closest('mat-toolbar');
+            if (!toolbarElement) { throw new Error('The navigation description has no toolbar'); }
+            const toolbar = toolbarElement.getBoundingClientRect();
+            const hit = label.ownerDocument.elementFromPoint(
+                bounds.left + bounds.width / 2, bounds.top + bounds.height / 2);
+            const exposed = bounds.top >= toolbar.top && bounds.bottom <= toolbar.bottom && label.contains(hit);
+            expect(exposed, `${label.textContent?.trim()} description is exposed in the toolbar`).to.equal(visible);
+        });
+    }
+
+    function visit(path: string) {
+        cy.visit(path, {
+            onBeforeLoad(win) {
+                win.localStorage.setItem('221:localSearchPromptDisplayed', JSON.stringify('true'));
+                win.localStorage.setItem('221:Global:messageSubjectDragTipShown', JSON.stringify('true'));
+                win.localStorage.setItem('221:Desktop:mailViewerOnRightSide', JSON.stringify('true'));
+                win.localStorage.setItem('221:preference_keys',
+                    '["Global:messageSubjectDragTipShown", "Desktop:mailViewerOnRightSide"]');
+            }
+        });
+    }
+
+    before(() => {
+        expect(Cypress.browser.family,
+            'native touch acceptance requires Chromium (including the default Electron browser)').to.equal('chromium');
+    });
+
+    beforeEach(() => {
+        cy.viewport(1920, 1080);
+        cy.then(() => protocol('Emulation.setTouchEmulationEnabled', { enabled: true, maxTouchPoints: 1 }));
+    });
+
+    afterEach(() => {
+        cy.then(() => {
+            touchListeners.splice(0).forEach(remove => remove());
+            const release = touching ? sendTouch('touchCancel') : Cypress.Promise.resolve();
+            return release.then(() => protocol('Emulation.setTouchEmulationEnabled', { enabled: false }));
+        });
+    });
+
+    it('holds and slides across header descriptions without navigating, then accepts a normal tap', () => {
+        const contacts = '#mainMenuContainer a[routerlink="/contacts"]';
+        const calendar = '#mainMenuContainer a[routerlink="/calendar"]';
+        visit('/');
+        cy.location('pathname').should('equal', '/');
+
+        startTouch(`${contacts} mat-icon`);
+        cy.wait(550);
+        navigationDescription(contacts, true);
+        pointOn(`${calendar} mat-icon`).then(point => sendTouch('touchMove', point));
+        navigationDescription(calendar, true);
+        navigationDescription(contacts, false);
+        cy.location('pathname').should('equal', '/');
+        cy.then(() => sendTouch('touchEnd'));
+        navigationDescription(calendar, false);
+
+        // Include Chromium's delayed compatibility-click window before asserting no action.
+        cy.wait(350);
+        cy.location('pathname').should('equal', '/');
+        tap(`${contacts} mat-icon`);
+        cy.location('pathname').should('equal', '/contacts');
+        cy.contains('Runbox 7 Contacts').should('be.visible');
+    });
+
+    it('describes Reply on hold without composing, then replies on a normal tap', () => {
+        const reply = 'single-mail-viewer button[mattooltip="Reply"]';
+        visit('/#Inbox:11');
+        cy.get('#messageHeaderSubject').should('contain', 'No \'To\', just \'CC\'');
+        cy.hash().should('equal', '#Inbox:11');
+
+        startTouch(reply);
+        cy.get('.mat-tooltip-show').should('be.visible').and('have.text', 'Reply');
+        cy.location('pathname').should('equal', '/');
+        cy.then(() => sendTouch('touchEnd'));
+        cy.get('.mat-tooltip-show').should('not.exist');
+        cy.wait(350);
+        cy.location('pathname').should('equal', '/');
+        cy.hash().should('equal', '#Inbox:11');
+
+        tap(reply);
+        cy.location('pathname').should('equal', '/compose');
+        cy.get('mat-card-actions div').should('contain', 'Re: No \'To\', just \'CC\'');
+    });
+
+    it('describes the mobile attachment button without opening its picker until a normal tap', () => {
+        cy.viewport('iphone-6');
+        visit('/compose?new=true');
+        cy.get('#attachMobile').should('be.visible').scrollIntoView();
+        cy.get('#attachMobile').closest('mat-card').find<HTMLInputElement>('input[type="file"]').then(inputs => {
+            expect(inputs.length, 'one file input for the editing draft').to.equal(1);
+            cy.stub(inputs[0], 'click').as('chooseFiles');
+        });
+
+        startTouch('#attachMobile');
+        cy.get('.mat-tooltip-show').should('be.visible').and('have.text', 'Attach files');
+        cy.get('@chooseFiles').should('not.have.been.called');
+        cy.then(() => sendTouch('touchEnd'));
+        cy.get('.mat-tooltip-show').should('not.exist');
+        cy.wait(350);
+        cy.get('@chooseFiles').should('not.have.been.called');
+
+        tap('#attachMobile');
+        cy.get('@chooseFiles').should('have.been.calledOnce');
+        cy.location('pathname').should('equal', '/compose');
+    });
+});

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -189,7 +189,7 @@
       </div>
   </mat-sidenav>
   <div id="mailMenuContainer">
-    <mat-toolbar id="mailMenu" style="display: flex">
+    <mat-toolbar appTouchDescriptions id="mailMenu" style="display: flex">
       <button mat-icon-button (click)="sidemenu.toggle();" matTooltip="Toggle folder pane" id="toggleFolderPaneIcon">
 	    <mat-icon svgIcon="menu"></mat-icon>
       </button>
@@ -426,7 +426,7 @@
   </div>
 
   <!-- Message action floating menu for mobile screens -->
-  <div class="contextToolButtonsMobile" *ngIf="mobileQuery.matches && !hasChildRouterOutlet && showSelectOperations && !showSelectMarkOpMenu">
+  <div appTouchDescriptions class="contextToolButtonsMobile" *ngIf="mobileQuery.matches && !hasChildRouterOutlet && showSelectOperations && !showSelectMarkOpMenu">
     <button mat-fab matTooltip="Move&nbsp;to&nbsp;folder" matTooltipPosition="left" (click)="moveToFolder()">
       <mat-icon svgIcon="folder"></mat-icon>
     </button>
@@ -455,7 +455,7 @@
   </div>
   
   <!-- Message action floating submenu for mobile screens -->
-  <div class="contextToolButtonsMobile" *ngIf="mobileQuery.matches && !hasChildRouterOutlet && showSelectOperations && showSelectMarkOpMenu">
+  <div appTouchDescriptions class="contextToolButtonsMobile" *ngIf="mobileQuery.matches && !hasChildRouterOutlet && showSelectOperations && showSelectMarkOpMenu">
     <button mat-fab matTooltip="Mark unread" matTooltipPosition="left" (click)="setReadStatus(false)">
       <mat-icon svgIcon="email-mark-as-unread"></mat-icon>
     </button>

--- a/src/app/common/common.module.ts
+++ b/src/app/common/common.module.ts
@@ -27,6 +27,7 @@ import { RunboxContactSupportSnackBar, RunboxContactSupportSnackBarContent } fro
 import { RunboxLoadingComponent } from './loading.component';
 import { BackgroundActivityIndicatorComponent } from './background-activity-indicator.component';
 import { UsageReportsService } from './usage-reports.service';
+import { TouchDescriptionDirective, TouchDescriptionsDirective } from '../directives/touch-descriptions.directive';
 
 @NgModule({
     imports: [
@@ -35,12 +36,16 @@ import { UsageReportsService } from './usage-reports.service';
         MatProgressSpinnerModule,
     ],
     declarations: [
+        TouchDescriptionDirective,
+        TouchDescriptionsDirective,
         BackgroundActivityIndicatorComponent,
         RunboxContactSupportComponent,
         RunboxContactSupportSnackBarContent,
         RunboxLoadingComponent,
     ],
     exports: [
+        TouchDescriptionDirective,
+        TouchDescriptionsDirective,
         BackgroundActivityIndicatorComponent,
         RunboxContactSupportComponent,
         RunboxLoadingComponent,

--- a/src/app/compose/compose.component.html
+++ b/src/app/compose/compose.component.html
@@ -3,7 +3,7 @@
         <div class="draft-title">
             {{model.subject ? model.subject : "New message"}}
         </div>
-        <div class="draft-buttons">
+        <div class="draft-buttons" appTouchDescriptions>
 	    <mat-checkbox *ngIf="editing" formControlName="useHTML" (change)="htmlToggled()" id="useHTML" matTooltip="Use HTML (rich text)">HTML</mat-checkbox>
             <button *ngIf="editing" mat-icon-button matTooltip="Attach files" id="attachDesktop" (click)="attachFilesClicked()">
                 <mat-icon svgIcon="attachment" style="transform: rotate(90deg)"></mat-icon>
@@ -136,7 +136,7 @@
         </span>
 
         <div [hidden]="!editing">
-            <div class="draft-buttons">
+            <div class="draft-buttons" appTouchDescriptions>
                 <button *ngIf="editing" mat-icon-button matTooltip="Attach files" id="attachMobile" (click)="attachFilesClicked()">
                     <mat-icon svgIcon="attachment"></mat-icon>
                 </button>

--- a/src/app/compose/compose.module.ts
+++ b/src/app/compose/compose.module.ts
@@ -19,6 +19,7 @@
 
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { RunboxCommonModule } from '../common/common.module';
 import { MatLegacyAutocompleteModule as MatAutocompleteModule } from '@angular/material/legacy-autocomplete';
 import { MatLegacyButtonModule as MatButtonModule } from '@angular/material/legacy-button';
 import { MatLegacyCardModule as MatCardModule } from '@angular/material/legacy-card';
@@ -43,6 +44,7 @@ export { MailRecipientInputComponent} from './mailrecipientinput.component';
 @NgModule({
   imports: [
       CommonModule,
+      RunboxCommonModule,
       MatAutocompleteModule,
       MatCheckboxModule,
       MatButtonModule,

--- a/src/app/directives/touch-descriptions.directive.spec.ts
+++ b/src/app/directives/touch-descriptions.directive.spec.ts
@@ -1,0 +1,383 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2019 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed, fakeAsync, tick, flush } from '@angular/core/testing';
+import { CommonModule } from '@angular/common';
+import { Platform } from '@angular/cdk/platform';
+import { OverlayContainer } from '@angular/cdk/overlay';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatLegacyTooltipModule as MatTooltipModule } from '@angular/material/legacy-tooltip';
+import { MatLegacyMenuModule as MatMenuModule } from '@angular/material/legacy-menu';
+import { RunboxCommonModule } from '../common/common.module';
+
+@Component({
+    template: `
+        <div appTouchDescriptions style="position: fixed; top: 20px; left: 20px; display: flex">
+            <button id="first" matTooltip="First action" (click)="actions.push('first')"
+                    style="width: 80px; height: 40px"><span>First</span></button>
+            <button id="second" matTooltip="Second action" (click)="actions.push('second')"
+                    style="width: 80px; height: 40px">Second</button>
+            <button id="nested" (click)="actions.push('nested')" style="width: 80px; height: 40px">
+                <span matTooltip="Save draft">Save</span>
+            </button>
+            <button id="menu" matTooltip="More actions" [matMenuTriggerFor]="menu">More</button>
+            <mat-menu #menu="matMenu"><button mat-menu-item>Menu option</button></mat-menu>
+            <input id="input" matTooltip="Search text" />
+            <div class="mainMenu">
+                <a id="nav" href="#contacts" (click)="$event.preventDefault(); actions.push('nav')">
+                    Contacts<p class="mainMenuDesc">Contacts</p>
+                </a>
+            </div>
+            <button *ngIf="showDynamic" id="dynamic" matTooltip="Dynamic action"
+                    (click)="actions.push('dynamic')">Dynamic</button>
+        </div>
+        <button id="outside" matTooltip="Outside action">Outside</button>
+    `
+})
+class TouchDescriptionTestComponent {
+    actions: string[] = [];
+    showDynamic = false;
+}
+
+describe('Touch toolbar descriptions (#2002)', () => {
+    let fixture: ComponentFixture<TouchDescriptionTestComponent>;
+    let overlay: OverlayContainer;
+
+    function element(id: string): HTMLElement {
+        return fixture.nativeElement.querySelector('#' + id);
+    }
+
+    function contact(id: string, identifier = 1): Touch {
+        const target = element(id);
+        const rect = target.getBoundingClientRect();
+        const clientX = rect.left + rect.width / 2;
+        const clientY = rect.top + rect.height / 2;
+        return { identifier, target, clientX, clientY, pageX: clientX, pageY: clientY,
+            screenX: clientX, screenY: clientY, force: 1, radiusX: 1, radiusY: 1, rotationAngle: 0 };
+    }
+
+    function touch(type: string, target: HTMLElement, current: Touch[], changed = current): TouchEvent {
+        const event = new Event(type, { bubbles: true, cancelable: true });
+        Object.defineProperties(event, {
+            touches: { value: current }, targetTouches: { value: current },
+            changedTouches: { value: changed }
+        });
+        target.dispatchEvent(event);
+        return event as TouchEvent;
+    }
+
+    function click(id: string, detail = 1): MouseEvent {
+        const event = new MouseEvent('click', { bubbles: true, cancelable: true, detail });
+        element(id).dispatchEvent(event);
+        return event;
+    }
+
+    function start(id = 'first'): Touch {
+        const point = contact(id);
+        touch('touchstart', element(id), [point]);
+        return point;
+    }
+
+    function settle(ms = 0) {
+        tick(ms);
+        fixture.detectChanges();
+        tick();
+        fixture.detectChanges();
+    }
+
+    function visibleDescription(): string {
+        return overlay.getContainerElement().textContent?.trim() || '';
+    }
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [CommonModule, MatTooltipModule, MatMenuModule, RunboxCommonModule, NoopAnimationsModule],
+            declarations: [TouchDescriptionTestComponent],
+            providers: [{ provide: Platform, useValue: {
+                isBrowser: true, ANDROID: true, IOS: false, FIREFOX: true,
+                SAFARI: false, WEBKIT: false, BLINK: false, EDGE: false, TRIDENT: false
+            } }]
+        });
+        fixture = TestBed.createComponent(TouchDescriptionTestComponent);
+        fixture.detectChanges();
+        overlay = TestBed.inject(OverlayContainer);
+    });
+
+    afterEach(() => {
+        if (!fixture.componentRef.hostView.destroyed) { fixture.destroy(); }
+        overlay.ngOnDestroy();
+    });
+
+    it('shows the description on hold and prevents the release click from running the action', fakeAsync(() => {
+        const point = start();
+        settle(600);
+        expect(visibleDescription()).toContain('First action');
+        touch('touchend', element('first'), [], [point]);
+        const generatedClick = click('first');
+        settle();
+        expect(fixture.componentInstance.actions).toEqual([]);
+        expect(generatedClick.defaultPrevented).toBeTrue();
+        flush();
+    }));
+
+    it('follows the finger to another description without activating either control', fakeAsync(() => {
+        start();
+        settle(600);
+        const point = contact('second');
+        touch('touchmove', element('first'), [point]);
+        settle();
+        expect(visibleDescription()).toContain('Second action');
+        expect(visibleDescription()).not.toContain('First action');
+        touch('touchend', element('first'), [], [point]);
+        click('first');
+        click('second');
+        settle();
+        expect(fixture.componentInstance.actions).toEqual([]);
+        flush();
+    }));
+
+    it('lets a later deliberate tap activate the original control', fakeAsync(() => {
+        const first = start();
+        settle(600);
+        touch('touchend', element('first'), [], [first]);
+        click('first');
+        const second = start();
+        settle(50);
+        touch('touchend', element('first'), [], [second]);
+        click('first');
+        settle();
+        expect(fixture.componentInstance.actions).toEqual(['first']);
+        flush();
+    }));
+
+    it('allows a scrolling gesture before the hold threshold without showing a description', fakeAsync(() => {
+        const point = start();
+        const moved = { ...point, clientX: point.clientX + 30 } as Touch;
+        const move = touch('touchmove', element('first'), [moved]);
+        settle(600);
+        expect(move.defaultPrevented).toBeFalse();
+        expect(visibleDescription()).toBe('');
+        expect(element('first').style.touchAction).not.toBe('none');
+        touch('touchcancel', element('first'), [], [moved]);
+        settle();
+        flush();
+    }));
+
+    it('keeps normal short taps working without showing a description', fakeAsync(() => {
+        const point = start();
+        settle(50);
+        touch('touchend', element('first'), [], [point]);
+        click('first');
+        expect(fixture.componentInstance.actions).toEqual(['first']);
+        expect(visibleDescription()).toBe('');
+        flush();
+    }));
+
+    it('suppresses a compatibility mouse sequence generated after the hold', fakeAsync(() => {
+        const point = start();
+        settle(600);
+        touch('touchend', element('first'), [], [point]);
+        element('first').dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+        element('first').dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+        click('first');
+        expect(fixture.componentInstance.actions).toEqual([]);
+        flush();
+    }));
+
+    it('allows a real mouse pointer to activate a control after a held touch', fakeAsync(() => {
+        const point = start();
+        settle(600);
+        touch('touchend', element('first'), [], [point]);
+        const pointer = new Event('pointerdown', { bubbles: true });
+        Object.defineProperty(pointer, 'pointerType', { value: 'mouse' });
+        element('second').dispatchEvent(pointer);
+        click('second');
+        expect(fixture.componentInstance.actions).toEqual(['second']);
+        flush();
+    }));
+
+    it('allows keyboard activation after exploring descriptions', fakeAsync(() => {
+        const point = start();
+        settle(600);
+        touch('touchend', element('first'), [], [point]);
+        click('second', 0);
+        expect(fixture.componentInstance.actions).toEqual(['second']);
+        flush();
+    }));
+
+    it('cancels a pending hold when a second finger lands outside the toolbar', fakeAsync(() => {
+        const point = start();
+        touch('touchstart', element('outside'), [point, contact('outside', 2)]);
+        settle(600);
+        expect(visibleDescription()).not.toContain('First action');
+        expect(visibleDescription()).toContain('Outside action');
+        flush();
+    }));
+
+    it('cancels a pending hold on touchcancel', fakeAsync(() => {
+        const point = start();
+        touch('touchcancel', element('first'), [], [point]);
+        settle(600);
+        expect(visibleDescription()).toBe('');
+        flush();
+    }));
+
+    it('reveals the existing header label without following its link', fakeAsync(() => {
+        const point = start('nav');
+        settle(600);
+        expect(element('nav').parentElement.classList).toContain('touch-description-visible');
+        touch('touchend', element('nav'), [], [point]);
+        click('nav');
+        expect(fixture.componentInstance.actions).toEqual([]);
+        expect(element('nav').parentElement.classList).not.toContain('touch-description-visible');
+        flush();
+    }));
+
+    it('uses the whole button hit area when its tooltip belongs to a child icon', fakeAsync(() => {
+        const point = start('nested');
+        settle(600);
+        expect(visibleDescription()).toContain('Save draft');
+        touch('touchend', element('nested'), [], [point]);
+        click('nested');
+        expect(fixture.componentInstance.actions).toEqual([]);
+        flush();
+    }));
+
+    it('prevents a menu trigger from opening on release and lets a subsequent tap open it', fakeAsync(() => {
+        const point = start('menu');
+        settle(600);
+        touch('touchend', element('menu'), [], [point]);
+        click('menu');
+        settle();
+        expect(overlay.getContainerElement().querySelector('[role="menu"]')).toBeNull();
+        const next = start('menu');
+        touch('touchend', element('menu'), [], [next]);
+        click('menu');
+        settle();
+        expect(overlay.getContainerElement().querySelector('[role="menu"]')).not.toBeNull();
+        flush();
+    }));
+
+    it('supports controls created and destroyed while the toolbar remains present', fakeAsync(() => {
+        fixture.componentInstance.showDynamic = true;
+        fixture.detectChanges();
+        const original = element('dynamic');
+        const point = start('dynamic');
+        settle(600);
+        expect(visibleDescription()).toContain('Dynamic action');
+        fixture.componentInstance.showDynamic = false;
+        fixture.detectChanges();
+        settle();
+        expect(visibleDescription()).not.toContain('Dynamic action');
+        touch('touchend', original, [], [point]);
+        const context = new MouseEvent('contextmenu', { bubbles: true, cancelable: true });
+        element('first').dispatchEvent(context);
+        expect(context.defaultPrevented).toBeFalse();
+        const move = touch('touchmove', element('first'), [contact('first')]);
+        expect(move.defaultPrevented).toBeFalse();
+        flush();
+    }));
+
+    it('suppresses the native context menu only during an eligible touch gesture', fakeAsync(() => {
+        const ordinary = new MouseEvent('contextmenu', { bubbles: true, cancelable: true });
+        element('nav').dispatchEvent(ordinary);
+        expect(ordinary.defaultPrevented).toBeFalse();
+        const point = start('nav');
+        const held = new MouseEvent('contextmenu', { bubbles: true, cancelable: true });
+        element('nav').dispatchEvent(held);
+        expect(held.defaultPrevented).toBeTrue();
+        touch('touchcancel', element('nav'), [], [point]);
+        flush();
+    }));
+
+    it('hides the description outside the toolbar while keeping the release inert', fakeAsync(() => {
+        start();
+        settle(600);
+        const point = { ...contact('first'), clientX: 1000, clientY: 600 } as Touch;
+        touch('touchmove', element('first'), [point]);
+        settle();
+        expect(visibleDescription()).toBe('');
+        touch('touchend', element('first'), [], [point]);
+        click('first');
+        expect(fixture.componentInstance.actions).toEqual([]);
+        flush();
+    }));
+
+    it('leaves search-input touches outside toolbar exploration', fakeAsync(() => {
+        const point = contact('input');
+        const beginning = touch('touchstart', element('input'), [point]);
+        const move = touch('touchmove', element('input'), [{ ...point, clientX: point.clientX + 30 }]);
+        expect(beginning.defaultPrevented).toBeFalse();
+        expect(move.defaultPrevented).toBeFalse();
+        touch('touchend', element('input'), [], [point]);
+        flush();
+    }));
+
+    it('cleans up a pending hold when the toolbar is destroyed', fakeAsync(() => {
+        start();
+        fixture.destroy();
+        tick(600);
+        expect(visibleDescription()).toBe('');
+        flush();
+    }));
+
+    it('cleans up a visible description when the toolbar is destroyed', fakeAsync(() => {
+        start();
+        settle(600);
+        fixture.destroy();
+        tick(600);
+        expect(visibleDescription()).toBe('');
+        flush();
+    }));
+
+    it('keeps the eventual release inert if a different preview target disappears', fakeAsync(() => {
+        fixture.componentInstance.showDynamic = true;
+        fixture.detectChanges();
+        start();
+        settle(600);
+        const point = contact('dynamic');
+        touch('touchmove', element('first'), [point]);
+        settle();
+        expect(visibleDescription()).toContain('Dynamic action');
+        fixture.componentInstance.showDynamic = false;
+        fixture.detectChanges();
+        settle(1500);
+        touch('touchend', element('first'), [], [point]);
+        click('first');
+        expect(fixture.componentInstance.actions).toEqual([]);
+        flush();
+    }));
+
+    it('cancels a pending hold when its originating control is removed', fakeAsync(() => {
+        fixture.componentInstance.showDynamic = true;
+        fixture.detectChanges();
+        const original = element('dynamic');
+        const point = start('dynamic');
+        fixture.componentInstance.showDynamic = false;
+        fixture.detectChanges();
+        touch('touchend', original, [], [point]);
+        const context = new MouseEvent('contextmenu', { bubbles: true, cancelable: true });
+        element('first').dispatchEvent(context);
+        expect(context.defaultPrevented).toBeFalse();
+        settle(600);
+        expect(visibleDescription()).toBe('');
+        flush();
+    }));
+});

--- a/src/app/directives/touch-descriptions.directive.ts
+++ b/src/app/directives/touch-descriptions.directive.ts
@@ -1,0 +1,243 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2019 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { Directive, ElementRef, Inject, NgZone, OnDestroy, OnInit, Optional, Self } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
+import { MatLegacyTooltip as MatTooltip } from '@angular/material/legacy-tooltip';
+
+@Directive({ selector: '[appTouchDescriptions]' })
+export class TouchDescriptionsDirective implements OnInit, OnDestroy {
+    private items = new Set<TouchDescriptionDirective>();
+    private removeListeners: (() => void)[] = [];
+    private gestureListeners: (() => void)[] = [];
+    private holdTimer: ReturnType<typeof setTimeout>;
+    private clickTimer: ReturnType<typeof setTimeout>;
+    private identifier: number | null = null;
+    private origin: Touch;
+    private originatingItem: TouchDescriptionDirective | null = null;
+    private current: TouchDescriptionDirective | null = null;
+    private exploring = false;
+    private suppressClick = false;
+    private navigationBounds = new Map<TouchDescriptionDirective, DOMRect>();
+
+    constructor(private element: ElementRef<HTMLElement>, private zone: NgZone,
+                @Inject(DOCUMENT) private document: Document) {}
+
+    ngOnInit() {
+        this.zone.runOutsideAngular(() => {
+            const host = this.element.nativeElement;
+            this.listen(host, 'touchstart', event => this.start(event as TouchEvent));
+            this.listen(host, 'click', event => this.click(event as MouseEvent));
+            this.listen(host, 'pointerdown', event => {
+                if ((event as PointerEvent).pointerType === 'mouse') { this.clearClickSuppression(); }
+            });
+            this.listen(host, 'contextmenu', event => {
+                if (this.identifier !== null) { event.preventDefault(); }
+            });
+        });
+    }
+
+    register(item: TouchDescriptionDirective) { this.items.add(item); }
+
+    unregister(item: TouchDescriptionDirective) {
+        this.items.delete(item);
+        this.navigationBounds.delete(item);
+        if (this.originatingItem === item) { this.cancel(); }
+        else if (this.current === item) { this.show(null); }
+    }
+
+    contains(element: HTMLElement): boolean { return this.element.nativeElement.contains(element); }
+
+    private listen(target: EventTarget, type: string, listener: EventListener,
+                   removers = this.removeListeners) {
+        target.addEventListener(type, listener, { capture: true, passive: false });
+        removers.push(() => target.removeEventListener(type, listener, true));
+    }
+
+    private eligible(item: TouchDescriptionDirective): boolean {
+        return this.contains(item.element) && item.available;
+    }
+
+    private start(event: TouchEvent) {
+        if (event.touches.length !== 1) { this.cancel(); return; }
+        this.cancel();
+        this.clearClickSuppression();
+        const item = Array.from(this.items).find(candidate =>
+            this.eligible(candidate) && candidate.control.contains(event.target as Node));
+        if (!item) { return; }
+        this.originatingItem = item;
+        this.origin = event.touches[0];
+        this.identifier = this.origin.identifier;
+        this.trackGesture();
+        this.navigationBounds.clear();
+        this.items.forEach(candidate => {
+            if (candidate.navigation && this.eligible(candidate)) {
+                this.navigationBounds.set(candidate, candidate.control.getBoundingClientRect());
+            }
+        });
+        this.holdTimer = setTimeout(() => {
+            if (!this.eligible(item)) { this.cancel(); return; }
+            this.exploring = true;
+            this.suppressClick = true;
+            this.show(item);
+        }, 500);
+    }
+
+    private trackGesture() {
+        // Only a pending/active hold needs document listeners; normal page scrolling stays untouched.
+        this.listen(this.document, 'touchstart', event => {
+            if ((event as TouchEvent).touches.length > 1) { this.cancel(); }
+        }, this.gestureListeners);
+        this.listen(this.document, 'touchmove', event => this.move(event as TouchEvent), this.gestureListeners);
+        this.listen(this.document, 'touchend', event => this.end(event as TouchEvent), this.gestureListeners);
+        this.listen(this.document, 'touchcancel', () => this.cancel(), this.gestureListeners);
+        this.listen(this.document, 'scroll', () => this.cancel(), this.gestureListeners);
+        if (this.document.defaultView) {
+            this.listen(this.document.defaultView, 'resize', () => this.cancel(), this.gestureListeners);
+            this.listen(this.document.defaultView, 'blur', () => this.cancel(), this.gestureListeners);
+        }
+    }
+
+    private move(event: TouchEvent) {
+        if (this.identifier === null) { return; }
+        const point = Array.from(event.touches).find(touch => touch.identifier === this.identifier);
+        if (!point || event.touches.length !== 1) { this.cancel(); return; }
+        if (!this.exploring) {
+            // Moving before the hold is a native scroll, not a request to explore descriptions.
+            if (Math.hypot(point.clientX - this.origin.clientX, point.clientY - this.origin.clientY) > 10) {
+                this.cancel();
+            }
+            return;
+        }
+        event.preventDefault();
+        const hit = this.document.elementFromPoint(point.clientX, point.clientY);
+        const host = this.element.nativeElement;
+        if (!hit || !host.contains(hit)) { this.show(null); return; }
+        const item = Array.from(this.items).find(candidate => {
+            if (!this.eligible(candidate)) { return false; }
+            if (candidate.control.contains(hit)) { return true; }
+            // Header labels move on reveal; retain their original horizontal touch targets.
+            const bounds = this.navigationBounds.get(candidate);
+            const toolbarBounds = host.getBoundingClientRect();
+            return !!bounds && point.clientX >= bounds.left && point.clientX <= bounds.right &&
+                point.clientY >= toolbarBounds.top && point.clientY <= toolbarBounds.bottom;
+        });
+        this.show(item || null);
+    }
+
+    private end(event: TouchEvent) {
+        if (this.identifier === null) { return; }
+        if (!Array.from(event.changedTouches).some(touch => touch.identifier === this.identifier)) { return; }
+        if (this.exploring) { event.preventDefault(); }
+        this.cancel();
+    }
+
+    private click(event: MouseEvent) {
+        const pointer = event as PointerEvent;
+        const source = event as MouseEvent & { sourceCapabilities?: { firesTouchEvents: boolean } };
+        if (this.suppressClick && (event.detail > 0 || pointer.pointerType === 'touch' ||
+            source.sourceCapabilities?.firesTouchEvents)) {
+            event.preventDefault();
+            event.stopImmediatePropagation();
+        }
+    }
+
+    private show(item: TouchDescriptionDirective | null) {
+        if (this.current === item) { return; }
+        this.zone.run(() => {
+            this.current?.hide();
+            this.current = item;
+            this.current?.show();
+        });
+    }
+
+    private cancel() {
+        clearTimeout(this.holdTimer);
+        this.gestureListeners.forEach(remove => remove());
+        this.gestureListeners = [];
+        this.identifier = null;
+        this.originatingItem = null;
+        if (this.exploring) {
+            clearTimeout(this.clickTimer);
+            this.clickTimer = setTimeout(() => this.clearClickSuppression(), 1000);
+        }
+        this.exploring = false;
+        this.show(null);
+    }
+
+    private clearClickSuppression() {
+        clearTimeout(this.clickTimer);
+        this.suppressClick = false;
+    }
+
+    ngOnDestroy() {
+        this.cancel();
+        this.clearClickSuppression();
+        this.removeListeners.forEach(remove => remove());
+        this.items.clear();
+    }
+}
+
+@Directive({
+    // Augment existing descriptions only inside an explicitly opted-in toolbar.
+    // eslint-disable-next-line @angular-eslint/directive-selector
+    selector: '[matTooltip], .mainMenu'
+})
+export class TouchDescriptionDirective implements OnInit, OnDestroy {
+    element: HTMLElement;
+    control: HTMLElement;
+    navigation: boolean;
+    private registered = false;
+
+    constructor(element: ElementRef<HTMLElement>,
+                @Optional() private toolbar: TouchDescriptionsDirective,
+                @Optional() @Self() private tooltip: MatTooltip) {
+        this.element = element.nativeElement;
+        this.navigation = this.element.classList.contains('mainMenu');
+    }
+
+    get available(): boolean {
+        return !!this.control && !this.control.matches(':disabled, [aria-disabled="true"]') &&
+            (this.navigation || !!this.tooltip?.message && !this.tooltip.disabled);
+    }
+
+    ngOnInit() {
+        this.control = this.navigation ? this.element.querySelector('a, button') :
+            this.element.closest('a, button, [role="button"]');
+        if (!this.toolbar || !this.control || !this.toolbar.contains(this.element)) { return; }
+        // Disable Material's own hold timer before its ngAfterViewInit installs touch listeners.
+        if (this.tooltip) { this.tooltip.touchGestures = 'off'; }
+        this.toolbar.register(this);
+        this.registered = true;
+    }
+
+    show() {
+        if (this.navigation) { this.element.classList.add('touch-description-visible'); }
+        else { this.tooltip.show(0); }
+    }
+
+    hide() {
+        if (this.navigation) { this.element.classList.remove('touch-description-visible'); }
+        else { this.tooltip.hide(0); }
+    }
+
+    ngOnDestroy() {
+        if (this.registered) { this.toolbar.unregister(this); }
+    }
+}

--- a/src/app/mailviewer/singlemailviewer.component.html
+++ b/src/app/mailviewer/singlemailviewer.component.html
@@ -4,7 +4,7 @@
     sandbox="allow-same-origin allow-modals"
     style="width: 0px; height: 0px; border: none; position: absolute"
   ></iframe>
-  <mat-toolbar *ngIf="mailObj" style="display: flex; overflow-x: auto;">
+  <mat-toolbar appTouchDescriptions *ngIf="mailObj" style="display: flex; overflow-x: auto;">
     
     <!-- Message preview toolbar -->
     <!-- NOTE: These items need to be replicated in the overflow toolbar further down. The number of items shown is controlled by morebuttonindex and TOOLBAR_BUTTON_WIDTH in the .ts file. -->

--- a/src/app/menu/headertoolbar.component.html
+++ b/src/app/menu/headertoolbar.component.html
@@ -1,4 +1,4 @@
-<mat-toolbar style="background-image: linear-gradient(177deg, #0068b7, #003156);" color="primary" id="mainMenuContainer">
+<mat-toolbar appTouchDescriptions style="background-image: linear-gradient(177deg, #0068b7, #003156);" color="primary" id="mainMenuContainer">
   <a routerLink="/welcome" class="mainMenuLogo"><img src="assets/runbox7_blue.png" id="logo" alt="Runbox 7" /></a>
 
   <div class="mainMenu">

--- a/src/app/menu/menu.module.ts
+++ b/src/app/menu/menu.module.ts
@@ -19,6 +19,7 @@
 
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { RunboxCommonModule } from '../common/common.module';
 import { MatLegacyButtonModule as MatButtonModule } from '@angular/material/legacy-button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatLegacyMenuModule as MatMenuModule } from '@angular/material/legacy-menu';
@@ -32,6 +33,7 @@ import { SidenavMenuComponent } from './sidenav-menu.component';
 @NgModule({
   imports: [
       CommonModule,
+      RunboxCommonModule,
       MatIconModule,
       MatButtonModule,
       MatToolbarModule,

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -735,7 +735,7 @@ rmm-headertoolbar {
     transition: margin-top 0.25s;
 }
 
-.mainMenu:hover {
+.mainMenu:hover, .mainMenu.touch-description-visible {
     margin-top: -10px;
 
     .mainMenuDesc {


### PR DESCRIPTION
Fixes #2002.

Holding an icon for 500 ms now reveals its existing description. Sliding across nearby icons changes the description, and releasing does not activate an action, menu or link. A separate tap still activates the control.

The behavior covers header navigation, the mail and message toolbars, both compose action strips and mobile message-action buttons. Moving before the hold threshold preserves scrolling. The implementation handles cancellation, multiple touches and controls removed during a gesture, and releases its temporary document listeners when the gesture ends.

Validation on macOS with Node 16.20.2:

- The complete `npm run ci-tests` command passes: lint, policy checks, 278 unit tests, 77 Cypress tests across 27 specs, and the production build. Two existing unit tests remain disabled upstream.
- The 21 focused gesture tests pass with this change. The same spec against unchanged `cf7250c7f98b896044465a1e93a0b30b0f6a6f58` produces 12 failures and 9 passes, with no compilation or harness failure.
- Three Cypress acceptance cases use trusted Chromium touch input: header hold/slide/release followed by navigation, Reply hold/release followed by composing, and mobile attachment hold/release followed by one file-input click. The attachment test stubs that input's `click` method to avoid an operating-system dialog. Physical iOS and Android devices were not tested.

The unit tests and browser tests are in separate, independently cherry-pickable commits (`fe225bc4` and `e53e16a9`); the implementation and usage documentation are in `b5eb870a`.

Please consider this contribution under the Runbox 7 feature bounty program and confirm whether it qualifies, the award amount and the payment process.

AI use: OpenAI Codex (GPT-6), including delegated Codex agents, was used for the implementation, tests, documentation and review in Codex desktop. The desktop harness version was not recorded. Relevant tools were the local terminal, Git, Node, Firefox, Cypress and the GitHub connector.
