### PR TITLE
feat(compose): let users hide draft preview cards

### DIFF
--- a/docs/draft-preview-visibility.md
+++ b/docs/draft-preview-visibility.md
@@ -1,0 +1,35 @@
+# Hide draft previews while composing
+
+Issue: https://github.com/runbox/runbox7/issues/430
+
+Draft Desk normally displays an editor alongside the other draft preview cards.
+With many drafts, those cards occupy space while the user writes a message.
+
+The **Show draft previews** checkbox starts checked. Uncheck it to hide the
+preview cards. Every draft already open for editing remains visible. Check it
+again to restore the previews. The setting lasts until leaving Draft Desk.
+
+Only visibility changes: the draft models, compose components, unsent text,
+save operations and draft ordering are retained. Closing the last editor can
+leave no visible cards; the checkbox and explanatory text remain available to
+restore the list. The existing **Show more** control is hidden with the previews.
+
+## Reproduction and checks
+
+Use a mailbox containing several saved drafts, or the repository's local mock
+server. This behavior does not depend on a local search index.
+
+1. Open Draft Desk and start composing a message.
+2. Enter text in the message body.
+3. Uncheck **Show draft previews**. Preview cards disappear; open editors remain.
+4. Check the control again. The previews return and the edited text is retained.
+5. With previews hidden, close an editor, then check the control to restore its
+   preview. No draft is deleted by changing this option.
+
+`draftdesk.component.spec.ts` checks the default view, multiple open editors,
+component and text retention, and recovery after the last editor closes.
+`e2e/cypress/integration/draft-preview-visibility.ts` exercises the real compose
+components and mock API at 1280 px and 375 px.
+
+These checks address preview visibility. They do not replace the broader draft
+list redesign requested in #22 or change draft sorting and persistence.

--- a/e2e/cypress/integration/draft-preview-visibility.ts
+++ b/e2e/cypress/integration/draft-preview-visibility.ts
@@ -1,0 +1,35 @@
+/// <reference types="cypress" />
+
+describe('Draft preview visibility (#430)', () => {
+    beforeEach(async () => {
+        localStorage.setItem('221:localSearchPromptDisplayed', JSON.stringify('true'));
+        (await indexedDB.databases())
+            .filter(db => db.name && /messageCache/.test(db.name))
+            .forEach(db => indexedDB.deleteDatabase(db.name!));
+    });
+
+    [1280, 375].forEach(width => {
+        it(`hides other draft previews and restores them without losing edited text at ${width}px`, { retries: 0 }, () => {
+            cy.viewport(width, 812);
+            cy.visit('/compose?new=true');
+            cy.get('compose .draftPreview').should('have.length.greaterThan', 0);
+            cy.get('textarea[formcontrolname="msg_body"]:visible').first()
+                .type('Keep this unsent message while hiding other drafts.');
+
+            cy.contains('mat-checkbox', 'Show draft previews').scrollIntoView().should('be.visible').as('previewControl');
+            cy.get('@previewControl').find('input').should('be.checked');
+            cy.get('@previewControl').find('label').click();
+            cy.get('compose .draftPreview').each($preview => {
+                cy.wrap($preview).should('not.be.visible');
+                expect($preview[0].getBoundingClientRect().height).to.equal(0);
+            });
+            cy.get('textarea[formcontrolname="msg_body"]:visible').first()
+                .should('have.value', 'Keep this unsent message while hiding other drafts.');
+
+            cy.get('@previewControl').find('label').click();
+            cy.get('compose .draftPreview').first().scrollIntoView().should('be.visible');
+            cy.get('compose .draft-card:not(.draftPreview) textarea[formcontrolname="msg_body"]').first()
+                .should('have.value', 'Keep this unsent message while hiding other drafts.');
+        });
+    });
+});

--- a/src/app/compose/draftdesk.component.html
+++ b/src/app/compose/draftdesk.component.html
@@ -3,8 +3,14 @@
     <h1>Draft Desk</h1>
   </div>
   
-  <compose [model]="draftModel" (draftDeleted)="draftDeleted($event)" #draft *ngFor="let draftModel of draftModelsInView" [ngClass]="{'draftPreviewContainer': !editing}"></compose>
-  <div *ngIf="hasMoreDrafts" class="has-more-drafts">            
+  <div *ngIf="draftModelsInView.length > 0" class="draftdesk-options">
+    <mat-checkbox [checked]="showDraftPreviews" (change)="showDraftPreviews = $event.checked">
+      Show draft previews
+    </mat-checkbox>
+    <span *ngIf="!showDraftPreviews">Only drafts open for editing are shown.</span>
+  </div>
+  <compose [model]="draftModel" (draftDeleted)="draftDeleted($event)" #draft *ngFor="let draftModel of draftModelsInView" [ngClass]="{'draftPreviewContainer': !editing}" [hidden]="!showDraftPreviews && !draft.editing"></compose>
+  <div *ngIf="hasMoreDrafts && showDraftPreviews" class="has-more-drafts">
     <button mat-icon-button mat-tooltip="Show more" (click)="showMore()" style="transform: scale(4,4);">
       <mat-icon svgIcon="dots-horizontal"></mat-icon>
     </button>        

--- a/src/app/compose/draftdesk.component.scss
+++ b/src/app/compose/draftdesk.component.scss
@@ -18,6 +18,16 @@
     width: 90%;
 }
 
+.draftdesk-options {
+    position: relative;
+    top: 55px;
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-bottom: 12px;
+}
+
 @media only screen and (max-width: 768px) {
     .draftdesk-container {
         padding: 0;

--- a/src/app/compose/draftdesk.component.scss
+++ b/src/app/compose/draftdesk.component.scss
@@ -32,6 +32,10 @@
     .draftdesk-container {
         padding: 0;
     }
+
+    .draftdesk-options {
+        padding: 0 16px;
+    }
 }
 
 .more-drafts {

--- a/src/app/compose/draftdesk.component.spec.ts
+++ b/src/app/compose/draftdesk.component.spec.ts
@@ -1,0 +1,124 @@
+// --------- BEGIN RUNBOX LICENSE ---------
+// Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
+// 
+// This file is part of Runbox 7.
+// 
+// Runbox 7 is free software: You can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+// 
+// Runbox 7 is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
+// ---------- END RUNBOX LICENSE ----------
+
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CommonModule } from '@angular/common';
+import { MatLegacyCheckboxModule as MatCheckboxModule } from '@angular/material/legacy-checkbox';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { ActivatedRoute, Router } from '@angular/router';
+import { By } from '@angular/platform-browser';
+import { BehaviorSubject, of } from 'rxjs';
+import { DraftDeskComponent } from './draftdesk.component';
+import { DraftDeskService, DraftFormModel } from './draftdesk.service';
+import { RunboxWebmailAPI } from '../rmmapi/rbwebmail';
+
+@Component({
+    // Match the real compose selector used by Draft Desk.
+    // eslint-disable-next-line @angular-eslint/component-selector
+    selector: 'compose',
+    template: '<textarea>{{model.msg_body}}</textarea>'
+})
+class ComposeStubComponent {
+    @Input() model: DraftFormModel;
+    @Output() draftDeleted = new EventEmitter<number>();
+    editing = false;
+}
+
+describe('Draft Desk preview visibility (#430)', () => {
+    let fixture: ComponentFixture<DraftDeskComponent>;
+    let drafts: DraftFormModel[];
+
+    beforeEach(async () => {
+        drafts = [11, 12, 13].map(mid => Object.assign(new DraftFormModel(), {
+            mid, subject: `Draft ${mid}`, msg_body: `Unsent text ${mid}`
+        }));
+        await TestBed.configureTestingModule({
+            imports: [CommonModule, MatCheckboxModule, NoopAnimationsModule],
+            declarations: [DraftDeskComponent, ComposeStubComponent],
+            providers: [
+                { provide: RunboxWebmailAPI, useValue: {} },
+                { provide: Router, useValue: { navigate: () => Promise.resolve(true) } },
+                { provide: ActivatedRoute, useValue: { queryParams: of({}) } },
+                { provide: DraftDeskService, useValue: {
+                    draftModels: new BehaviorSubject(drafts), fromsSubject: new BehaviorSubject([])
+                } }
+            ]
+        }).compileComponents();
+        fixture = TestBed.createComponent(DraftDeskComponent);
+        fixture.detectChanges();
+    });
+
+    function togglePreviews() {
+        const checkbox: HTMLInputElement = fixture.nativeElement.querySelector('mat-checkbox input');
+        expect(checkbox).withContext('An accessible control must let the user hide other draft previews').not.toBeNull();
+        checkbox.click();
+        fixture.detectChanges();
+    }
+
+    function composeElements() {
+        return fixture.debugElement.queryAll(By.directive(ComposeStubComponent));
+    }
+
+    it('initially shows the existing draft previews', () => {
+        expect(composeElements().length).toBe(3);
+        composeElements().forEach(el => expect(getComputedStyle(el.nativeElement).display).not.toBe('none'));
+    });
+
+    it('hides previews while retaining every open editor and its unsent content', () => {
+        const elements = composeElements();
+        elements[0].componentInstance.editing = true;
+        elements[2].componentInstance.editing = true;
+        const textarea: HTMLTextAreaElement = elements[0].nativeElement.querySelector('textarea');
+        textarea.value = 'Still editing this unsaved text';
+        togglePreviews();
+
+        expect(getComputedStyle(elements[1].nativeElement).display).toBe('none');
+        [0, 2].forEach(i => expect(getComputedStyle(elements[i].nativeElement).display).not.toBe('none'));
+        expect(composeElements()[0].componentInstance).toBe(elements[0].componentInstance);
+        expect(textarea.value).toBe('Still editing this unsaved text');
+        expect(fixture.componentInstance.draftModelsInView).toEqual(drafts);
+    });
+
+    it('restores the same preview and editor components when the control is switched back on', () => {
+        const elements = composeElements();
+        elements[0].componentInstance.editing = true;
+        togglePreviews();
+        togglePreviews();
+
+        composeElements().forEach((el, i) => {
+            expect(el.componentInstance).toBe(elements[i].componentInstance);
+            expect(getComputedStyle(el.nativeElement).display).not.toBe('none');
+            expect(el.componentInstance.model).toBe(drafts[i]);
+        });
+        expect(elements[0].componentInstance.editing).toBeTrue();
+    });
+
+    it('keeps the control available after the last editor closes so the user can recover the list', () => {
+        const elements = composeElements();
+        elements[0].componentInstance.editing = true;
+        togglePreviews();
+        elements[0].componentInstance.editing = false;
+        fixture.detectChanges();
+        composeElements().forEach(el => expect(getComputedStyle(el.nativeElement).display).toBe('none'));
+
+        togglePreviews();
+        composeElements().forEach(el => expect(getComputedStyle(el.nativeElement).display).not.toBe('none'));
+    });
+});

--- a/src/app/compose/draftdesk.component.spec.ts
+++ b/src/app/compose/draftdesk.component.spec.ts
@@ -1,18 +1,18 @@
 // --------- BEGIN RUNBOX LICENSE ---------
 // Copyright (C) 2016-2026 Runbox Solutions AS (runbox.com).
-// 
+//
 // This file is part of Runbox 7.
-// 
+//
 // Runbox 7 is free software: You can redistribute it and/or modify it
 // under the terms of the GNU General Public License as published by the
 // Free Software Foundation, either version 3 of the License, or (at your
 // option) any later version.
-// 
+//
 // Runbox 7 is distributed in the hope that it will be useful, but
 // WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
 // General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with Runbox 7. If not, see <https://www.gnu.org/licenses/>.
 // ---------- END RUNBOX LICENSE ----------

--- a/src/app/compose/draftdesk.component.ts
+++ b/src/app/compose/draftdesk.component.ts
@@ -32,6 +32,7 @@ const MAX_DRAFTS_IN_VIEW = 10;
 })
 export class DraftDeskComponent implements OnInit {
     public draftModelsInView: DraftFormModel[] = [];
+    public showDraftPreviews = true;
     public hasMoreDrafts = false;
     public currentMaxDraftsInView: number = MAX_DRAFTS_IN_VIEW;
     private hasInitialized = false;


### PR DESCRIPTION
Draft Desk keeps the other draft preview cards visible while a user writes a message. This adds a **Show draft previews** checkbox so those cards can be hidden while every open editor remains available.

Fixes #430.

The control starts checked and lasts for the current Draft Desk view. It retains compose components, draft models and unsent text. Turning it back on restores the previews; the control also remains available after the last editor closes. Saved preferences, ordering and pagination state are retained.

The production change is limited to the Draft Desk template, one boolean and control styles. I searched open and closed PRs for `430` (0 results) and `draft` (78 results), including related sorting/content-preservation changes, and found no duplicate. The broader draft-list redesign in #22 remains outside this change.

### Validation

- Focused unit cases: **3 feature assertions failed and the existing-default case passed before implementation; all 4 passed afterward**. These cover multiple open editors, retained component/model identity, unsent text, restoring previews and recovering after closing the last editor.
- New Cypress regression: **both 1280 px and 375 px failed before implementation because the checkbox was absent; both passed afterward**, including zero layout height for hidden previews and retained edited text after restoring the list.
- Full `npm run ci-tests` on published head **9d7a346f**: **exit 0; 261 unit tests passed, 2 existing skips; all 76 browser tests across 27 specs passed; lint, policy and production build passed**. Lint reports 780 warnings.
- Additional local Firefox checks verified the space-key toggle and retained text at both widths. The mobile layout was inspected and the control inset aligned with the editor content.
- The published branch was fetched back and its entire Git tree matched the local final implementation. The full suite above ran on that exact published commit; `git diff --check` also passed.

An earlier full run failed two existing calendar assertions: the current-time-plus-one-hour fixture spanned displayed midnight, producing two day cells where one was expected. Both failures reproduced on unchanged upstream `8526cf72` (5 calendar cases passed, 2 failed). At `2026-09-12T23:43:05Z`, the fixture displayed Sep 12 23:43 through Sep 13 00:43. The temporary diagnostic output was removed. After natural UTC midnight, the final full suite passed without changing calendar code, assertions, skips, fixture dates or system clock.

The unit and browser tests are separate commits **693c5f51** and **69c486f3**, preceding implementation **49216d36**. **156b8d88** only normalizes the new unit-test file's line endings/header whitespace and can be cherry-picked independently. Reproduction notes are in `docs/draft-preview-visibility.md`.

Environment: Windows, Node **16.20.2**, Firefox **155.0**, Cypress **12.17.4 / Electron 106**, local mock API. npm scripts used the task-scoped Git/MSYS shell and existing `cygpath -w` adapter, with no repository test configuration changes. The additional Playwright screenshot/keyboard helper used Node 24. Existing template, mock-service and dependency warnings remain in the logs.

### AI disclosure

**GPT-6 via OpenAI Codex desktop** performed source inspection, implementation, tests, documentation and browser-based submission under the account owner's explicit authorization. The exact desktop harness version was not exposed by the session. No separate human code review is claimed.

Observed enabled plugin configuration: `visualize`, `documents`, `pdf`, `spreadsheets`, `presentations`, `template-creator`, `codex-app-tools`, `browser`, `unified-computer-use`, `sites`, and `computer-use`. The session also advertises `deep-research-work` and `plugin-management`. This contribution used shell/git execution and browser automation; the other listed plugins were not used to generate the change.

### Mobile preview

The local mock mailbox with previews hidden (left) and restored (right):

<img width="300" alt="Draft previews hidden while the editor retains its text" src="https://github.com/user-attachments/assets/97870c12-094d-4a51-8e60-4a44f61e1e38" />
<img width="300" alt="Draft previews restored below the same editor" src="https://github.com/user-attachments/assets/7403ae4b-bf34-4bb3-af0b-cbf249b84e66" />