### PR TITLE
fix(domainregister): compare email domain quota numerically

### DIFF
--- a/e2e/cypress/integration/domreg.ts
+++ b/e2e/cypress/integration/domreg.ts
@@ -1,6 +1,23 @@
 /// <reference types="cypress" />
 
 describe('Domain registration', () => {
+    it('Shows the registration form when numeric-string quota has room (#1994)', () => {
+        cy.intercept('GET', '/rest/v1/email_hosting/domains_quota', {
+            result: { domain_quota_used: '7', domain_quota_allowed: '20' },
+        });
+        cy.intercept('GET', '/rest/v1/domain_registration/enom/tld_list', {
+            result: {
+                product_list: [{
+                    tld: 'com', currency: 'USD', price: '10', supports_whois_privacy: false,
+                    period: [{ period: 1, period_unit: 'year', price: '10' }],
+                }],
+            },
+        });
+        cy.visit('/domainregistration');
+        cy.contains('domain-register h2', 'Register a new domain name').should('be.visible');
+        cy.contains('domain-register h2', 'Email Domain quota limit').should('not.exist');
+    });
+
     it('Should display domreg component', () => {
         cy.visit('/domainregistration');
         cy.get('domain-register mat-card-title').should('contain', 'Domain Registration');

--- a/src/app/domainregister/domainregister.component.spec.ts
+++ b/src/app/domainregister/domainregister.component.spec.ts
@@ -1,0 +1,87 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+//
+// This file is part of Runbox 7.
+//
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { HttpClient } from '@angular/common/http';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { MatLegacySnackBar as MatSnackBar } from '@angular/material/legacy-snack-bar';
+import { of } from 'rxjs';
+import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
+import { DomainRegisterComponent } from './domainregister.component';
+
+describe('DomainRegisterComponent email domain quota (#1994)', () => {
+    let component: DomainRegisterComponent;
+    let httpMock: HttpTestingController;
+    let snackBar: jasmine.SpyObj<MatSnackBar>;
+    const quotaUrl = '/rest/v1/email_hosting/domains_quota';
+    const availabilityUrl = '/rest/v1/domain_registration/enom/check_avail';
+
+    beforeEach(() => {
+        snackBar = jasmine.createSpyObj<MatSnackBar>('MatSnackBar', ['open']);
+        TestBed.configureTestingModule({
+            imports: [HttpClientTestingModule],
+            providers: [{ provide: RunboxWebmailAPI, useValue: { me: of({ is_trial: false }) } }],
+        });
+        httpMock = TestBed.inject(HttpTestingController);
+        component = new DomainRegisterComponent(
+            TestBed.inject(HttpClient), snackBar, TestBed.inject(RunboxWebmailAPI)
+        );
+        httpMock.match('/rest/v1/domain_registration/enom/tld_list').forEach(request => {
+            request.flush({ result: { product_list: [{ tld: 'com' }] } });
+        });
+        component.domain_wanted = 'example.com';
+    });
+
+    afterEach(() => httpMock.verify());
+
+    for (const used of ['7', 7]) {
+        it(`allows an availability check when ${JSON.stringify(used)} domains are used out of "20"`, () => {
+            httpMock.expectOne(quotaUrl).flush({
+                result: { domain_quota_used: used, domain_quota_allowed: '20' },
+            });
+            expect(snackBar.open).not.toHaveBeenCalled();
+            // The template uses these same values to decide whether to show the registration form.
+            expect(component.domain_quota_used < component.domain_quota_allowed).toBeTrue();
+            component.check_avail();
+            const request = httpMock.expectOne(availabilityUrl);
+            expect(request.request.method).toBe('POST');
+            expect(request.request.body).toEqual({ sld: 'example', tld: 'com' });
+            request.flush({ status: 'error', errors: ['End of synthetic availability response'] });
+        });
+    }
+
+    for (const quota of [
+        { used: '20', allowed: '20' },
+        { used: '100', allowed: '20' },
+        { used: '0', allowed: '0' },
+        { used: 0, allowed: 0 },
+    ]) {
+        it(`blocks availability at quota ${JSON.stringify(quota)}`, () => {
+            httpMock.expectOne(quotaUrl).flush({
+                result: { domain_quota_used: quota.used, domain_quota_allowed: quota.allowed },
+            });
+            expect(snackBar.open).toHaveBeenCalled();
+            expect(component.domain_quota_used >= component.domain_quota_allowed).toBeTrue();
+            snackBar.open.calls.reset();
+            component.check_avail();
+            expect(snackBar.open).toHaveBeenCalled();
+            httpMock.expectNone(availabilityUrl);
+        });
+    }
+});

--- a/src/app/domainregister/domainregister.component.ts
+++ b/src/app/domainregister/domainregister.component.ts
@@ -194,7 +194,7 @@ export class DomainRegisterComponent implements AfterViewInit {
 
   public check_avail = function () {
     if (this.is_btn_search_domain_disabled) { return; }
-    if ( this.domain_quota_used && this.domain_quota_allowed && this.domain_quota_used >= this.domain_quota_allowed ) {
+    if ( this.domain_quota_used >= this.domain_quota_allowed ) {
         return this.show_error('You have reached your allowed Email Domain quota. Please purchase more Email Hosting products.', 'Dismiss');
     }
     this.is_btn_search_domain_disabled = true;
@@ -820,8 +820,9 @@ export class DomainRegisterComponent implements AfterViewInit {
     const req = this.http.get('/rest/v1/email_hosting/domains_quota');
     req.pipe(timeout(180000))
       .subscribe((result: any) => {
-        this.domain_quota_allowed = result.result.domain_quota_allowed;
-        this.domain_quota_used = result.result.domain_quota_used;
+        // The API can return strings; both the template and action checks need numeric counts.
+        this.domain_quota_allowed = Number(result.result.domain_quota_allowed);
+        this.domain_quota_used = Number(result.result.domain_quota_used);
         if ( this.domain_quota_used >= this.domain_quota_allowed ) {
             this.show_error('You have reached your allowed Email Domain quota. Please purchase more Email Hosting products.', 'Dismiss');
         }


### PR DESCRIPTION
An account using 7 of 20 email domains can be blocked from registering another domain when the quota API returns numeric strings. Comparing `"7" >= "20"` produces the wrong result; conversely, `"100"` can fall below `"20"`.

Convert the two API counts to numbers before the warning and template use them. Apply the same numeric comparison to the availability action, including a zero allowance, so that the action agrees with the displayed quota.

Fixes #1994.

The earlier, closed/unmerged #1997 already identified the numeric-string comparison. This submission adds failing-first component and rendered-form regressions, and covers the zero-allowance action check. No new diagnosis is claimed.

### Tests and commits

- `e64d674876d9bcce0082b30108836e96f977f639` contains only tests and can be cherry-picked separately. Six component cases check below/equal/over-quota counts and zero allowance through Angular's HTTP testing controller. The Cypress regression checks the rendered registration form with a synthetic `"7"` / `"20"` response.
- `5d2f40df56afb74b2cfb253edcecbccc64679f75` contains only the implementation fix.

Before the fix, the six component tests produced **3 failures and 3 passes** in real headless Firefox. The domain-registration Cypress spec produced **1 failure and 1 pass**: the new test could not find the registration heading, and the captured page showed the quota-full warning at 7/20. That red Cypress run also encountered a Windows process-cleanup error, addressed in the local environment before the full run below.

On the final commit, the unmodified **`npm run ci-tests`** runner completed all five phases and exited **0**:

| Phase | Actual result |
| --- | --- |
| Lint | 0 errors, 780 warnings |
| Policy | Completed; its 62 historical commit-format warnings were checked against the untouched upstream history. Both new commits also satisfy the PR commit-lint expression and 100-character line limit. |
| Firefox unit tests | **263 passed, 2 pre-existing skips** in `searchservice.spec.ts`; no added skips. |
| Cypress E2E | **75 passed across 26 specs**, 0 failed, 0 pending, 0 skipped. |
| Production build | Completed. A subsequent build-only run corrected Git Bash path conversion, as detailed below. |

The unit log includes console errors from existing component fixtures. An additional unit run on untouched base `8526cf725abc8eb24ebf88419411b11ade6a7ab0` exited 0 with **257 passed and the same 2 skips**, and reproduced the same distinct console-error messages. These are not being described as a warning-free suite.

### AI and environment disclosure

OpenAI Codex authored the tests and fix, ran and inspected the verification, and prepared/submitted this contribution on behalf of @zbzbdzb. Model identity exposed by the environment: **Codex based on GPT-6**; an exact model snapshot is not exposed. Harness: **Codex desktop 26.908.4834.0**. No human-authorship or manual-review claim is made.

Validation used Windows, Node **16.20.2**, Firefox **140.15.0 ESR**, Cypress **12.17.4** / Electron **21.0.0**, and Git Bash. All domain data was synthetic; no production account, domain purchase or production security testing was involved.

<details>
<summary>Local environment adaptations and build audit</summary>

The repository's scripts ran through Git Bash. `NO_PROXY=localhost,127.0.0.1,::1` kept readiness requests to the local mock server out of the inherited proxy. Firefox was supplied through `FIREFOX_BIN` and Node used `--max-old-space-size=4096`.

Windows no longer provided `wmic.exe`, which legacy `ps-tree` uses during server cleanup. A local executable outside this contribution implemented only its read-only `PROCESS GET Name,ProcessId,ParentProcessId,Status` query using actual `Win32_Process` data through .NET `System.Management`. A real spawned parent/child check verified enumeration. It does not fake test results, modify dependencies or support mutations. Final local runs left no listeners on the mock server, Angular or Karma test ports.

The first production output revealed Git Bash translating the service-worker `/app/` prefix into a Windows path. Set `MSYS_NO_PATHCONV=1` and reran `npm run ci-tests -- build` on the unchanged final commit; it exited 0. The resulting index has `<base href="/app/">`, the service-worker index is `/app/index.html`, asset URLs retain `/app/`, all 17 JavaScript bundles contain the Sentry injection marker, and `ngsw.json` appData records commit `5d2f40df`. This checks the post-build effects as well as the outer command exit.

No source, test, dependency lockfile or CI configuration was changed to accommodate the local environment.

</details>

<details>
<summary>Plugin inventory requested by AGENTS.md</summary>

The local configuration marks these plugins enabled: google-calendar, slack, computer-use, visualize, chrome, github, gmail, documents, spreadsheets, presentations, build-web-apps, codex-security, canva, nvidia, google-drive, pdf, template-creator, cad, codex-app-tools, desktop-commander, browser-use, browser, unified-computer-use. The configured superpowers plugin is disabled.

Additional plugin packages visible in the session catalog or local manifest cache: Higgsfield (`app-6a3293e129088191abf0875820e839da`), bionemo-agent-toolkit, build-ios-apps, build-macos-apps, build-mcp-apps, codex-browser-recorder, codex-replay, creative-production, data-analytics, deep-research-work, healthcare-public-data, openai-templates, outlook-email, plugin-management, and product-design. A cached package is not evidence of enablement or use.

Tools actually used for this contribution were shell, Git/GitHub CLI and API, npm, Firefox/Karma and Cypress. Gmail was used for a separate administrative eligibility inquiry; Codex app tools tracked task status. The listed design, document, media, scientific and unrelated application plugins did not author this patch.

</details>
